### PR TITLE
Reinstate opt_einsum-based optimizer

### DIFF
--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -94,22 +94,24 @@ REDUCE_OP_TO_TORCH = {
 }
 
 
-# TODO fill out all pairs
 ASSOCIATIVE_OPS = frozenset([
-    (add, add),
-    (mul, mul),
-    (logaddexp, logaddexp),
-    (and_, and_),
-    (or_, or_),
-    (min, min),
-    (max, max),
+    add,
+    mul,
+    logaddexp,
+    and_,
+    or_,
+    min,
+    max,
 ])
 
 
-# TODO fill out all pairs
 DISTRIBUTIVE_OPS = frozenset([
     (logaddexp, add),
     (add, mul),
+    (max, mul),
+    (min, mul),
+    (max, add),
+    (min, add),
 ])
 
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -94,8 +94,29 @@ REDUCE_OP_TO_TORCH = {
 }
 
 
+# TODO fill out all pairs
+ASSOCIATIVE_OPS = frozenset([
+    (add, add),
+    (mul, mul),
+    (logaddexp, logaddexp),
+    (and_, and_),
+    (or_, or_),
+    (min, min),
+    (max, max),
+])
+
+
+# TODO fill out all pairs
+DISTRIBUTIVE_OPS = frozenset([
+    (logaddexp, add),
+    (add, mul),
+])
+
+
 __all__ = [
     'REDUCE_OP_TO_TORCH',
+    'ASSOCIATIVE_OPS',
+    'DISTRIBUTIVE_OPS',
     'abs',
     'add',
     'and_',

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -178,8 +178,8 @@ def optimize_reduction(op, arg, reduced_vars):
 
         # don't reduce a dimension too early - keep a collections.Counter
         # and only reduce when the dimension is removed from all lhs terms in path
-        reduce_dim_counter.subtract({d: 1 for d in reduced_vars & set(ta.inputs.keys())})
-        reduce_dim_counter.subtract({d: 1 for d in reduced_vars & set(tb.inputs.keys())})
+        reduce_dim_counter.subtract({d: 1 for d in reduced_vars & frozenset(ta.inputs.keys())})
+        reduce_dim_counter.subtract({d: 1 for d in reduced_vars & frozenset(tb.inputs.keys())})
 
         # reduce variables that don't appear in other terms
         both_vars = frozenset(ta.inputs.keys()) | frozenset(tb.inputs.keys())

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -151,11 +151,12 @@ def optimize_reduction(op, arg, reduced_vars):
     size_dict = {}
     for operand in arg.operands:
         inputs.append(frozenset(d for d in operand.inputs.keys()))
-        size_dict.update({k: (REAL_SIZE if v.dtype == 'real' else v.dtype)
+        size_dict.update({k: ((REAL_SIZE * v.num_elements) if v.dtype == 'real' else v.dtype)
                           for k, v in operand.inputs.items()})
     outputs = frozenset().union(*inputs) - reduced_vars
 
     # optimize path with greedy opt_einsum optimizer
+    # TODO switch to new 'auto' strategy when it's released
     path = greedy(inputs, outputs, size_dict)
 
     # convert path IR back to sequence of Reduce(Finitary(...))

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -119,13 +119,14 @@ def distribute_finitary(op, operands):
     elif any(isinstance(term, Finitary) and (term.op, op) in DISTRIBUTIVE_OPS
              for term in operands):
         # a * b * (c + d) -> (a * b * c) + (a * b * d)
-        for i, term in enumerate(operands):
-            if isinstance(term, Finitary) and (term.op, op) in DISTRIBUTIVE_OPS:
-                new_operands = []
-                for term_operand in term.operands:
-                    new_operands.append(
-                        Finitary(op, (term_operand,) + operands[:i] + operands[i+1:]))
-                return Finitary(term.op, new_operands)
+        return None  # skip this pass for now
+        # for i, term in enumerate(operands):
+        #     if isinstance(term, Finitary) and (term.op, op) in DISTRIBUTIVE_OPS:
+        #         new_operands = []
+        #         for term_operand in term.operands:
+        #             new_operands.append(
+        #                 Finitary(op, (term_operand,) + operands[:i] + operands[i+1:]))
+        #         return Finitary(term.op, new_operands)
 
     return None
 
@@ -151,6 +152,9 @@ def optimize_reduction(op, arg, reduced_vars):
     Recursively convert large Reduce(Finitary) ops to many smaller versions
     by reordering execution with a modified opt_einsum optimizer
     """
+    if not (op, arg.op) in DISTRIBUTIVE_OPS:
+        return None
+
     # build opt_einsum optimizer IR
     inputs = []
     size_dict = {}

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -178,14 +178,14 @@ def optimize_reduction(op, arg, reduced_vars):
         reduce_dim_counter.subtract((d, 1) for d in reduced_vars & set(tb.inputs.keys()))
 
         path_end_reduced_vars = frozenset(d for d in reduced_vars & (set(ta.inputs.keys()) | set(tb.inputs.keys()))
-                                         if reduce_dim_counter[d] == 0)
+                                          if reduce_dim_counter[d] == 0)
 
         path_end = Reduce(reduce_op, path_end_finitary, path_end_reduced_vars)
         operands[a] = path_end
 
     # reduce any remaining dims, if necessary
     final_reduced_vars = frozenset(d for (d, count) in reduce_dim_counter.items()
-                                  if count > 0) & reduced_vars
+                                   if count > 0) & reduced_vars
     if final_reduced_vars:
         path_end = Reduce(reduce_op, path_end, final_reduced_vars)
     return path_end

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -47,23 +47,6 @@ def eager_finitary(op, operands):
     return reduce(lambda lhs, rhs: Binary(op, lhs, rhs), operands)
 
 
-def desugar(cls, *args):
-    result = _desugar(cls, *args)
-    if result is None:
-        result = reflect(cls, *args)
-    return result
-
-
-_desugar = KeyedRegistry(default=lambda *args: None)
-desugar.register = _desugar.register
-
-
-@desugar.register(Binary, object, Funsor, Funsor)
-def binary_to_finitary(op, lhs, rhs):
-    """convert Binary to Finitary"""
-    return Finitary(op, (lhs, rhs))
-
-
 def associate(cls, *args):
     result = _associate(cls, *args)
     if result is None:
@@ -73,6 +56,12 @@ def associate(cls, *args):
 
 _associate = KeyedRegistry(default=lambda *args: None)
 associate.register = _associate.register
+
+
+@associate.register(Binary, object, Funsor, Funsor)
+def binary_to_finitary(op, lhs, rhs):
+    """convert Binary to Finitary"""
+    return Finitary(op, (lhs, rhs))
 
 
 @associate.register(Finitary, object, tuple)
@@ -209,9 +198,6 @@ def optimize_reduction(op, arg, reduced_vars):
 
 
 def apply_optimizer(x):
-
-    with interpretation(desugar):
-        x = reinterpret(x)
 
     with interpretation(associate):
         x = reinterpret(x)

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -69,7 +69,7 @@ def associate_finitary(op, operands):
     # Finitary(Finitary) -> Finitary
     new_operands = []
     for term in operands:
-        if isinstance(term, Finitary) and (term.op, op) in ASSOCIATIVE_OPS:
+        if isinstance(term, Finitary) and term.op is op and op in ASSOCIATIVE_OPS:
             new_operands.extend(term.operands)
         else:
             new_operands.append(term)
@@ -84,7 +84,7 @@ def associate_reduce(op, arg, reduced_vars):
     Rewrite to the largest possible Reduce(Finitary) by combining Reduces
     Assumes that all input Reduce/Finitary ops have been rewritten
     """
-    if (arg.op, op) in ASSOCIATIVE_OPS:
+    if arg.op is op and op in ASSOCIATIVE_OPS:
         # Reduce(Reduce) -> Reduce
         new_reduced_vars = reduced_vars.union(arg.reduced_vars)
         return Reduce(op, arg.arg, new_reduced_vars)
@@ -104,6 +104,7 @@ distribute.register = _distribute.register
 
 @distribute.register(Finitary, object, tuple)
 def distribute_finitary(op, operands):
+    # TODO raise an error or warning on name collision
     if len(operands) == 1:
         return operands[0]
 

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -196,10 +196,9 @@ def optimize_reduction(op, arg, reduced_vars):
         # count new appearance of variables that aren't reduced
         reduce_dim_counter.update({d: 1 for d in reduced_vars & (both_vars - path_end_reduced_vars)})
 
-        with interpretation(reflect):
-            path_end = Finitary(finitary_op, (ta, tb))
-            if path_end_reduced_vars:
-                path_end = Reduce(reduce_op, path_end, path_end_reduced_vars)
+        path_end = Binary(finitary_op, ta, tb)
+        if path_end_reduced_vars:
+            path_end = Reduce(reduce_op, path_end, path_end_reduced_vars)
 
         operands[a] = path_end
 
@@ -207,8 +206,7 @@ def optimize_reduction(op, arg, reduced_vars):
     final_reduced_vars = frozenset(d for (d, count) in reduce_dim_counter.items()
                                    if count > 0) & reduced_vars
     if final_reduced_vars:
-        with interpretation(reflect):
-            path_end = Reduce(reduce_op, path_end, final_reduced_vars)
+        path_end = Reduce(reduce_op, path_end, final_reduced_vars)
     return path_end
 
 

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -125,10 +125,9 @@ def distribute_finitary(op, operands):
         else:
             remaining_terms.append(term)
 
-    if reduce_terms:
-        remaining_terms.append(
-            Reduce(reduce_op, Finitary(op, tuple(term.arg for term in reduce_terms)), reduced_vars))
-
+    if len(reduce_terms) > 1:
+        new_finitary_term = Finitary(op, tuple(term.arg for term in reduce_terms))
+        remaining_terms.append(Reduce(reduce_op, new_finitary_term, reduced_vars))
         return Finitary(op, tuple(remaining_terms))
 
     return None

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -116,6 +116,17 @@ def distribute_finitary(op, operands):
 
         with interpretation(reflect):
             return Reduce(operands[0].op, Finitary(op, tuple(new_operands)), new_reduced_vars)
+    elif any(isinstance(term, Finitary) and (term.op, op) in DISTRIBUTIVE_OPS
+             for term in operands):
+        # a * b * (c + d) -> (a * b * c) + (a * b * d)
+        for i, term in enumerate(operands):
+            if isinstance(term, Finitary) and (term.op, op) in DISTRIBUTIVE_OPS:
+                new_operands = []
+                for term_operand in term.operands:
+                    new_operands.append(
+                        Finitary(op, (term_operand,) + operands[:i] + operands[i+1:]))
+                return Finitary(term.op, new_operands)
+
     return None
 
 

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -128,7 +128,7 @@ def distribute_finitary(op, operands):
         remaining_terms.append(
             Reduce(reduce_op, Finitary(op, tuple(term.arg for term in reduce_terms)), reduced_vars))
 
-        return Finitary(op, remaining_terms)
+        return Finitary(op, tuple(remaining_terms))
 
     return None
 

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -1,0 +1,205 @@
+from __future__ import absolute_import, division, print_function
+
+import collections
+from six.moves import reduce
+
+from opt_einsum.paths import greedy
+
+from funsor.domains import find_domain
+from funsor.interpreter import interpretation, reinterpret
+from funsor.registry import KeyedRegistry
+from funsor.terms import eager, reflect, Binary, Funsor, Number, Reduce, Variable
+from funsor.torch import Tensor
+
+
+class Finitary(Funsor):
+    """
+    Lazy finitary operation. Used internally in the optimizer.
+    """
+    def __init__(self, op, operands):
+        assert callable(op)
+        assert isinstance(operands, tuple)
+        assert all(isinstance(operand, Funsor) for operand in operands)
+        inputs = collections.OrderedDict()
+        for operand in operands:
+            inputs.update(operand.inputs)
+
+        output = reduce(lambda lhs, rhs: find_domain(op, lhs, rhs),
+                        [operand.output for operand in reversed(operands)])
+
+        super(Finitary, self).__init__(inputs, output)
+        self.op = op
+        self.operands = operands
+
+    def __repr__(self):
+        return 'Finitary({}, {})'.format(self.op.__name__, self.operands)
+
+    def eager_subs(self, subs):
+        if not any(k in self.inputs for k, v in subs):
+            return self
+        operands = tuple(operand.eager_subs(subs) for operand in self.operands)
+        return Finitary(self.op, operands)
+
+
+@eager.register(Finitary, object, tuple)
+def eager_finitary(op, operands):
+    return reduce(lambda lhs, rhs: Binary(op, lhs, rhs), operands)
+
+
+def desugar(cls, *args):
+    result = _desugar(cls, *args)
+    if result is None:
+        result = reflect(cls, *args)
+    return result
+
+
+_desugar = KeyedRegistry(default=lambda *args: None)
+desugar.register = _desugar.register
+
+
+@desugar.register(Binary, object, Funsor, Funsor)
+def binary_to_finitary(op, lhs, rhs):
+    """convert Binary to Finitary"""
+    return Finitary(op, (lhs, rhs))
+
+
+def deoptimize(cls, *args):
+    result = _deoptimize(cls, *args)
+    if result is None:
+        result = reflect(cls, *args)
+    return result
+
+
+_deoptimize = KeyedRegistry(default=lambda *args: None)
+deoptimize.register = _deoptimize.register
+
+
+@deoptimize.register(Finitary, object, tuple)
+def deoptimize_finitary(op, operands):
+    """
+    Rewrite to the largest possible Finitary(Finitary/Reduce) by moving Reduces
+    Assumes that all input Finitary ops have been rewritten
+    """
+    # two cases to rewrite, which we handle in separate branches:
+    if all(isinstance(term, (Finitary, Number, Tensor, Variable)) for term in operands):  # TODO check distributivity
+        # Case 1) Finitary(Finitary) -> Finitary
+        new_operands = []
+        for term in operands:
+            if isinstance(term, Finitary) and term.op == op:
+                new_operands.extend(term.operands)
+            else:
+                new_operands.append(term)
+
+        with interpretation(reflect):
+            return Finitary(op, tuple(new_operands))
+    elif all(isinstance(term, Reduce) for term in operands):  # TODO check distributivity
+        # Case 2) Finitary(Reduce, Reduce) -> Reduce(Finitary(lhs.arg, rhs.arg))
+        new_operands = []
+        new_reduced_vars = set()
+        for term in operands:
+            new_operands.append(term.arg)
+            new_reduced_vars = new_reduced_vars.union(term.reduced_vars)
+
+        with interpretation(reflect):
+            return Reduce(operands[0].op, Finitary(op, tuple(new_operands)), new_reduced_vars)
+    elif all(not isinstance(term, (Reduce, Finitary)) for term in operands):
+        with interpretation(reflect):
+            return Finitary(op, operands)  # nothing to do, reflect
+    else:
+        # Note: if we can't rewrite all operands in the finitary, fail for now
+        # A more sophisticated strategy is to apply this rule recursively
+        # Alternatively, we could do this rewrite on Binary ops instead of Finitary
+        raise NotImplementedError("TODO(eb8680) handle mixed case")
+
+
+@deoptimize.register(Reduce, object, Reduce, frozenset)
+def deoptimize_reduce(op, arg, reduced_vars):
+    """
+    Rewrite to the largest possible Reduce(Finitary) by combining Reduces
+    Assumes that all input Reduce/Finitary ops have been rewritten
+    """
+    if arg.op == op:
+        # Reduce(Reduce) -> Reduce
+        new_reduced_vars = reduced_vars.union(arg.reduced_vars)
+        return Reduce(op, arg.arg, new_reduced_vars)
+    return None
+
+
+def optimize(cls, *args):
+    result = _optimize(cls, *args)
+    if result is None:
+        result = reflect(cls, *args)
+    return result
+
+
+_optimize = KeyedRegistry(default=lambda *args: None)
+optimize.register = _optimize.register
+
+
+# TODO set a better value for this
+REAL_SIZE = 3  # the "size" of a real-valued dimension passed to the path optimizer
+
+
+@optimize.register(Reduce, object, Finitary, frozenset)
+def optimize_reduction(op, arg, reduced_vars):
+    r"""
+    Recursively convert large Reduce(Finitary) ops to many smaller versions
+    by reordering execution with a modified opt_einsum optimizer
+    """
+    # build opt_einsum optimizer IR
+    inputs = []
+    size_dict = {}
+    for operand in arg.operands:
+        inputs.append(frozenset(d for d in operand.inputs.keys()))
+        size_dict.update({k: (REAL_SIZE if v.dtype == 'real' else v.dtype)
+                          for k, v in operand.inputs.items()})
+    outputs = frozenset().union(*inputs) - reduced_vars
+
+    # optimize path with greedy opt_einsum optimizer
+    path = greedy(inputs, outputs, size_dict)
+
+    # convert path IR back to sequence of Reduce(Finitary(...))
+
+    # first prepare a reduce_dim counter to avoid early reduction
+    reduce_dim_counter = collections.Counter()
+    for input in inputs:
+        reduce_dim_counter.update({d: 1 for d in input})
+
+    reduce_op, finitary_op = op, arg.op
+    operands = list(arg.operands)
+    for (a, b) in path:
+        ta = operands[a]
+        tb = operands.pop(b)
+        path_end_finitary = Binary(finitary_op, ta, tb)
+
+        # don't reduce a dimension too early - keep a collections.Counter
+        # and only reduce when the dimension is removed from all lhs terms in path
+        reduce_dim_counter.subtract((d, 1) for d in reduced_vars & set(ta.inputs.keys()))
+        reduce_dim_counter.subtract((d, 1) for d in reduced_vars & set(tb.inputs.keys()))
+
+        path_end_reduced_vars = frozenset(d for d in reduced_vars & (set(ta.inputs.keys()) | set(tb.inputs.keys()))
+                                         if reduce_dim_counter[d] == 0)
+
+        path_end = Reduce(reduce_op, path_end_finitary, path_end_reduced_vars)
+        operands[a] = path_end
+
+    # reduce any remaining dims, if necessary
+    final_reduced_vars = frozenset(d for (d, count) in reduce_dim_counter.items()
+                                  if count > 0) & reduced_vars
+    if final_reduced_vars:
+        path_end = Reduce(reduce_op, path_end, final_reduced_vars)
+    return path_end
+
+
+def apply_optimizer(x):
+
+    with interpretation(desugar):
+        x = reinterpret(x)
+
+    with interpretation(deoptimize):
+        x = reinterpret(x)
+
+    with interpretation(optimize):
+        x = reinterpret(x)
+
+    return reinterpret(x)  # use previous interpretation

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -67,6 +67,9 @@ def make_einsum_example(equation, fill=None, sizes=(2, 3)):
         Tensor(operand, collections.OrderedDict([(d, bint(sizes[d])) for d in inp]))
         for inp, operand in zip(inputs, operands)
     ]
+
+    assert equation == \
+        ",".join(["".join(operand.inputs.keys()) for operand in funsor_operands]) + "->" + ",".join(outputs)
     return inputs, outputs, sizes, operands, funsor_operands
 
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -9,8 +9,9 @@ import torch
 from six import integer_types
 from six.moves import reduce
 
+import funsor.ops as ops
 from funsor.domains import bint
-from funsor.terms import Funsor
+from funsor.terms import Binary, Funsor
 from funsor.torch import Tensor
 
 
@@ -95,3 +96,27 @@ def random_tensor(dtype, shape):
         return torch.randn(shape)
     else:
         raise ValueError('unknown dtype: {}'.format(repr(dtype)))
+
+
+def naive_einsum(eqn, *terms, **kwargs):
+    backend = kwargs.pop('backend', 'torch')
+    if backend == 'torch':
+        sum_op, prod_op = ops.add, ops.mul
+    elif backend == 'pyro.ops.einsum.torch_log':
+        sum_op, prod_op = ops.logaddexp, ops.add
+    else:
+        raise ValueError("{} backend not implemented".format(backend))
+
+    assert isinstance(eqn, str)
+    assert all(isinstance(term, Funsor) for term in terms)
+    inputs, output = eqn.split('->')
+    assert len(output.split(',')) == 1
+    input_dims = frozenset(d for inp in inputs.split(',') for d in inp)
+    output_dims = frozenset(d for d in output)
+    reduce_dims = tuple(d for d in input_dims - output_dims)
+    prod = terms[0]
+    for term in terms[1:]:
+        prod = Binary(prod_op, prod, term)
+    for reduce_dim in reduce_dims:
+        prod = prod.reduce(sum_op, reduce_dim)
+    return prod

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -106,9 +106,9 @@ def test_einsum(equation, backend):
 
 
 OPTIMIZED_EINSUM_EXAMPLES = [
-    make_chain_einsum(t) for t in range(2, 100, 10)
+    make_chain_einsum(t) for t in range(2, 50, 10)
 ] + [
-    make_hmm_einsum(t) for t in range(2, 100, 10)
+    make_hmm_einsum(t) for t in range(2, 50, 10)
 ]
 
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -78,9 +78,8 @@ EINSUM_EXAMPLES = [
 
 
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
-@pytest.mark.parametrize('optimized', [False, True])
 @pytest.mark.parametrize('backend', ['torch', 'pyro.ops.einsum.torch_log'])
-def test_einsum(equation, optimized, backend):
+def test_einsum(equation, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
     expected = opt_einsum.contract(equation, *operands, backend=backend)
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -62,8 +62,8 @@ EINSUM_EXAMPLES = [
     "a,a,a,ab->ab",
     make_chain_einsum(5),
     make_hmm_einsum(6),
-    # make_hmm_einsum(20),  # slows down tests
-    # make_hmm_einsum(50),  # slows down tests
+    # make_hmm_einsum(20),  # slows down tests if optimized=False
+    # make_hmm_einsum(50),  # slows down tests if optimized=False
 ]
 
 XFAIL_EINSUM_EXAMPLES = [

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -16,10 +16,10 @@ from funsor.testing import xfail_param, make_einsum_example
 
 
 def make_hmm_einsum(num_steps):
-    inputs = []
+    inputs = [str(opt_einsum.get_symbol(0))]
     for t in range(num_steps):
         inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
-        inputs.append(str(opt_einsum.get_symbol(t)))
+        inputs.append(str(opt_einsum.get_symbol(t+1)))
     equation = ",".join(inputs) + "->"
     return equation
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -13,48 +13,7 @@ from funsor.terms import reflect, Binary
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 
-from funsor.testing import assert_close, make_einsum_example
-
-
-def make_chain_einsum(num_steps):
-    inputs = [str(opt_einsum.get_symbol(0))]
-    for t in range(num_steps):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
-    equation = ",".join(inputs) + "->"
-    return equation
-
-
-def make_hmm_einsum(num_steps):
-    inputs = [str(opt_einsum.get_symbol(0))]
-    for t in range(num_steps):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
-        inputs.append(str(opt_einsum.get_symbol(t+1)))
-    equation = ",".join(inputs) + "->"
-    return equation
-
-
-def naive_einsum(eqn, *terms, **kwargs):
-    backend = kwargs.pop('backend', 'torch')
-    if backend == 'torch':
-        sum_op, prod_op = ops.add, ops.mul
-    elif backend == 'pyro.ops.einsum.torch_log':
-        sum_op, prod_op = ops.logaddexp, ops.add
-    else:
-        raise ValueError("{} backend not implemented".format(backend))
-
-    assert isinstance(eqn, str)
-    assert all(isinstance(term, funsor.Funsor) for term in terms)
-    inputs, output = eqn.split('->')
-    assert len(output.split(',')) == 1
-    input_dims = frozenset(d for inp in inputs.split(',') for d in inp)
-    output_dims = frozenset(d for d in output)
-    reduce_dims = tuple(d for d in input_dims - output_dims)
-    prod = terms[0]
-    for term in terms[1:]:
-        prod = Binary(prod_op, prod, term)
-    for reduce_dim in reduce_dims:
-        prod = prod.reduce(sum_op, reduce_dim)
-    return prod
+from funsor.testing import assert_close, make_einsum_example, naive_einsum
 
 
 def naive_plated_einsum(eqn, *terms, **kwargs):
@@ -72,8 +31,6 @@ EINSUM_EXAMPLES = [
     "a,a,a,ab->ab",
     "ab->ba",
     "ab,bc,cd->da",
-    make_chain_einsum(5),
-    make_hmm_einsum(6),
 ]
 
 
@@ -92,35 +49,6 @@ def test_einsum(equation, backend):
     actual = naive_einsum(equation, *funsor_operands, backend=backend)
 
     assert_close(actual, actual_optimized, atol=1e-4)
-
-    assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
-    if len(outputs[0]) > 0:
-        actual = actual.align(tuple(outputs[0]))
-
-    assert expected.shape == actual.data.shape
-    assert torch.allclose(expected, actual.data)
-    for output in outputs:
-        for i, output_dim in enumerate(output):
-            assert output_dim in actual.inputs
-            assert actual.inputs[output_dim].dtype == sizes[output_dim]
-
-
-OPTIMIZED_EINSUM_EXAMPLES = [
-    make_chain_einsum(t) for t in range(2, 50, 10)
-] + [
-    make_hmm_einsum(t) for t in range(2, 50, 10)
-]
-
-
-@pytest.mark.parametrize('equation', OPTIMIZED_EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
-def test_optimized_einsum(equation, backend):
-    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    expected = opt_einsum.contract(equation, *operands, backend=backend)
-    with interpretation(reflect):
-        naive_ast = naive_einsum(equation, *funsor_operands, backend=backend)
-        optimized_ast = apply_optimizer(naive_ast)
-    actual = reinterpret(optimized_ast)  # eager by default
 
     assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
     if len(outputs[0]) > 0:

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -7,9 +7,8 @@ import torch
 from pyro.ops.contract import naive_ubersum
 
 import funsor
-import funsor.ops as ops
 
-from funsor.terms import reflect, Binary
+from funsor.terms import reflect
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -33,7 +33,8 @@ def make_hmm_einsum(num_steps):
     return equation
 
 
-def naive_einsum(eqn, *terms, backend='torch'):
+def naive_einsum(eqn, *terms, **kwargs):
+    backend = kwargs.pop('backend', 'torch')
     if backend == 'torch':
         sum_op, prod_op = ops.add, ops.mul
     elif backend == 'pyro.ops.einsum.torch_log':

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -75,8 +75,6 @@ XFAIL_EINSUM_EXAMPLES = [
 @pytest.mark.parametrize('optimized', [False, True])
 def test_einsum(equation, optimized):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    assert equation == ",".join(["".join(operand.inputs.keys()) for operand in funsor_operands]) + "->" + ",".join(outputs)
-
     expected = opt_einsum.contract(equation, *operands, backend='torch')
     if optimized:
         with interpretation(reflect):

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from collections import OrderedDict
+
+import opt_einsum
+import torch
+from pyro.ops.contract import naive_ubersum
+
+import funsor
+import funsor.ops as ops
+
+from funsor.distributions import Categorical
+from funsor.domains import bint
+from funsor.interpreter import interpretation, reinterpret
+from funsor.optimizer import apply_optimizer
+from funsor.terms import reflect, Binary, Variable
+from funsor.torch import Tensor
+
+from funsor.testing import assert_close, make_einsum_example, naive_einsum
+
+
+def make_chain_einsum(num_steps):
+    inputs = [str(opt_einsum.get_symbol(0))]
+    for t in range(num_steps):
+        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
+    equation = ",".join(inputs) + "->"
+    return equation
+
+
+def make_hmm_einsum(num_steps):
+    inputs = [str(opt_einsum.get_symbol(0))]
+    for t in range(num_steps):
+        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
+        inputs.append(str(opt_einsum.get_symbol(t+1)))
+    equation = ",".join(inputs) + "->"
+    return equation
+
+
+OPTIMIZED_EINSUM_EXAMPLES = [
+    make_chain_einsum(t) for t in range(2, 50, 10)
+] + [
+    make_hmm_einsum(t) for t in range(2, 50, 10)
+]
+
+
+@pytest.mark.parametrize('equation', OPTIMIZED_EINSUM_EXAMPLES)
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+def test_optimized_einsum(equation, backend):
+    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
+    expected = opt_einsum.contract(equation, *operands, backend=backend)
+    with interpretation(reflect):
+        naive_ast = naive_einsum(equation, *funsor_operands, backend=backend)
+        optimized_ast = apply_optimizer(naive_ast)
+    actual = reinterpret(optimized_ast)  # eager by default
+
+    assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
+    if len(outputs[0]) > 0:
+        actual = actual.align(tuple(outputs[0]))
+
+    assert expected.shape == actual.data.shape
+    assert torch.allclose(expected, actual.data)
+    for output in outputs:
+        for i, output_dim in enumerate(output):
+            assert output_dim in actual.inputs
+            assert actual.inputs[output_dim].dtype == sizes[output_dim]
+
+
+@pytest.mark.xfail(reason="recursion errors?")
+@pytest.mark.parametrize("eqn1,eqn2", [
+    ("ab,bc,cd->d", "de,ef,fg->"),
+])
+@pytest.mark.parametrize("optimize1", [False, True])
+@pytest.mark.parametrize("optimize2", [False, True])
+@pytest.mark.parametrize("backend1", ['torch'])
+@pytest.mark.parametrize("backend2", ['torch', 'pyro.ops.einsum.torch_log'])
+def test_nested_einsum(eqn1, eqn2, optimize1, optimize2, backend1, backend2):
+    inputs1, outputs1, sizes1, operands1, _ = make_einsum_example(eqn1, sizes=(3,))
+    inputs2, outputs2, sizes2, operands2, funsor_operands2 = make_einsum_example(eqn2, sizes=(3,))
+
+    operands1 = [torch.distributions.Categorical(probs=operand).probs
+                 for operand in operands1]
+
+    expected1 = opt_einsum.contract(eqn1, *operands1, backend=backend1)
+    expected2 = opt_einsum.contract(outputs1[0] + "," + eqn2, *([expected1] + operands2), backend=backend2)
+
+    with interpretation(reflect):
+        funsor_operands1 = [
+            Categorical(probs=Tensor(
+                operand,  # XXX .abs()?
+                inputs=OrderedDict([(d, bint(sizes1[d])) for d in inp[:-1]])
+            ))(value=Variable(inp[-1], bint(sizes1[inp[-1]])))
+            for inp, operand in zip(inputs1, operands1)
+        ]
+
+    with interpretation(reflect):
+        output1 = naive_einsum(eqn1, *tuple(funsor_operands1), backend=backend1)
+        output1 = apply_optimizer(output1) if optimize1 else output1
+        output2 = naive_einsum(outputs1[0] + "," + eqn2, *tuple([output1] + funsor_operands2), backend=backend2)
+        output2 = apply_optimizer(output2) if optimize2 else output2
+
+    actual2 = reinterpret(output2)
+    assert torch.allclose(expected2, actual2.data)

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -5,19 +5,17 @@ from collections import OrderedDict
 
 import opt_einsum
 import torch
-from pyro.ops.contract import naive_ubersum
 
 import funsor
-import funsor.ops as ops
 
 from funsor.distributions import Categorical
 from funsor.domains import bint
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
-from funsor.terms import reflect, Binary, Variable
+from funsor.terms import reflect, Variable
 from funsor.torch import Tensor
 
-from funsor.testing import assert_close, make_einsum_example, naive_einsum
+from funsor.testing import make_einsum_example, naive_einsum
 
 
 def make_chain_einsum(num_steps):
@@ -87,7 +85,7 @@ def test_nested_einsum(eqn1, eqn2, optimize1, optimize2, backend1, backend2):
     with interpretation(reflect):
         funsor_operands1 = [
             Categorical(probs=Tensor(
-                operand,  # XXX .abs()?
+                operand,
                 inputs=OrderedDict([(d, bint(sizes1[d])) for d in inp[:-1]])
             ))(value=Variable(inp[-1], bint(sizes1[inp[-1]])))
             for inp, operand in zip(inputs1, operands1)


### PR DESCRIPTION
This PR adds an updated version of the old opt_einsum optimizer and tests it against the existing `test_einsum` tests.

Tasks:
- [x] Rewrite `Binary` ops to `Finitary`
- [x] Exploit associativity of `Finitary` ops
- [x] Exploit associativity of `Reduce` ops
- [x] Exploit distributivity for `Reduce` and `Finitary`
- [x] Support multiple semirings
- [x] Support distributivity in mixed terms like `Finitary(Reduce, Finitary)`
- [x] Add HMM-style test cases that only work with optimization enabled
- [x] Add more tests that exercise edge cases

Triaged:
- Distribute `Finitary` ops over one another (no optimizer for this currently)
- Implement tensor variable elimination #9 
- Handle variable name collisons correctly throughout the optimizer instead of assuming global scope