### PR TITLE
Fix Categorical distribution and getitem op

### DIFF
--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -161,7 +161,7 @@ class Tensor(Funsor):
                 inputs[k] = domain
 
         # Construct a dict with each input's positional dim,
-        # counting from the right so as to support broadcasting.ft.
+        # counting from the right so as to support broadcasting.
         total_size = len(inputs) + len(self.output.shape)  # Assumes only scalar indices.
         new_dims = {}
         for k, domain in inputs.items():

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -258,16 +258,26 @@ def eager_binary_number_tensor(op, lhs, rhs):
 
 @eager.register(Binary, object, Tensor, Tensor)
 def eager_binary_tensor_tensor(op, lhs, rhs):
-    assert lhs.output.shape == rhs.output.shape
+    # Compute inputs and outputs.
     dtype = find_domain(op, lhs.output, rhs.output).dtype
-    if op is ops.getitem:
-        raise NotImplementedError('TODO shift dim to index on')
     if lhs.inputs == rhs.inputs:
         inputs = lhs.inputs
-        data = op(lhs.data, rhs.data)
+        lhs_data, rhs_data = lhs.data, rhs.data
     else:
         inputs, (lhs_data, rhs_data) = align_tensors(lhs, rhs)
+
+    if op is ops.getitem:
+        # getitem has special shape semantics.
+        if rhs.output.shape:
+            raise NotImplementedError('TODO support vector indexing')
+        assert lhs.output.shape == (rhs.dtype,)
+        index = [torch.arange(size).reshape((-1,) + (1,) * (lhs_data.dim() - pos - 2))
+                 for pos, size in enumerate(lhs_data.shape)]
+        index[-1] = rhs_data
+        data = lhs_data[tuple(index)]
+    else:
         data = op(lhs_data, rhs_data)
+
     return Tensor(data, inputs, dtype)
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -10,10 +10,9 @@ import funsor
 import funsor.distributions as dist
 from funsor import Tensor
 from funsor.domains import ints, reals
-from funsor.testing import assert_close, check_funsor
+from funsor.testing import assert_close, check_funsor, random_tensor
 
 
-@pytest.mark.xfail(reason='TODO fix eager_binary_tensor_tensor(ops.getitem,-,-)')
 @pytest.mark.parametrize('size', [4])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
 def test_categorical_density(size, batch_shape):
@@ -26,8 +25,10 @@ def test_categorical_density(size, batch_shape):
 
     check_funsor(categorical, {'probs': reals(size), 'value': ints(size)}, reals())
 
-    probs = Tensor(torch.randn(batch_shape + (size,)), inputs)
-    value = Tensor((torch.rand(batch_shape) * size).long().clamp(min=0, max=size-1), inputs)
+    probs_data = torch.randn(batch_shape + (size,)).exp()
+    probs_data /= probs_data.sum(-1, keepdim=True)
+    probs = Tensor(probs_data, inputs)
+    value = Tensor(random_tensor(ints(size, batch_shape)), inputs, size)
     expected = categorical(probs, value)
     check_funsor(expected, inputs, reals())
 


### PR DESCRIPTION
Addresses #19 

This implements proper handling of `ops.getitem` and fixes the previously xfailing test of the `Categorical` distribution. This is required to get the discrete HMM example working.

## Tested

- fixed previously xfailing test