### PR TITLE
Implement Op wrapper class to enable pattern matching

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -199,7 +199,7 @@ def eager_normal(loc, scale, value):
 
 
 # Create a Gaussian from a noisy identity transform.
-# This is extrememly limited but suffices for examples/kalman_filter.py
+# This is extremely limited but suffices for examples/kalman_filter.py
 @eager.register(Normal, Variable, Tensor, Variable)
 def eager_normal(loc, scale, value):
     assert loc.output == reals()

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -7,6 +7,7 @@ import torch
 from contextlib2 import contextmanager
 
 from funsor.domains import Domain
+from funsor.ops import Op
 from funsor.six import singledispatch
 
 _INTERPRETATION = None  # To be set later in funsor.terms
@@ -65,6 +66,7 @@ def reinterpret_funsor(x):
 @reinterpret.register(types.BuiltinFunctionType)
 @reinterpret.register(torch.Tensor)
 @reinterpret.register(Domain)
+@reinterpret.register(Op)
 def _reinterpret_ground(x):
     return x
 


### PR DESCRIPTION
This implements an `Op` wrapper class around operators to enable:
1. pattern matching (e.g. `Op` versus `AssociativeOp`), and
2. slightly cleaner pretty printing of expressions.

After this PR we might further create additional singleton classes to clean up some of our pattern matching logic, e.g.
```py
# OLD
@eager.register(Binary, Op, Gaussian, Gaussian)
def binary_gaussian_gaussian(op, lhs, rhs):
    if op is ops.add:
        ...do stuff...
    return None  # defer to default implementation

# NEW
@eager.register(Binary, AddOp, Gaussian, Gaussian)
def add_gaussian_gaussian(op, lhs, rhs):
    assert op is ops.add
    ...do stuff...
```
We might also simplify registration of pairs of functions by defining a special `CommutativeOp` registration mechanism.

## Tested
- exercised by existing unit tests
- I verified that this has no measurable performance impact