### PR TITLE
Add simple wrapper around torch.einsum

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from funsor.domains import Domain, find_domain, bint, reals
+from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor
-from funsor.torch import Function, Tensor, arange, function
+from funsor.torch import Function, Tensor, arange, einsum, function
 
 from . import distributions, domains, handlers, interpreter, minipyro, ops, terms, torch
 
@@ -18,6 +18,7 @@ __all__ = [
     'backward',
     'distributions',
     'domains',
+    'einsum',
     'find_domain',
     'function',
     'handlers',

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -387,3 +387,29 @@ def test_align():
         for j in range(3):
             for k in range(4):
                 assert x(i=i, j=j, k=k) == y(i=i, j=j, k=k)
+
+
+@pytest.mark.parametrize('equation', [
+    'a->a',
+    'a,a->a',
+    'a,b->',
+    'a,b->a',
+    'a,b->b',
+    'a,b->ab',
+    'a,b->ba',
+    'ab,ba->',
+    'ab,ba->a',
+    'ab,ba->b',
+    'ab,ba->ab',
+    'ab,ba->ba',
+    'ab,bc->ac',
+])
+def test_einsum(equation):
+    sizes = dict(a=2, b=3, c=4)
+    inputs, outputs = equation.split('->')
+    inputs = inputs.split(',')
+    tensors = [torch.randn(tuple(sizes[d] for d in dims)) for dims in inputs]
+    funsors = [Tensor(x) for x in tensors]
+    expected = Tensor(torch.einsum(equation, *tensors))
+    actual = funsor.einsum(equation, *funsors)
+    assert_close(actual, expected)


### PR DESCRIPTION
This adds a simple wrapper `funsor.einsum` around `torch.einsum` for manipulating event tensors.

Note that the more interesting einsum-style algorithms in funsor are exposed as funsor-controlled dimensions and implemented in the optimizer #40 . This PR simply makes it easier to manipulate event tensors, as e.g. used in multivariate distributions. This is required for some of the affine linear algebra in `to_affine()` and `Gaussian` in #37 .

## Tested

- added a unit test