### PR TITLE
Fix filling in of defaults for distribution classes

### DIFF
--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -47,7 +47,7 @@ def main(args):
 
     # Train model parameters.
     print('---- training ----')
-    data = torch.ones(args.time_steps)
+    data = torch.ones(args.time_steps, dtype=torch.long)
     optim = torch.optim.Adam(params, lr=args.learning_rate)
     for step in range(args.train_steps):
         optim.zero_grad()

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -64,6 +64,12 @@ class CategoricalMeta(FunsorMeta):
     Wrapper to fill in default params.
     """
     def __call__(cls, probs, value=None):
+        probs = to_funsor(probs)
+        if value is None:
+            size = probs.output.shape[0]
+            value = Variable('value', bint(size))
+        else:
+            value = to_funsor(value)
         return super(CategoricalMeta, cls).__call__(probs, value)
 
 
@@ -72,12 +78,6 @@ class Categorical(Distribution):
     dist_class = dist.Categorical
 
     def __init__(self, probs, value=None):
-        probs = to_funsor(probs)
-        if value is None:
-            size = probs.output.shape[0]
-            value = Variable('value', bint(size))
-        else:
-            value = to_funsor(value)
         super(Categorical, self).__init__(probs, value)
 
 
@@ -97,16 +97,25 @@ def eager_categorical(probs, value):
     return Categorical.eager_log_prob(probs=probs, value=value)
 
 
-class Normal(Distribution):
-    dist_class = dist.Normal
-
-    def __init__(self, loc, scale, value=None):
+class NormalMeta(FunsorMeta):
+    """
+    Wrapper to fill in default params.
+    """
+    def __call__(cls, loc, scale, value=None):
         loc = to_funsor(loc)
         scale = to_funsor(scale)
         if value is None:
             value = Variable('value', reals())
         else:
             value = to_funsor(value)
+        return super(NormalMeta, cls).__call__(loc, scale, value)
+
+
+@add_metaclass(NormalMeta)
+class Normal(Distribution):
+    dist_class = dist.Normal
+
+    def __init__(self, loc, scale, value=None):
         super(Normal, self).__init__(loc, scale, value)
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -8,9 +8,16 @@ import torch
 
 import funsor
 import funsor.distributions as dist
-from funsor import Tensor
 from funsor.domains import bint, reals
+from funsor.terms import Variable
 from funsor.testing import assert_close, check_funsor, random_tensor
+from funsor.torch import Tensor
+
+
+def test_categorical_defaults():
+    probs = Variable('probs', reals(3))
+    value = Variable('value', bint(3))
+    assert dist.Categorical(probs) is dist.Categorical(probs, value)
 
 
 @pytest.mark.parametrize('size', [4])
@@ -35,6 +42,13 @@ def test_categorical_density(size, batch_shape):
     actual = dist.Categorical(probs, value)
     check_funsor(actual, inputs, reals())
     assert_close(actual, expected)
+
+
+def test_normal_defaults():
+    loc = Variable('loc', reals())
+    scale = Variable('scale', reals())
+    value = Variable('value', reals())
+    assert dist.Normal(loc, scale) is dist.Normal(loc, scale, value)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])


### PR DESCRIPTION
This ensures are filled in before the interpreter seeks matches.

This is important so that e.g. `Non` defaults and `numbers.Number` defaults can be promoted to `Variable` and `funsor.Number` respectively. This is needed by `Gaussian` tests in #37.

Note that these metaclasses can later be refactored in a more general way; this PR simply corrects behavior.

## Tested

- added two new unit tests
- fixed examples/discrete_hmm.py