### PR TITLE
Drop support for int array domains; rename ints() -> bint()

### DIFF
--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -21,12 +21,12 @@ def main(args):
 
         trans = dist.Categorical(probs=funsor.Tensor(
             trans_probs,
-            inputs=OrderedDict([('prev', funsor.ints(2))]),
+            inputs=OrderedDict([('prev', funsor.bint(2))]),
         ))
 
         emit = dist.Categorical(probs=funsor.Tensor(
             emit_probs,
-            inputs=OrderedDict([('latent', funsor.ints(2))]),
+            inputs=OrderedDict([('latent', funsor.bint(2))]),
         ))
 
         x_curr = funsor.to_funsor(0)
@@ -34,7 +34,7 @@ def main(args):
             x_prev = x_curr
 
             # A delayed sample statement.
-            x_curr = funsor.Variable('x_{}'.format(t), funsor.ints())
+            x_curr = funsor.Variable('x_{}'.format(t), funsor.bint())
             prob *= trans(prev=x_prev, value=x_curr)
 
             prob *= emit(latent=x_curr, value=y)

--- a/examples/ss_vae_delayed.py
+++ b/examples/ss_vae_delayed.py
@@ -53,7 +53,7 @@ def guide(image):
 def main(args):
     # Generate fake data.
     data = funsor.Tensor(torch.randn(100),
-                         inputs=OrderedDict([('data', funsor.ints(100))]),
+                         inputs=OrderedDict([('data', funsor.bint(100))]),
                          output=funsor.reals())
 
     # Train.

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from funsor.domains import Domain, find_domain, ints, reals
+from funsor.domains import Domain, find_domain, bint, reals
 from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor
 from funsor.torch import Function, Tensor, arange, function
@@ -22,7 +22,7 @@ __all__ = [
     'function',
     'handlers',
     'interpreter',
-    'ints',
+    'bint',
     'minipyro',
     'of_shape',
     'ops',

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -5,7 +5,7 @@ from collections import OrderedDict, defaultdict
 import pyro.distributions as dist
 
 import funsor.ops as ops
-from funsor.domains import ints, reals
+from funsor.domains import bint, reals
 from funsor.pattern import simplify_sum
 from funsor.terms import Binary, Funsor, Number, Variable, eager, to_funsor
 from funsor.torch import Tensor, align_tensors
@@ -93,7 +93,7 @@ class Categorical(Distribution):
         probs = to_funsor(probs)
         if value is None:
             size = probs.output.shape[0]
-            value = Variable('value', ints(size))
+            value = Variable('value', bint(size))
         else:
             value = to_funsor(value)
         super(Categorical, self).__init__(probs, value)

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -131,11 +131,6 @@ def eager_normal(loc, scale, value):
 # Conjugacy Relationships
 ################################################################################
 
-@eager.register(Binary, object, Categorical, Categorical)
-def eager_binary_categorical_categorical(op, lhs, rhs):
-    raise NotImplementedError('TODO')
-
-
 @eager.register(Binary, object, Normal, Normal)
 def eager_binary_normal_normal(op, lhs, rhs):
     if op is not ops.add:

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -30,8 +30,8 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
         shape = tuple(self.shape)
         if isinstance(self.dtype, integer_types):
             if not shape:
-                return 'ints({})'.format(self.dtype)
-            return 'ints({}, {})'.format(self.dtype, shape)
+                return 'bint({})'.format(self.dtype)
+            return 'bint({}, {})'.format(self.dtype, shape)
         if not shape:
             return 'reals()'
         return 'reals{}'.format(shape)
@@ -54,7 +54,7 @@ def reals(*shape):
     return Domain(shape, 'real')
 
 
-def ints(size):
+def bint(size):
     """
     Construct a bounded integer domain of scalar shape.
     """
@@ -100,6 +100,6 @@ def find_domain(op, *domains):
 __all__ = [
     'Domain',
     'find_domain',
-    'ints',
+    'bint',
     'reals',
 ]

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -24,7 +24,7 @@ from six.moves import reduce
 
 import funsor.interpreter as interpreter
 import funsor.ops as ops
-from funsor.domains import Domain, find_domain, ints
+from funsor.domains import Domain, find_domain, bint
 from funsor.interpreter import interpret
 from funsor.registry import KeyedRegistry
 from funsor.six import getargspec, singledispatch
@@ -642,7 +642,7 @@ class Stack(Funsor):
         assert not any(name in x.inputs for x in components)
         assert len(set(x.output for x in components)) == 1
         output = components[0].output
-        domain = ints(len(components))
+        domain = bint(len(components))
         inputs = OrderedDict([(name, domain)])
         for x in components:
             inputs.update(x.inputs)
@@ -667,7 +667,7 @@ class Stack(Funsor):
             return Stack(components, self.name)
 
         # Try to eagerly select an index.
-        assert index.output == ints(len(self.components))
+        assert index.output == bint(len(self.components))
         subs = subs[:pos] + subs[1 + pos:]
 
         if isinstance(index, Number):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
+import operator
+
 import torch
 from six import integer_types
+from six.moves import reduce
 
-from funsor.domains import Domain
 from funsor.terms import Funsor
 from funsor.torch import Tensor
 
@@ -50,17 +52,18 @@ def assert_equiv(x, y):
     check_funsor(x, y.inputs, y.output, y.data)
 
 
-def random_tensor(domain):
+def random_tensor(dtype, shape):
     """
     Creates a random :class:`torch.Tensor` suitable for a given
     :class:`~funsor.domains.Domain`.
     """
-    assert isinstance(domain, Domain)
-    if isinstance(domain.dtype, integer_types):
-        return torch.multinomial(torch.ones(domain.dtype),
-                                 domain.num_elements,
-                                 replacement=True).reshape(domain.shape)
-    elif domain.dtype == "real":
-        return torch.randn(domain.shape)
+    assert isinstance(shape, tuple)
+    if isinstance(dtype, integer_types):
+        num_elements = reduce(operator.mul, shape, 1)
+        return torch.multinomial(torch.ones(dtype),
+                                 num_elements,
+                                 replacement=True).reshape(shape)
+    elif dtype == "real":
+        return torch.randn(shape)
     else:
-        raise ValueError('unknown dtype: {}'.format(repr(domain.dtype)))
+        raise ValueError('unknown dtype: {}'.format(repr(dtype)))

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -7,7 +7,7 @@ import torch
 from six import add_metaclass, integer_types
 
 import funsor.ops as ops
-from funsor.domains import Domain, find_domain, ints
+from funsor.domains import Domain, find_domain, bint
 from funsor.six import getargspec
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor
 
@@ -275,7 +275,7 @@ def arange(name, size):
     :rtype: Tensor
     """
     data = torch.arange(size)
-    inputs = OrderedDict([(name, ints(size))])
+    inputs = OrderedDict([(name, bint(size))])
     return Tensor(data, inputs, dtype=size)
 
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -25,21 +25,12 @@ def align_tensors(*args):
         with given ``inputs``.
     :rtype: tuple
     """
-    # Collect nominal shapes.
+    # Compute result shapes.
     inputs = OrderedDict()
     for x in args:
         inputs.update(x.inputs)
-
-    # Compute linear shapes.
-    sizes = []
-    shapes = []
-    for domain in inputs.values():
-        size = domain.dtype
-        assert isinstance(size, int)
-        sizes.append(size ** domain.num_elements)
-        shapes.append((size,) * domain.num_elements)
-    sizes = dict(zip(inputs, sizes))
-    shapes = dict(zip(inputs, shapes))
+    sizes = {k: domain.dtype for k, domain in inputs.items()}
+    assert all(isinstance(size, integer_types) for size in sizes.values())
 
     # Convert each Number or Tensor.
     tensors = []
@@ -65,8 +56,7 @@ def align_tensors(*args):
                       x_output.shape)
 
         # Unsquash multivariate input dims.
-        x = x.reshape(sum((shapes[k] if k in x_inputs else (1,) * len(shapes[k]) for k in inputs),
-                          ()) + x_output.shape)
+        x = x.reshape(tuple(sizes[k] if k in x_inputs else 1 for k in inputs) + x_output.shape)
         tensors.append(x)
 
     return inputs, tensors
@@ -98,8 +88,7 @@ class Tensor(Funsor):
         assert isinstance(inputs, tuple)
         assert all(isinstance(d.dtype, integer_types) for k, d in inputs)
         inputs = OrderedDict(inputs)
-        input_dim = sum(d.num_elements for d in inputs.values())
-        output = Domain(data.shape[input_dim:], dtype)
+        output = Domain(data.shape[len(inputs):], dtype)
         super(Tensor, self).__init__(inputs, output)
         self.data = data
 
@@ -165,8 +154,7 @@ class Tensor(Funsor):
         total_size = len(inputs) + len(self.output.shape)  # Assumes only scalar indices.
         new_dims = {}
         for k, domain in inputs.items():
-            if domain.num_elements != 1:
-                raise NotImplementedError('TODO support vector indexing')
+            assert not domain.shape
             new_dims[k] = len(new_dims) - total_size
 
         # Use advanced indexing to construct a simultaneous substitution.
@@ -187,8 +175,6 @@ class Tensor(Funsor):
                     index.append(v.data.reshape(tuple(v_shape)))
             else:
                 # Construct a [:] slice for this preserved input.
-                if domain.num_elements != 1:
-                    raise NotImplementedError('TODO support vector indexing')
                 offset_from_right = -1 - new_dims[k]
                 index.append(torch.arange(domain.dtype).reshape(
                     (-1,) + (1,) * offset_from_right))
@@ -224,13 +210,12 @@ class Tensor(Funsor):
             offset = 0
             for k, domain in self.inputs.items():
                 if k in reduced_vars:
-                    if domain.num_elements > 1:
-                        raise NotImplementedError('TODO')
+                    assert not domain.shape
                     data = torch_op(data, dim=offset)
                     if op is ops.min or op is ops.max:
                         data = data[0]
                 else:
-                    offset += domain.num_elements
+                    offset += 1
             inputs = OrderedDict((k, v) for k, v in self.inputs.items()
                                  if k not in reduced_vars)
             return Tensor(data, inputs, self.dtype)
@@ -241,7 +226,7 @@ class Tensor(Funsor):
 def eager_binary_tensor_number(op, lhs, rhs):
     if op is ops.getitem:
         # Shift by that Funsor is using for inputs.
-        index = [slice(None)] * sum(d.num_elements for d in lhs.inputs.values())
+        index = [slice(None)] * len(lhs.inputs)
         index.append(rhs.data)
         index = tuple(index)
         data = lhs.data[index]
@@ -307,8 +292,7 @@ def materialize(x):
         if not isinstance(domain.dtype, integer_types):
             raise ValueError('materialize() requires integer free variables but found '
                              '"{}" of domain {}'.format(name, domain))
-        if domain.shape:
-            raise NotImplementedError('TODO implement arange with nontrivial shape')
+        assert not domain.shape
         subs.append((name, arange(name, domain.dtype)))
     subs = tuple(subs)
     return x.eager_subs(subs)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -9,7 +9,7 @@ import torch
 import funsor
 import funsor.distributions as dist
 from funsor import Tensor
-from funsor.domains import ints, reals
+from funsor.domains import bint, reals
 from funsor.testing import assert_close, check_funsor, random_tensor
 
 
@@ -17,13 +17,13 @@ from funsor.testing import assert_close, check_funsor, random_tensor
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
 def test_categorical_density(size, batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
-    inputs = OrderedDict((k, ints(v)) for k, v in zip(batch_dims, batch_shape))
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
-    @funsor.of_shape(reals(size), ints(size))
+    @funsor.of_shape(reals(size), bint(size))
     def categorical(probs, value):
         return probs[value].log()
 
-    check_funsor(categorical, {'probs': reals(size), 'value': ints(size)}, reals())
+    check_funsor(categorical, {'probs': reals(size), 'value': bint(size)}, reals())
 
     probs_data = torch.randn(batch_shape + (size,)).exp()
     probs_data /= probs_data.sum(-1, keepdim=True)
@@ -40,7 +40,7 @@ def test_categorical_density(size, batch_shape):
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
 def test_normal_density(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
-    inputs = OrderedDict((k, ints(v)) for k, v in zip(batch_dims, batch_shape))
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
     @funsor.of_shape(reals(), reals(), reals())
     def normal(loc, scale, value):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -28,7 +28,7 @@ def test_categorical_density(size, batch_shape):
     probs_data = torch.randn(batch_shape + (size,)).exp()
     probs_data /= probs_data.sum(-1, keepdim=True)
     probs = Tensor(probs_data, inputs)
-    value = Tensor(random_tensor(ints(size, batch_shape)), inputs, size)
+    value = Tensor(random_tensor(size, batch_shape), inputs, size)
     expected = categorical(probs, value)
     check_funsor(expected, inputs, reals())
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -67,7 +67,7 @@ XFAIL_EINSUM_EXAMPLES = [
 def test_einsum(equation):
     inputs, outputs, operands, sizes = make_example(equation)
     funsor_operands = [
-        funsor.Tensor(operand, OrderedDict([(d, funsor.ints(sizes[d])) for d in inp]))
+        funsor.Tensor(operand, OrderedDict([(d, funsor.bint(sizes[d])) for d in inp]))
         for inp, operand in zip(inputs, operands)
     ]
     expected = torch.einsum(equation, operands)
@@ -98,7 +98,7 @@ PLATED_EINSUM_EXAMPLES = [(ex, '') for ex in EINSUM_EXAMPLES] + [
 def test_plated_einsum(equation, plates):
     inputs, outputs, operands, sizes = make_example(equation)
     funsor_operands = [
-        funsor.Tensor(operand, OrderedDict([(d, funsor.ints(sizes[d])) for d in inp]))
+        funsor.Tensor(operand, OrderedDict([(d, funsor.bint(sizes[d])) for d in inp]))
         for inp, operand in zip(inputs, operands)
     ]
     expected = naive_ubersum(equation, *operands, plates=plates, backend='torch', modulo_total=False)[0]

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -8,7 +8,7 @@ from six.moves import reduce
 
 import funsor
 import funsor.ops as ops
-from funsor.domains import Domain, ints, reals
+from funsor.domains import Domain, bint, reals
 from funsor.terms import Binary, Number, Stack, Variable, to_funsor
 from funsor.testing import check_funsor
 
@@ -26,16 +26,16 @@ def test_to_funsor_undefined(x):
 
 
 def test_cons_hash():
-    assert Variable('x', ints(3)) is Variable('x', ints(3))
+    assert Variable('x', bint(3)) is Variable('x', bint(3))
     assert Variable('x', reals()) is Variable('x', reals())
-    assert Variable('x', reals()) is not Variable('x', ints(3))
+    assert Variable('x', reals()) is not Variable('x', bint(3))
     assert Number(0, 3) is Number(0, 3)
     assert Number(0.) is Number(0.)
     assert Number(0.) is not Number(0, 3)
 
 
 @pytest.mark.parametrize('expr', [
-    "Variable('x', ints(3))",
+    "Variable('x', bint(3))",
     "Variable('x', reals())",
     "Number(0.)",
     "Number(1, dtype=10)",
@@ -48,7 +48,7 @@ def test_reinterpret(expr):
     assert funsor.reinterpret(x) is x
 
 
-@pytest.mark.parametrize('domain', [ints(3), reals()])
+@pytest.mark.parametrize('domain', [bint(3), reals()])
 def test_variable(domain):
     x = Variable('x', domain)
     check_funsor(x, {'x': domain}, domain)
@@ -58,7 +58,7 @@ def test_variable(domain):
     assert x('y') is y
     assert x(x='y') is y
     assert x(x=y) is y
-    x4 = Variable('x', ints(4))
+    x4 = Variable('x', bint(4))
     assert x4 is not x
     assert x4('x') is x4
     assert x(x=x4) is x4
@@ -145,12 +145,12 @@ def test_binary(symbol, data1, data2):
 @pytest.mark.parametrize('op', ops.REDUCE_OP_TO_TORCH,
                          ids=[op.__name__ for op in ops.REDUCE_OP_TO_TORCH])
 def test_reduce_all(op):
-    x = Variable('x', ints(2))
-    y = Variable('y', ints(3))
-    z = Variable('z', ints(4))
+    x = Variable('x', bint(2))
+    y = Variable('y', bint(3))
+    z = Variable('z', bint(4))
     f = x * y + z
     dtype = f.dtype
-    check_funsor(f, {'x': ints(2), 'y': ints(3), 'z': ints(4)}, Domain((), dtype))
+    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Domain((), dtype))
     if op is ops.logaddexp:
         pytest.skip()
 
@@ -173,12 +173,12 @@ def test_reduce_all(op):
                          ids=[op.__name__ for op in ops.REDUCE_OP_TO_TORCH])
 def test_reduce_subset(op, reduced_vars):
     reduced_vars = frozenset(reduced_vars)
-    x = Variable('x', ints(2))
-    y = Variable('y', ints(3))
-    z = Variable('z', ints(4))
+    x = Variable('x', bint(2))
+    y = Variable('y', bint(3))
+    z = Variable('z', bint(4))
     f = x * y + z
     dtype = f.dtype
-    check_funsor(f, {'x': ints(2), 'y': ints(3), 'z': ints(4)}, Domain((), dtype))
+    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Domain((), dtype))
     if op is ops.logaddexp:
         pytest.skip()
 
@@ -201,7 +201,7 @@ def test_stack_simple():
     z = Number(4.)
 
     xyz = Stack((x, y, z), 'i')
-    check_funsor(xyz, {'i': ints(3)}, reals())
+    check_funsor(xyz, {'i': bint(3)}, reals())
 
     assert xyz(i=Number(0, 3)) is x
     assert xyz(i=Number(1, 3)) is y
@@ -213,10 +213,10 @@ def test_stack_subs():
     x = Variable('x', reals())
     y = Variable('y', reals())
     z = Variable('z', reals())
-    j = Variable('j', ints(3))
+    j = Variable('j', bint(3))
 
     f = Stack((Number(0), x, y * z), 'i')
-    check_funsor(f, {'i': ints(3), 'x': reals(), 'y': reals(), 'z': reals()},
+    check_funsor(f, {'i': bint(3), 'x': reals(), 'y': reals(), 'z': reals()},
                  reals())
 
     assert f(i=Number(0, 3)) is Number(0)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import funsor
-from funsor.domains import Domain, ints, reals
+from funsor.domains import Domain, bint, reals
 from funsor.terms import Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import Tensor, align_tensors
@@ -28,59 +28,59 @@ def test_cons_hash():
 
 def test_indexing():
     data = torch.randn(4, 5)
-    inputs = OrderedDict([('i', ints(4)),
-                          ('j', ints(5))])
+    inputs = OrderedDict([('i', bint(4)),
+                          ('j', bint(5))])
     x = Tensor(data, inputs)
     check_funsor(x, inputs, reals(), data)
 
     assert x() is x
     assert x(k=3) is x
-    check_funsor(x(1), {'j': ints(5)}, reals(), data[1])
+    check_funsor(x(1), {'j': bint(5)}, reals(), data[1])
     check_funsor(x(1, 2), {}, reals(), data[1, 2])
     check_funsor(x(1, 2, k=3), {}, reals(), data[1, 2])
     check_funsor(x(1, j=2), {}, reals(), data[1, 2])
     check_funsor(x(1, j=2, k=3), (), reals(), data[1, 2])
-    check_funsor(x(1, k=3), {'j': ints(5)}, reals(), data[1])
-    check_funsor(x(i=1), {'j': ints(5)}, reals(), data[1])
+    check_funsor(x(1, k=3), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(i=1), {'j': bint(5)}, reals(), data[1])
     check_funsor(x(i=1, j=2), (), reals(), data[1, 2])
     check_funsor(x(i=1, j=2, k=3), (), reals(), data[1, 2])
-    check_funsor(x(i=1, k=3), {'j': ints(5)}, reals(), data[1])
-    check_funsor(x(j=2), {'i': ints(4)}, reals(), data[:, 2])
-    check_funsor(x(j=2, k=3), {'i': ints(4)}, reals(), data[:, 2])
+    check_funsor(x(i=1, k=3), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(j=2), {'i': bint(4)}, reals(), data[:, 2])
+    check_funsor(x(j=2, k=3), {'i': bint(4)}, reals(), data[:, 2])
 
 
 def test_advanced_indexing_shape():
     I, J, M, N = 4, 5, 2, 3
     x = Tensor(torch.randn(4, 5), OrderedDict([
-        ('i', ints(I)),
-        ('j', ints(J)),
+        ('i', bint(I)),
+        ('j', bint(J)),
     ]))
-    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', ints(M))]))
-    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', ints(N))]))
+    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', bint(M))]))
+    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', bint(N))]))
     assert x.data.shape == (4, 5)
 
-    check_funsor(x(i=m), {'j': ints(J), 'm': ints(M)}, reals())
-    check_funsor(x(i=m, j=n), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(i=m, j=n, k=m), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(i=m, k=m), {'j': ints(J), 'm': ints(M)}, reals())
-    check_funsor(x(i=n), {'j': ints(J), 'n': ints(N)}, reals())
-    check_funsor(x(i=n, k=m), {'j': ints(J), 'n': ints(N)}, reals())
-    check_funsor(x(j=m), {'i': ints(I), 'm': ints(M)}, reals())
-    check_funsor(x(j=m, i=n), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(j=m, i=n, k=m), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(j=m, k=m), {'i': ints(I), 'm': ints(M)}, reals())
-    check_funsor(x(j=n), {'i': ints(I), 'n': ints(N)}, reals())
-    check_funsor(x(j=n, k=m), {'i': ints(I), 'n': ints(N)}, reals())
-    check_funsor(x(m), {'j': ints(J), 'm': ints(M)}, reals())
-    check_funsor(x(m, j=n), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(m, j=n, k=m), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(m, k=m), {'j': ints(J), 'm': ints(M)}, reals())
-    check_funsor(x(m, n), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(m, n, k=m), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(n), {'j': ints(J), 'n': ints(N)}, reals())
-    check_funsor(x(n, k=m), {'j': ints(J), 'n': ints(N)}, reals())
-    check_funsor(x(n, m), {'m': ints(M), 'n': ints(N)}, reals())
-    check_funsor(x(n, m, k=m), {'m': ints(M), 'n': ints(N)}, reals())
+    check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(i=m, j=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(i=m, j=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(i=m, k=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(i=n), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(i=n, k=m), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(j=m), {'i': bint(I), 'm': bint(M)}, reals())
+    check_funsor(x(j=m, i=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(j=m, i=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(j=m, k=m), {'i': bint(I), 'm': bint(M)}, reals())
+    check_funsor(x(j=n), {'i': bint(I), 'n': bint(N)}, reals())
+    check_funsor(x(j=n, k=m), {'i': bint(I), 'n': bint(N)}, reals())
+    check_funsor(x(m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(m, j=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, j=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, k=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(m, n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(n), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(n, k=m), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(n, m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(n, m, k=m), {'m': bint(M), 'n': bint(N)}, reals())
 
 
 @pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
@@ -92,19 +92,19 @@ def test_advanced_indexing_tensor(output_shape):
     #      \ | /
     #        x
     x = Tensor(torch.randn((2, 3, 4) + output_shape), OrderedDict([
-        ('i', ints(2)),
-        ('j', ints(3)),
-        ('k', ints(4)),
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
     ]))
     i = Tensor(random_tensor(2, (5,)), OrderedDict([
-        ('u', ints(5)),
+        ('u', bint(5)),
     ]))
     j = Tensor(random_tensor(3, (6, 5)), OrderedDict([
-        ('v', ints(6)),
-        ('u', ints(5)),
+        ('v', bint(6)),
+        ('u', bint(5)),
     ]))
     k = Tensor(random_tensor(4, (6,)), OrderedDict([
-        ('v', ints(6)),
+        ('v', bint(6)),
     ]))
 
     expected_data = torch.empty((5, 6) + output_shape)
@@ -112,8 +112,8 @@ def test_advanced_indexing_tensor(output_shape):
         for v in range(6):
             expected_data[u, v] = x.data[i.data[u], j.data[v, u], k.data[v]]
     expected = Tensor(expected_data, OrderedDict([
-        ('u', ints(5)),
-        ('v', ints(6)),
+        ('u', bint(5)),
+        ('v', bint(6)),
     ]))
 
     assert_equiv(expected, x(i, j, k))
@@ -138,12 +138,12 @@ def test_advanced_indexing_tensor(output_shape):
 @pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
 def test_advanced_indexing_lazy(output_shape):
     x = Tensor(torch.randn((2, 3, 4) + output_shape), OrderedDict([
-        ('i', ints(2)),
-        ('j', ints(3)),
-        ('k', ints(4)),
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
     ]))
-    u = Variable('u', ints(2))
-    v = Variable('v', ints(3))
+    u = Variable('u', bint(2))
+    v = Variable('v', bint(3))
     i = 1 - u
     j = 2 - v
     k = u + v
@@ -156,8 +156,8 @@ def test_advanced_indexing_lazy(output_shape):
         for v in range(3):
             expected_data[u, v] = x.data[i_data[u], j_data[v], k_data[u, v]]
     expected = Tensor(expected_data, OrderedDict([
-        ('u', ints(2)),
-        ('v', ints(3)),
+        ('u', bint(2)),
+        ('v', bint(3)),
     ]))
 
     assert_equiv(expected, x(i, j, k))
@@ -192,7 +192,7 @@ def unary_eval(symbol, x):
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}
     shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
+    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     dtype = 'real'
     data = torch.rand(shape) + 0.5
     if symbol == '~':
@@ -227,8 +227,8 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape1 = tuple(sizes[d] for d in dims1)
     shape2 = tuple(sizes[d] for d in dims2)
-    inputs1 = OrderedDict((d, ints(sizes[d])) for d in dims1)
-    inputs2 = OrderedDict((d, ints(sizes[d])) for d in dims2)
+    inputs1 = OrderedDict((d, bint(sizes[d])) for d in dims1)
+    inputs2 = OrderedDict((d, bint(sizes[d])) for d in dims2)
     data1 = torch.rand(shape1) + 0.5
     data2 = torch.rand(shape2) + 0.5
     dtype = 'real'
@@ -251,7 +251,7 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
 def test_binary_funsor_scalar(symbol, dims, scalar):
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
+    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data1 = torch.rand(shape) + 0.5
     expected_data = binary_eval(symbol, data1, scalar)
 
@@ -266,7 +266,7 @@ def test_binary_funsor_scalar(symbol, dims, scalar):
 def test_binary_scalar_funsor(symbol, dims, scalar):
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
+    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data1 = torch.rand(shape) + 0.5
     expected_data = binary_eval(symbol, scalar, data1)
 
@@ -283,7 +283,7 @@ REDUCE_OPS = ['sum', 'prod', 'logsumexp', 'all', 'any', 'min', 'max']
 def test_reduce_all(dims, op_name):
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
+    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data = torch.rand(shape) + 0.5
     if op_name in ['all', 'any']:
         data = data.byte()
@@ -309,7 +309,7 @@ def test_reduce_subset(dims, reduced_vars, op_name):
     reduced_vars = frozenset(reduced_vars)
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
+    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data = torch.rand(shape) + 0.5
     dtype = 'real'
     if op_name in ['all', 'any']:
@@ -318,7 +318,7 @@ def test_reduce_subset(dims, reduced_vars, op_name):
     x = Tensor(data, inputs, dtype)
     actual = getattr(x, op_name)(reduced_vars)
     expected_inputs = OrderedDict(
-        (d, ints(sizes[d])) for d in dims if d not in reduced_vars)
+        (d, bint(sizes[d])) for d in dims if d not in reduced_vars)
 
     reduced_vars &= frozenset(dims)
     if not reduced_vars:
@@ -376,9 +376,9 @@ def test_function_lazy_matmul():
 
 def test_align():
     x = Tensor(torch.randn(2, 3, 4), OrderedDict([
-        ('i', ints(2)),
-        ('j', ints(3)),
-        ('k', ints(4)),
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
     ]))
     y = x.align(('j', 'k', 'i'))
     assert isinstance(y, Tensor)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -96,14 +96,14 @@ def test_advanced_indexing_tensor(output_shape):
         ('j', ints(3)),
         ('k', ints(4)),
     ]))
-    i = Tensor(random_tensor(ints(2, (5,))), OrderedDict([
+    i = Tensor(random_tensor(2, (5,)), OrderedDict([
         ('u', ints(5)),
     ]))
-    j = Tensor(random_tensor(ints(3, (6, 5))), OrderedDict([
+    j = Tensor(random_tensor(3, (6, 5)), OrderedDict([
         ('v', ints(6)),
         ('u', ints(5)),
     ]))
-    k = Tensor(random_tensor(ints(4, (6,))), OrderedDict([
+    k = Tensor(random_tensor(4, (6,)), OrderedDict([
         ('v', ints(6)),
     ]))
 
@@ -185,11 +185,14 @@ def unary_eval(symbol, x):
     return getattr(x, symbol)()
 
 
-@pytest.mark.parametrize('shape', [(), (4,), (2, 3)])
+@pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
     '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
 ])
-def test_unary(symbol, shape):
+def test_unary(symbol, dims):
+    sizes = {'a': 3, 'b': 4}
+    shape = tuple(sizes[d] for d in dims)
+    inputs = OrderedDict((d, ints(sizes[d])) for d in dims)
     dtype = 'real'
     data = torch.rand(shape) + 0.5
     if symbol == '~':
@@ -197,9 +200,9 @@ def test_unary(symbol, shape):
         dtype = 2
     expected_data = unary_eval(symbol, data)
 
-    x = Tensor(data, dtype=dtype)
+    x = Tensor(data, inputs, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, {}, funsor.Domain(shape, dtype), expected_data)
+    check_funsor(actual, inputs, funsor.Domain((), dtype), expected_data)
 
 
 BINARY_OPS = [


### PR DESCRIPTION
This PR drops support for integer array `Domain`s and renames `ints()` to `bint()` for "bounded integer".

For ease of review, I've split this PR into two separate commits
1. Drop support for int arrays
2. A pure renaming `ints` -> `bint`

## Motivation
- As @neerajprad points out, it is unclear whether bounded integers are useful.
- Prior to this PR only scalar arrays of integers (i.e. of empty shape `()`) could be used for indexing. It is unclear what multimensional integer arrays even mean.
- To properly index into tensors with multiple integers, we would need a 1-d array of bounded integers with *heterogeneous* bound. This possible future behavior is incompatible with the current interface, but will be forwards-compatible with this PR (e.g. via `bint(4,5)` to index into a `4x5` matrix). I have no plans to implement this soon.
- What about `Multinomial` and `OneHotCategorical`? Actually those are treated as multivariate real distributions in PyTorch, and we plan to maintain backwards compatibility. Moreover neither are precisely elements of the integer n-cube (the `ints()` type prior to this PR), but are rather elements of the integer simplex (`choose(n,k)` and `choose(n,1)`, respectively). 
- This PR avoids the excruciatingly complex math to make advanced indexing support vector indices (@jpchen and @fritzo abandoned an early attempt at this in #33 )

## Tested

- updated existing tests