### PR TITLE
Add a simple Delta distribution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -30,6 +30,17 @@ def numbers_to_tensors(*args):
     return args
 
 
+class DistributionMeta(FunsorMeta):
+    """
+    Wrapper to fill in default values and convert Numbers to Tensors.
+    """
+    def __call__(cls, *args, **kwargs):
+        args = cls._fill_defaults(*args, **kwargs)
+        args = numbers_to_tensors(*args)
+        return super(DistributionMeta, cls).__call__(*args)
+
+
+@add_metaclass(DistributionMeta)
 class Distribution(Funsor):
     """
     Funsor backed by a PyTorch distribution object.
@@ -78,75 +89,85 @@ class Distribution(Funsor):
 # Distribution Wrappers
 ################################################################################
 
-class CategoricalMeta(FunsorMeta):
-    """
-    Wrapper to fill in default params.
-    """
-    def __call__(cls, probs, value=None):
+class Categorical(Distribution):
+    dist_class = dist.Categorical
+
+    @staticmethod
+    def _fill_defaults(probs, value=None):
         probs = to_funsor(probs)
         if value is None:
             size = probs.output.shape[0]
             value = Variable('value', bint(size))
         else:
             value = to_funsor(value)
-        probs, value = numbers_to_tensors(probs, value)
-        return super(CategoricalMeta, cls).__call__(probs, value)
-
-
-@add_metaclass(CategoricalMeta)
-class Categorical(Distribution):
-    dist_class = dist.Categorical
+        return probs, value
 
     def __init__(self, probs, value=None):
         super(Categorical, self).__init__(probs, value)
 
 
-@eager.register(Categorical, Funsor, Number)
+@eager.register(Categorical, Funsor, Tensor)
 def eager_categorical(probs, value):
     return probs[value].log()
 
 
-@eager.register(Categorical, (Number, Tensor), (Number, Tensor))
+@eager.register(Categorical, Tensor, Tensor)
 def eager_categorical(probs, value):
     return Categorical.eager_log_prob(probs=probs, value=value)
 
 
-@eager.register(Categorical, (Number, Tensor), Variable)
+@eager.register(Categorical, Tensor, Variable)
 def eager_categorical(probs, value):
     value = materialize(value)
     return Categorical.eager_log_prob(probs=probs, value=value)
 
 
-class NormalMeta(FunsorMeta):
-    """
-    Wrapper to fill in default params.
-    """
-    def __call__(cls, loc, scale, value=None):
+class Delta(Distribution):
+    dist_class = dist.Delta
+
+    @staticmethod
+    def _fill_defaults(v, log_density=0, value=None):
+        v = to_funsor(v)
+        log_density = to_funsor(log_density)
+        if value is None:
+            value = Variable('value', reals())
+        else:
+            value = to_funsor(value)
+        return v, log_density, value
+
+    def __init__(self, v, log_density=0, value=None):
+        return super(Delta, self).__init__(v, log_density, value)
+
+
+@eager.register(Delta, Tensor, Tensor, Tensor)
+def eager_delta(v, log_density, value):
+    return Delta.eager_log_prob(v=v, log_density=log_density, value=value)
+
+
+class Normal(Distribution):
+    dist_class = dist.Normal
+
+    @staticmethod
+    def _fill_defaults(loc, scale, value=None):
         loc = to_funsor(loc)
         scale = to_funsor(scale)
         if value is None:
             value = Variable('value', reals())
         else:
             value = to_funsor(value)
-        loc, scale, value = numbers_to_tensors(loc, scale, value)
-        return super(NormalMeta, cls).__call__(loc, scale, value)
-
-
-@add_metaclass(NormalMeta)
-class Normal(Distribution):
-    dist_class = dist.Normal
+        return loc, scale, value
 
     def __init__(self, loc, scale, value=None):
         super(Normal, self).__init__(loc, scale, value)
 
 
-@eager.register(Normal, (Number, Tensor), (Number, Tensor), (Number, Tensor))
+@eager.register(Normal, Tensor, Tensor, Tensor)
 def eager_normal(loc, scale, value):
     return Normal.eager_log_prob(loc=loc, scale=scale, value=value)
 
 
 # Create a Gaussian from a ground observation.
-@eager.register(Normal, Variable, (Number, Tensor), (Number, Tensor))
+@eager.register(Normal, Variable, Tensor, Tensor)
 def eager_normal(loc, scale, value):
     assert loc.output == reals()
     inputs, (scale, value) = align_tensors(scale, value)
@@ -159,7 +180,7 @@ def eager_normal(loc, scale, value):
 
 
 # Create a Gaussian from a ground observation.
-@eager.register(Normal, (Number, Tensor), (Number, Tensor), Variable)
+@eager.register(Normal, Tensor, Tensor, Variable)
 def eager_normal(loc, scale, value):
     assert value.output == reals()
     inputs, (loc, scale) = align_tensors(loc, scale)
@@ -173,7 +194,7 @@ def eager_normal(loc, scale, value):
 
 # Create a Gaussian from a noisy identity transform.
 # This is extrememly limited but suffices for examples/kalman_filter.py
-@eager.register(Normal, Variable, (Number, Tensor), Variable)
+@eager.register(Normal, Variable, Tensor, Variable)
 def eager_normal(loc, scale, value):
     assert loc.output == reals()
     assert value.output == reals()
@@ -191,6 +212,7 @@ def eager_normal(loc, scale, value):
 
 __all__ = [
     'Categorical',
+    'Delta',
     'Distribution',
     'Normal',
 ]

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -141,7 +141,13 @@ class Delta(Distribution):
 
 @eager.register(Delta, Tensor, Tensor, Tensor)
 def eager_delta(v, log_density, value):
-    return Delta.eager_log_prob(v=v, log_density=log_density, value=value)
+    # This handles event_dim specially, and hence cannot use the
+    # generic Delta.eager_log_prob() method.
+    assert v.output == value.output
+    event_dim = len(v.output.shape)
+    inputs, (v, log_density, value) = align_tensors(v, log_density, value)
+    data = dist.Delta(v, log_density, event_dim).log_prob(value)
+    return Tensor(data, inputs)
 
 
 class Normal(Distribution):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -51,6 +51,12 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
         if actual.dtype in (torch.long, torch.uint8):
             assert (actual == expected).all(), msg
         else:
+            eq = (actual == expected)
+            if eq.all():
+                return
+            if eq.any():
+                actual = actual[~eq]
+                expected = expected[~eq]
             diff = (actual.detach() - expected.detach()).abs()
             if atol is not None:
                 assert diff.max() < atol, msg

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -62,7 +62,7 @@ def test_delta_density(batch_shape, event_shape):
     def delta(v, log_density, value):
         eq = (v == value)
         for _ in range(len(event_shape)):
-            eq = eq.min(dim=-1)[0]
+            eq = eq.all(dim=-1)
         return eq.type(v.dtype).log() + log_density
 
     check_funsor(delta, {'v': reals(*event_shape),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -22,7 +22,7 @@ def test_categorical_defaults():
 
 
 @pytest.mark.parametrize('size', [4])
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_categorical_density(size, batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -52,20 +52,26 @@ def test_delta_defaults():
     assert dist.Delta(v, log_density) is dist.Delta(v, log_density, value)
 
 
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
-def test_delta_density(batch_shape):
+@pytest.mark.parametrize('event_shape', [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_delta_density(batch_shape, event_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
-    @funsor.function(reals(), reals(), reals(), reals())
+    @funsor.function(reals(*event_shape), reals(), reals(*event_shape), reals())
     def delta(v, log_density, value):
-        return (v == value).type(v.dtype).log() + log_density
+        eq = (v == value)
+        for _ in range(len(event_shape)):
+            eq = eq.min(dim=-1)[0]
+        return eq.type(v.dtype).log() + log_density
 
-    check_funsor(delta, {'v': reals(), 'log_density': reals(), 'value': reals()}, reals())
+    check_funsor(delta, {'v': reals(*event_shape),
+                         'log_density': reals(),
+                         'value': reals(*event_shape)}, reals())
 
-    v = Tensor(torch.randn(batch_shape), inputs)
+    v = Tensor(torch.randn(batch_shape + event_shape), inputs)
     log_density = Tensor(torch.randn(batch_shape).exp(), inputs)
-    for value in [v, Tensor(torch.randn(batch_shape), inputs)]:
+    for value in [v, Tensor(torch.randn(batch_shape + event_shape), inputs)]:
         expected = delta(v, log_density, value)
         check_funsor(expected, inputs, reals())
 
@@ -81,7 +87,7 @@ def test_normal_defaults():
     assert dist.Normal(loc, scale) is dist.Normal(loc, scale, value)
 
 
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_normal_density(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -103,7 +109,7 @@ def test_normal_density(batch_shape):
     assert_close(actual, expected)
 
 
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_normal_gaussian_1(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -124,7 +130,7 @@ def test_normal_gaussian_1(batch_shape):
     assert_close(actual, expected, atol=1e-4)
 
 
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_normal_gaussian_2(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -145,7 +151,7 @@ def test_normal_gaussian_2(batch_shape):
     assert_close(actual, expected, atol=1e-4)
 
 
-@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_normal_gaussian_3(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))


### PR DESCRIPTION
Addresses #51

This PR
1. adds a simple `Delta` distribution to `funsor.distributions`
2. refactors all distributions to use a `._fill_defaults()` method, reducing metaclass boilerplate
3. removes `Number` handling from distribution pattern matching, since numbers should already be converted by `numbers_to_tensors()` in `DistributionMeta`.

This PR will be followed up by a general `Delta` class similar to `Tensor` and `Gaussian`.

## Tested
- added new unit tests for `dist.Delta`