### PR TITLE
Make funsor.torch.Function closed under substitution

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -265,7 +265,7 @@ def test_function_lazy_matmul():
     y = funsor.Tensor(torch.randn(4, 5))
     actual_lazy = matmul(x_lazy, y)
     check_funsor(actual_lazy, {'x': reals(3, 4)}, reals(3, 5))
-    assert isinstance(actual_lazy, funsor.terms.Substitute)
+    assert isinstance(actual_lazy, funsor.Function)
 
     x = funsor.Tensor(torch.randn(3, 4))
     actual = actual_lazy(x=x)


### PR DESCRIPTION
Addresses #27 

This makes `Function` closed under substitution, following the pattern of `Distribution` objects.

@eb8680 It is a little more subtle that I expected to make `Function` generic and let `Unary` and `Binary` inherit from `Function`. I suggest we prioritize #27 and then revisit our new class hierarchy.

## Tested

- updated an existing unit test