### PR TITLE
Drop Substitute funsor; close Function under substitution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -7,7 +7,7 @@ import pyro.distributions as dist
 import funsor.ops as ops
 from funsor.domains import ints, reals
 from funsor.pattern import simplify_sum
-from funsor.terms import Binary, Funsor, Number, Substitute, Variable, eager, to_funsor
+from funsor.terms import Binary, Funsor, Number, Variable, eager, to_funsor
 from funsor.torch import Tensor, align_tensors
 
 
@@ -63,7 +63,9 @@ class Distribution(Funsor):
 
     def eager_subs(self, subs):
         assert isinstance(subs, tuple)
-        params = OrderedDict((k, Substitute(v, subs)) for k, v in self.params)
+        if not any(k in self.inputs for k, v in subs):
+            return self
+        params = OrderedDict((k, v.eager_subs(subs)) for k, v in self.params)
         return type(self)(**params)
 
     def eager_reduce(self, op, dims):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -265,7 +265,7 @@ def test_function_lazy_matmul():
     y = funsor.Tensor(torch.randn(4, 5))
     actual_lazy = matmul(x_lazy, y)
     check_funsor(actual_lazy, {'x': reals(3, 4)}, reals(3, 5))
-    assert isinstance(actual_lazy, funsor.terms.Substitute)
+    assert isinstance(actual_lazy, funsor.Function)
 
     x = funsor.Tensor(torch.randn(3, 4))
     actual = actual_lazy(x=x)


### PR DESCRIPTION
Addresses #27 
Supersedes #28 

Thanks @eb8680 for suggesting this simplifying change!

1. Makes `Function` closed under substitution, following the pattern of `Distribution` objects.
2. Drops lazy `Substitution` objects and the global `eager_subs` function.
3. Updates `Tensor` and `Stack` to raise `NotImplementedError('TODO implement advanced indexing')`
4. Adds a check in `Tensor` to ensure tensors cannot depend on real free variables. (We may later create something like a `Branch(Tensor(...))` when substituting a real-dependency into a `Tensor`, but that requires more thinking).

## Tested

- updated an existing unit test