### PR TITLE
Implement Stack funsor

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -629,7 +629,7 @@ class Stack(Funsor):
 
         if pos is None:
             # Eagerly recurse into components.
-            assert not any(self.name in v for k, v in subs)
+            assert not any(self.name in v.inputs for k, v in subs)
             components = tuple(Substitute(x, subs) for x in self.components)
             return Stack(components, self.name)
 
@@ -644,8 +644,10 @@ class Stack(Funsor):
 
         if isinstance(index, Variable):
             # Rename the stacking dimension.
-            result = Stack(self.components, index.name)
-            return Substitute(result, subs) if subs else result
+            components = self.components
+            if subs:
+                components = tuple(Substitute(x, subs) for x in components)
+            return Stack(components, index.name)
 
         # TODO support advanced indexing
 
@@ -664,6 +666,7 @@ __all__ = [
     'Funsor',
     'Number',
     'Reduce',
+    'Stack',
     'Substitute',
     'Unary',
     'Variable',

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -275,8 +275,7 @@ class Function(Funsor):
         funsors = tuple(subs[key] for key in self.inputs)
         inputs, tensors = align_tensors(*funsors)
         data = self.fn(*tensors)
-        inputs = None  # FIXME
-        return Tensor(data, inputs, self.dtype)
+        return Tensor(data, dtype=self.dtype)
 
 
 def function(*signature):

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -9,7 +9,7 @@ from six.moves import reduce
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, ints, reals
-from funsor.terms import Binary, Number, Variable, to_funsor
+from funsor.terms import Binary, Number, Stack, Variable, to_funsor
 from funsor.testing import check_funsor
 
 np.seterr(all='ignore')
@@ -189,3 +189,18 @@ def test_reduce_subset(op, reduced_vars):
     # TODO check data
     if not reduced_vars:
         assert actual is f
+
+
+def test_stack():
+
+    x = Number(0.)
+    y = Number(1.)
+    z = Number(4.)
+
+    xyz = Stack((x, y, z), 'i')
+    check_funsor(xyz, {'i': ints(3)}, reals())
+
+    assert xyz(i=Number(0, 3)) is x
+    assert xyz(i=Number(1, 3)) is y
+    assert xyz(i=Number(2, 3)) is z
+    assert xyz.sum('i') == 5.

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -191,8 +191,7 @@ def test_reduce_subset(op, reduced_vars):
         assert actual is f
 
 
-def test_stack():
-
+def test_stack_simple():
     x = Number(0.)
     y = Number(1.)
     z = Number(4.)
@@ -204,3 +203,28 @@ def test_stack():
     assert xyz(i=Number(1, 3)) is y
     assert xyz(i=Number(2, 3)) is z
     assert xyz.sum('i') == 5.
+
+
+def test_stack_subs():
+    x = Variable('x', reals())
+    y = Variable('y', reals())
+    z = Variable('z', reals())
+    j = Variable('j', ints(3))
+
+    f = Stack((Number(0), x, y * z), 'i')
+    check_funsor(f, {'i': ints(3), 'x': reals(), 'y': reals(), 'z': reals()},
+                 reals())
+
+    assert f(i=Number(0, 3)) is Number(0)
+    assert f(i=Number(1, 3)) is x
+    assert f(i=Number(2, 3)) is y * z
+    assert f(i=j) is Stack((Number(0), x, y * z), 'j')
+    assert f(i='j') is Stack((Number(0), x, y * z), 'j')
+    assert f.sum('i') is Number(0) + x + (y * z)
+
+    assert f(x=0) is Stack((Number(0), Number(0), y * z), 'i')
+    assert f(y=x) is Stack((Number(0), x, x * z), 'i')
+    assert f(x=0, y=x) is Stack((Number(0), Number(0), x * z), 'i')
+    assert f(x=0, y=x, i=Number(2, 3)) is x * z
+    assert f(x=0, i=j) is Stack((Number(0), Number(0), y * z), 'j')
+    assert f(x=0, i='j') is Stack((Number(0), Number(0), y * z), 'j')


### PR DESCRIPTION
This implements a `Stack` funsor as suggested and pair coded with @jpchen .

`Stack` is mainly useful for testing, since we create a non-PyTorch equivalent to `Tensor` by `Stack`ing together `Number`s.

## Tested

- [x] add a simple unit test
- [x] add a test for dim renaming
- [x] add a test for nontermination
- [x] add a test of recursive substitution