### PR TITLE
Add numpy backend for funsor

### DIFF
--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -227,21 +227,6 @@ class Array(Funsor):
                                  if k not in reduced_vars)
             return Array(data, inputs, self.dtype)
         return super(Array, self).eager_reduce(op, reduced_vars)
-    #
-    # def abs(self):
-    #     return Unary(ops.abs, self)
-    #
-    # def sqrt(self):
-    #     return Unary(ops.sqrt, self)
-    #
-    # def exp(self):
-    #     return Unary(ops.exp, self)
-    #
-    # def log(self):
-    #     return Unary(ops.log, self)
-    #
-    # def log1p(self):
-    #     return Unary(ops.log1p, self)
 
 
 @eager.register(Binary, object, Array, Number)

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -137,14 +137,8 @@ class Array(Funsor):
         data = np.transpose(self.data, (tuple(old_dims.index(d) for d in new_dims)))
         return Array(data, inputs, self.dtype)
 
-    def eager_subs(self, dim_subs):
-        assert isinstance(dim_subs, tuple)
-        subs = {}
-        for k, v in dim_subs:
-            if k in self.inputs:
-                if not isinstance(v, Number):
-                    assert v.output != reals(), "subs for dim {} must be of bounded integer (bint) type.".format(k)
-                subs[k] = materialize(v)
+    def eager_subs(self, subs):
+        assert isinstance(subs, tuple)
         if not subs:
             return self
 

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -1,0 +1,299 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import OrderedDict
+
+import numpy as np
+from six import add_metaclass, integer_types
+
+import funsor.ops as ops
+from funsor.domains import Domain, bint, find_domain
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_funsor
+
+
+def align_array(new_inputs, x):
+    r"""
+    Permute and expand an array to match desired ``new_inputs``.
+
+    :param OrderedDict new_inputs: A target set of inputs.
+    :param funsor.terms.Funsor x: A :class:`Array`s or
+        :class:`~funsor.terms.Number`.
+    :return: a number or :class:`np.ndarray` that can be broadcast to other
+        array with inputs ``new_inputs``.
+    :rtype: tuple
+    """
+    assert isinstance(new_inputs, OrderedDict)
+    assert isinstance(x, (Number, Array))
+    assert all(isinstance(d.dtype, integer_types) for d in x.inputs.values())
+
+    data = x.data
+    if isinstance(x, Number):
+        return data
+
+    old_inputs = x.inputs
+    if old_inputs == new_inputs:
+        return data
+
+    # Permute squashed input dims.
+    x_keys = tuple(old_inputs)
+    data = np.transpose(data, (tuple(x_keys.index(k) for k in new_inputs if k in old_inputs) +
+                               tuple(range(len(old_inputs), data.ndim))))
+
+    # Unsquash multivariate input dims by filling in ones.
+    data = np.reshape(data, tuple(old_inputs[k].dtype if k in old_inputs else 1 for k in new_inputs) +
+                      x.output.shape)
+    return data
+
+
+def align_arrays(*args):
+    r"""
+    Permute multiple arrays before applying a broadcasted op.
+
+    This is mainly useful for implementing eager funsor operations.
+
+    :param funsor.terms.Funsor \*args: Multiple :class:`Array`s and
+        :class:`~funsor.terms.Number`s.
+    :return: a pair ``(inputs, arrays)`` where arrayss are all
+        :class:`np.ndarray`s that can be broadcast together to a single data
+        with given ``inputs``.
+    :rtype: tuple
+    """
+    inputs = OrderedDict()
+    for x in args:
+        inputs.update(x.inputs)
+    tensors = [align_array(inputs, x) for x in args]
+    return inputs, tensors
+
+
+class ArrayMeta(FunsorMeta):
+    """
+    Wrapper to fill in default args and convert between OrderedDict and tuple.
+    """
+    def __call__(cls, data, inputs=None, dtype="real"):
+        if inputs is None:
+            inputs = tuple()
+        elif isinstance(inputs, OrderedDict):
+            inputs = tuple(inputs.items())
+        return super(ArrayMeta, cls).__call__(data, inputs, dtype)
+
+
+@to_funsor.register(np.ndarray)
+@add_metaclass(ArrayMeta)
+class Array(Funsor):
+    """
+    Funsor backed by a numpy ndarray.
+
+    :param tuple dims: A tuple of strings of dimension names.
+    :param np.ndarray data: A np.ndarray of appropriate shape.
+    """
+    def __init__(self, data, inputs=None, dtype="real"):
+        assert isinstance(data, np.ndarray) or np.isscalar(data)
+        assert isinstance(inputs, tuple)
+        assert all(isinstance(d.dtype, integer_types) for k, d in inputs)
+        inputs = OrderedDict(inputs)
+        output = Domain(data.shape[len(inputs):], dtype)
+        super(Array, self).__init__(inputs, output)
+        self.data = data
+
+    def __repr__(self):
+        if self.output != "real":
+            return 'Array({}, {}, {})'.format(self.data, self.inputs, repr(self.dtype))
+        elif self.inputs:
+            return 'Array({}, {})'.format(self.data, self.inputs)
+        else:
+            return 'Array({})'.format(self.data)
+
+    def __str__(self):
+        if self.dtype != "real":
+            return 'Array({}, {}, {})'.format(self.data, self.inputs, repr(self.dtype))
+        elif self.inputs:
+            return 'Array({}, {})'.format(self.data, self.inputs)
+        else:
+            return str(self.data)
+
+    def __int__(self):
+        return int(self.data)
+
+    def __float__(self):
+        return float(self.data)
+
+    def __bool__(self):
+        return bool(self.data)
+
+    def item(self):
+        return self.data.item()
+
+    def align(self, names):
+        assert isinstance(names, tuple)
+        assert all(name in self.inputs for name in names)
+        if not names or names == tuple(self.inputs):
+            return self
+        inputs = OrderedDict((name, self.inputs[name]) for name in names)
+        inputs.update(self.inputs)
+
+        if any(d.shape for d in self.inputs.values()):
+            raise NotImplementedError("TODO: Implement align with vector indices.")
+        old_dims = tuple(self.inputs)
+        new_dims = tuple(inputs)
+        data = np.transpose(self.data, (tuple(old_dims.index(d) for d in new_dims)))
+        return Array(data, inputs, self.dtype)
+
+    def eager_subs(self, subs):
+        assert isinstance(subs, tuple)
+        subs = {k: materialize(v) for k, v in subs if k in self.inputs}
+        if not subs:
+            return self
+
+        # Compute result shapes.
+        inputs = OrderedDict()
+        for k, domain in self.inputs.items():
+            if k in subs:
+                inputs.update(subs[k].inputs)
+            else:
+                inputs[k] = domain
+
+        # Construct a dict with each input's positional dim,
+        # counting from the right so as to support broadcasting.
+        total_size = len(inputs) + len(self.output.shape)  # Assumes only scalar indices.
+        new_dims = {}
+        for k, domain in inputs.items():
+            assert not domain.shape
+            new_dims[k] = len(new_dims) - total_size
+
+        # Use advanced indexing to construct a simultaneous substitution.
+        index = []
+        for k, domain in self.inputs.items():
+            if k in subs:
+                v = subs.get(k)
+                if isinstance(v, Number):
+                    index.append(int(v.data))
+                else:
+                    # Permute and expand v.data to end up at new_dims.
+                    assert isinstance(v, Array)
+                    v = v.align(tuple(k2 for k2 in inputs if k2 in v.inputs))
+                    assert isinstance(v, Array)
+                    v_shape = [1] * total_size
+                    for k2, size in zip(v.inputs, v.data.shape):
+                        v_shape[new_dims[k2]] = size
+                    index.append(v.data.reshape(tuple(v_shape)))
+            else:
+                # Construct a [:] slice for this preserved input.
+                offset_from_right = -1 - new_dims[k]
+                index.append(np.arange(domain.dtype).reshape(
+                    (-1,) + (1,) * offset_from_right))
+
+        # Construct a [:] slice for the output.
+        for i, size in enumerate(self.output.shape):
+            offset_from_right = len(self.output.shape) - i - 1
+            index.append(np.arange(size).reshape(
+                (-1,) + (1,) * offset_from_right))
+
+        data = self.data[tuple(index)]
+        return Array(data, inputs, self.dtype)
+
+    def eager_unary(self, op):
+        return Array(op(self.data), self.inputs, self.dtype)
+
+    def eager_reduce(self, op, reduced_vars):
+        if op in ops.REDUCE_OP_TO_TORCH:
+            torch_op = ops.REDUCE_OP_TO_TORCH[op]
+            assert isinstance(reduced_vars, frozenset)
+            self_vars = frozenset(self.inputs)
+            reduced_vars = reduced_vars & self_vars
+            if reduced_vars == self_vars:
+                # Reduce all dims at once.
+                if op is ops.logaddexp:
+                    data = np.logaddexp.reduce(np.reshape(self.data, -1), 0)
+                    return Array(data, dtype=self.dtype)
+                return Array(torch_op(self.data), dtype=self.dtype)
+
+            # Reduce one dim at a time.
+            data = self.data
+            offset = 0
+            for k, domain in self.inputs.items():
+                if k in reduced_vars:
+                    assert not domain.shape
+                    data = torch_op(data, dim=offset)
+                    if op is ops.min or op is ops.max:
+                        data = data[0]
+                else:
+                    offset += 1
+            inputs = OrderedDict((k, v) for k, v in self.inputs.items()
+                                 if k not in reduced_vars)
+            return Array(data, inputs, self.dtype)
+        return super(Array, self).eager_reduce(op, reduced_vars)
+
+
+@eager.register(Binary, object, Array, Number)
+def eager_binary_tensor_number(op, lhs, rhs):
+    if op is ops.getitem:
+        # Shift by that Funsor is using for inputs.
+        index = [slice(None)] * len(lhs.inputs)
+        index.append(rhs.data)
+        index = tuple(index)
+        data = lhs.data[index]
+    else:
+        data = op(lhs.data, rhs.data)
+    return Array(data, lhs.inputs, lhs.dtype)
+
+
+@eager.register(Binary, object, Number, Array)
+def eager_binary_number_tensor(op, lhs, rhs):
+    data = op(lhs.data, rhs.data)
+    return Array(data, rhs.inputs, rhs.dtype)
+
+
+@eager.register(Binary, object, Array, Array)
+def eager_binary_tensor_tensor(op, lhs, rhs):
+    # Compute inputs and outputs.
+    dtype = find_domain(op, lhs.output, rhs.output).dtype
+    if lhs.inputs == rhs.inputs:
+        inputs = lhs.inputs
+        lhs_data, rhs_data = lhs.data, rhs.data
+    else:
+        inputs, (lhs_data, rhs_data) = align_arrays(lhs, rhs)
+
+    if op is ops.getitem:
+        # getitem has special shape semantics.
+        if rhs.output.shape:
+            raise NotImplementedError('TODO support vector indexing')
+        assert lhs.output.shape == (rhs.dtype,)
+        index = [np.arange(size).reshape((-1,) + (1,) * (lhs_data.ndim - pos - 2))
+                 for pos, size in enumerate(lhs_data.shape)]
+        index[-1] = rhs_data
+        data = lhs_data[tuple(index)]
+    else:
+        data = op(lhs_data, rhs_data)
+
+    return Array(data, inputs, dtype)
+
+
+def arange(name, size):
+    """
+    Helper to create a named :func:`np.arange` funsor.
+
+    :param str name: A variable name.
+    :param int size: A size.
+    :rtype: Tensor
+    """
+    data = np.arange(size)
+    inputs = OrderedDict([(name, bint(size))])
+    return Array(data, inputs, dtype=size)
+
+
+def materialize(x):
+    """
+    Attempt to convert a Funsor to a :class:`~funsor.terms.Number` or
+    :class:`np.ndarray` by substituting :func:`arange`s into its free variables.
+    """
+    assert isinstance(x, Funsor)
+    if isinstance(x, (Number, Array)):
+        return x
+    subs = []
+    for name, domain in x.inputs.items():
+        if not isinstance(domain.dtype, integer_types):
+            raise ValueError('materialize() requires integer free variables but found '
+                             '"{}" of domain {}'.format(name, domain))
+        assert not domain.shape
+        subs.append((name, arange(name, domain.dtype)))
+    subs = tuple(subs)
+    return x.eager_subs(subs)

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -6,7 +6,7 @@ import numpy as np
 from six import add_metaclass, integer_types
 
 import funsor.ops as ops
-from funsor.domains import Domain, bint, find_domain, reals
+from funsor.domains import Domain, bint, find_domain
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_funsor
 
 
@@ -139,6 +139,7 @@ class Array(Funsor):
 
     def eager_subs(self, subs):
         assert isinstance(subs, tuple)
+        subs = {k: materialize(v) for k, v in subs if k in self.inputs}
         if not subs:
             return self
 

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -187,7 +187,8 @@ class Array(Funsor):
             index.append(np.arange(size).reshape(
                 (-1,) + (1,) * offset_from_right))
 
-        data = self.data[tuple(index)]
+        # Due to dtype promotion some index data might have np.float values
+        data = self.data[tuple(i.astype(np.int64) if isinstance(i, np.ndarray) else i for i in index)]
         return Array(data, inputs, self.dtype)
 
     def eager_unary(self, op):

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -60,8 +60,8 @@ def align_arrays(*args):
     inputs = OrderedDict()
     for x in args:
         inputs.update(x.inputs)
-    tensors = [align_array(inputs, x) for x in args]
-    return inputs, tensors
+    arrays = [align_array(inputs, x) for x in args]
+    return inputs, arrays
 
 
 class ArrayMeta(FunsorMeta):
@@ -224,7 +224,7 @@ class Array(Funsor):
 
 
 @eager.register(Binary, object, Array, Number)
-def eager_binary_tensor_number(op, lhs, rhs):
+def eager_binary_array_number(op, lhs, rhs):
     if op is ops.getitem:
         # Shift by that Funsor is using for inputs.
         index = [slice(None)] * len(lhs.inputs)
@@ -237,13 +237,13 @@ def eager_binary_tensor_number(op, lhs, rhs):
 
 
 @eager.register(Binary, object, Number, Array)
-def eager_binary_number_tensor(op, lhs, rhs):
+def eager_binary_number_array(op, lhs, rhs):
     data = op(lhs.data, rhs.data)
     return Array(data, rhs.inputs, rhs.dtype)
 
 
 @eager.register(Binary, object, Array, Array)
-def eager_binary_tensor_tensor(op, lhs, rhs):
+def eager_binary_array_array(op, lhs, rhs):
     # Compute inputs and outputs.
     dtype = find_domain(op, lhs.output, rhs.output).dtype
     if lhs.inputs == rhs.inputs:
@@ -273,7 +273,7 @@ def arange(name, size):
 
     :param str name: A variable name.
     :param int size: A size.
-    :rtype: Tensor
+    :rtype: Array
     """
     data = np.arange(size)
     inputs = OrderedDict([(name, bint(size))])

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -188,7 +188,7 @@ class Array(Funsor):
                 (-1,) + (1,) * offset_from_right))
 
         # Due to dtype promotion some index data might have np.float values
-        data = self.data[tuple(i.astype(np.int64) if isinstance(i, np.ndarray) else i for i in index)]
+        data = self.data[tuple(index)]
         return Array(data, inputs, self.dtype)
 
     def eager_unary(self, op):

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -6,6 +6,7 @@ from numbers import Number
 import operator
 
 import numpy as np
+from funsor.six import singledispatch
 import torch
 
 _builtin_abs = abs
@@ -51,11 +52,21 @@ xor = AssociativeOp(operator.xor)
 
 
 @Op
+@singledispatch
+def abs(x):
+    return _builtin_abs(x)
+
+
+@Op
+@abs.register(torch.Tensor)
+@abs.register(np.ndarray)
+@abs.register(np.generic)
 def abs(x):
     return np.abs(x)
 
 
 @Op
+@singledispatch
 def sqrt(x):
     return np.sqrt(x)
 
@@ -141,6 +152,17 @@ REDUCE_OP_TO_TORCH = {
     logaddexp: torch.logsumexp,
     min: torch.min,
     max: torch.max,
+}
+
+
+REDUCE_OP_TO_NUMPY = {
+    add: np.sum,
+    mul: np.prod,
+    and_: np.all,
+    or_: np.any,
+    logaddexp: np.logaddexp,
+    min: np.min,
+    max: np.max,
 }
 
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from funsor.six import singledispatch
 from numbers import Number
 from operator import add, and_, eq, ge, getitem, gt, invert, le, lt, mul, ne, neg, or_, sub, truediv, xor
 
@@ -13,23 +14,23 @@ _builtin_pow = pow
 
 
 def abs(x):
-    return _builtin_abs(x) if isinstance(x, Number) else x.abs()
+    return np.abs(x)
 
 
 def sqrt(x):
-    return np.sqrt(x) if isinstance(x, Number) else x.sqrt()
+    return np.sqrt(x)
 
 
 def exp(x):
-    return np.exp(x) if isinstance(x, Number) else x.exp()
+    return np.exp(x)
 
 
 def log(x):
-    return np.log(x) if isinstance(x, Number) else x.log()
+    return np.log(x)
 
 
 def log1p(x):
-    return np.log1p(x) if isinstance(x, Number) else x.log1p()
+    return np.log1p(x)
 
 
 def pow(x, y):
@@ -55,17 +56,7 @@ def min(x, y):
 
 
 def max(x, y):
-    if hasattr(x, '__max__'):
-        return x.__max__(y)
-    if hasattr(y, '__max__'):
-        return y.__max__(x)
-    if isinstance(x, torch.Tensor):
-        if isinstance(y, torch.Tensor):
-            return torch.max(x, y)
-        return x.clamp(min=y)
-    if isinstance(y, torch.Tensor):
-        return y.clamp(min=x)
-    return _builtin_max(x, y)
+    return np.max(x, y)
 
 
 def logaddexp(x, y):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -550,6 +550,7 @@ class Number(Funsor):
             data = type(dtype)(data)
         else:
             assert isinstance(dtype, str) and dtype == "real"
+            data = float(data)
         inputs = OrderedDict()
         output = Domain((), dtype)
         super(Number, self).__init__(inputs, output)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -31,15 +31,11 @@ from funsor.registry import KeyedRegistry
 from funsor.six import getargspec, singledispatch
 
 
-def _cons_cache_key(*args):
-    return tuple(id(arg) if not isinstance(arg, Hashable) else arg for arg in args)
-
-
 def reflect(cls, *args):
     """
     Construct a funsor, populate ``._ast_values``, and cons hash.
     """
-    cache_key = _cons_cache_key(*args)
+    cache_key = tuple(id(arg) if not isinstance(arg, Hashable) else arg for arg in args)
     if cache_key in cls._cons_cache:
         return cls._cons_cache[cache_key]
     result = super(FunsorMeta, cls).__call__(*args)

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -5,12 +5,14 @@ import itertools
 import operator
 from collections import OrderedDict, namedtuple
 
+import numpy as np
 import pytest
 import torch
 from six.moves import reduce
 
 from funsor.domains import Domain, bint
 from funsor.gaussian import Gaussian
+from funsor.numpy import Array
 from funsor.terms import Funsor
 from funsor.torch import Tensor
 
@@ -131,6 +133,23 @@ def random_tensor(inputs, output):
                                  num_elements,
                                  replacement=True).reshape(shape)
     return Tensor(data, inputs, output.dtype)
+
+
+def random_array(inputs, output):
+    """
+    Creates a random :class:`funsor.numpy.Array` with given inputs and output.
+    """
+    assert isinstance(inputs, OrderedDict)
+    assert isinstance(output, Domain)
+    shape = tuple(d.dtype for d in inputs.values()) + output.shape
+    if output.dtype == 'real':
+        data = np.random.normal(size=shape)
+    else:
+        num_elements = reduce(operator.mul, shape, 1)
+        data = np.random.choice(np.arange(output.dtype),
+                                size=num_elements,
+                                replace=True).reshape(shape)
+    return Array(data, inputs, output.dtype)
 
 
 def random_gaussian(inputs):

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -52,8 +52,8 @@ def test_advanced_indexing_shape():
         ('i', bint(I)),
         ('j', bint(J)),
     ]))
-    m = Array(np.array([2, 3]), OrderedDict([('m', bint(M))]))
-    n = Array(np.array([0, 1, 1]), OrderedDict([('n', bint(N))]))
+    m = Array(np.array([2, 3]), OrderedDict([('m', bint(M))]), 4)
+    n = Array(np.array([0, 1, 1]), OrderedDict([('n', bint(N))]), 5)
     assert x.data.shape == (4, 5)
 
     check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
@@ -180,14 +180,16 @@ def test_advanced_indexing_lazy(output_shape):
 def unary_eval(symbol, x):
     if symbol in ['~', '-']:
         return eval('{} x'.format(symbol))
-    return getattr(np, symbol)(x)
+    elif isinstance(x, np.ndarray) or np.isscalar(x):
+        return getattr(np, symbol)(x)
+    else:
+        return getattr(x, symbol)()
 
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
     '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
 ])
-@pytest.mark.xfail(reason="bad operand type for XXX: 'Array'")
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}
     shape = tuple(sizes[d] for d in dims)

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,0 +1,192 @@
+from collections import OrderedDict
+
+import pytest
+
+import funsor
+from funsor import bint, reals, Variable
+from funsor.numpy import Array
+import numpy as np
+
+from funsor.testing import check_funsor, assert_equiv, random_array
+
+
+@pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.int32, np.int64, np.uint8])
+def test_to_funsor(shape, dtype):
+    t = np.random.normal(size=shape).astype(dtype)
+    f = funsor.to_funsor(t)
+    assert isinstance(f, Array)
+
+
+def test_cons_hash():
+    x = np.random.randn(3, 3)
+    assert Array(x) is Array(x)
+
+
+def test_indexing():
+    data = np.random.normal(size=(4, 5))
+    inputs = OrderedDict([('i', bint(4)),
+                          ('j', bint(5))])
+    x = Array(data, inputs)
+    check_funsor(x, inputs, reals(), data)
+
+    assert x() is x
+    assert x(k=3) is x
+    check_funsor(x(1), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(1, 2), {}, reals(), data[1, 2])
+    check_funsor(x(1, 2, k=3), {}, reals(), data[1, 2])
+    check_funsor(x(1, j=2), {}, reals(), data[1, 2])
+    check_funsor(x(1, j=2, k=3), (), reals(), data[1, 2])
+    check_funsor(x(1, k=3), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(i=1), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(i=1, j=2), (), reals(), data[1, 2])
+    check_funsor(x(i=1, j=2, k=3), (), reals(), data[1, 2])
+    check_funsor(x(i=1, k=3), {'j': bint(5)}, reals(), data[1])
+    check_funsor(x(j=2), {'i': bint(4)}, reals(), data[:, 2])
+    check_funsor(x(j=2, k=3), {'i': bint(4)}, reals(), data[:, 2])
+
+
+def test_advanced_indexing_shape():
+    I, J, M, N = 4, 5, 2, 3
+    x = Array(np.random.normal(size=(4, 5)), OrderedDict([
+        ('i', bint(I)),
+        ('j', bint(J)),
+    ]))
+    m = Array(np.array([2, 3]), OrderedDict([('m', bint(M))]))
+    n = Array(np.array([0, 1, 1]), OrderedDict([('n', bint(N))]))
+    assert x.data.shape == (4, 5)
+
+    check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(i=m, j=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(i=m, j=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(i=m, k=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(i=n), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(i=n, k=m), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(j=m), {'i': bint(I), 'm': bint(M)}, reals())
+    check_funsor(x(j=m, i=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(j=m, i=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(j=m, k=m), {'i': bint(I), 'm': bint(M)}, reals())
+    check_funsor(x(j=n), {'i': bint(I), 'n': bint(N)}, reals())
+    check_funsor(x(j=n, k=m), {'i': bint(I), 'n': bint(N)}, reals())
+    check_funsor(x(m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(m, j=n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, j=n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, k=m), {'j': bint(J), 'm': bint(M)}, reals())
+    check_funsor(x(m, n), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(m, n, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(n), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(n, k=m), {'j': bint(J), 'n': bint(N)}, reals())
+    check_funsor(x(n, m), {'m': bint(M), 'n': bint(N)}, reals())
+    check_funsor(x(n, m, k=m), {'m': bint(M), 'n': bint(N)}, reals())
+
+
+@pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
+def test_advanced_indexing_array(output_shape):
+    #      u   v
+    #     / \ / \
+    #    i   j   k
+    #     \  |  /
+    #      \ | /
+    #        x
+    output = reals(*output_shape)
+    x = random_array(OrderedDict([
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
+    ]), output)
+    i = random_array(OrderedDict([
+        ('u', bint(5)),
+    ]), bint(2))
+    j = random_array(OrderedDict([
+        ('v', bint(6)),
+        ('u', bint(5)),
+    ]), bint(3))
+    k = random_array(OrderedDict([
+        ('v', bint(6)),
+    ]), bint(4))
+
+    expected_data = np.empty((5, 6) + output_shape)
+    for u in range(5):
+        for v in range(6):
+            expected_data[u, v] = x.data[i.data[u], j.data[v, u], k.data[v]]
+    expected = Array(expected_data, OrderedDict([
+        ('u', bint(5)),
+        ('v', bint(6)),
+    ]))
+
+    assert_equiv(expected, x(i, j, k))
+    assert_equiv(expected, x(i=i, j=j, k=k))
+
+    assert_equiv(expected, x(i=i, j=j)(k=k))
+    assert_equiv(expected, x(j=j, k=k)(i=i))
+    assert_equiv(expected, x(k=k, i=i)(j=j))
+
+    assert_equiv(expected, x(i=i)(j=j, k=k))
+    assert_equiv(expected, x(j=j)(k=k, i=i))
+    assert_equiv(expected, x(k=k)(i=i, j=j))
+
+    assert_equiv(expected, x(i=i)(j=j)(k=k))
+    assert_equiv(expected, x(i=i)(k=k)(j=j))
+    assert_equiv(expected, x(j=j)(i=i)(k=k))
+    assert_equiv(expected, x(j=j)(k=k)(i=i))
+    assert_equiv(expected, x(k=k)(i=i)(j=j))
+    assert_equiv(expected, x(k=k)(j=j)(i=i))
+
+
+@pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
+def test_advanced_indexing_lazy(output_shape):
+    x = Array(np.random.normal(size=(2, 3, 4) + output_shape), OrderedDict([
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
+    ]))
+    u = Variable('u', bint(2))
+    v = Variable('v', bint(3))
+    i = 1 - u
+    j = 2 - v
+    k = u + v
+
+    expected_data = np.empty((2, 3) + output_shape)
+    i_data = funsor.numpy.materialize(i).data
+    j_data = funsor.numpy.materialize(j).data
+    k_data = funsor.numpy.materialize(k).data
+    for u in range(2):
+        for v in range(3):
+            expected_data[u, v] = x.data[i_data[u], j_data[v], k_data[u, v]]
+    expected = Array(expected_data, OrderedDict([
+        ('u', bint(2)),
+        ('v', bint(3)),
+    ]))
+
+    assert_equiv(expected, x(i, j, k))
+    assert_equiv(expected, x(i=i, j=j, k=k))
+
+    assert_equiv(expected, x(i=i, j=j)(k=k))
+    assert_equiv(expected, x(j=j, k=k)(i=i))
+    assert_equiv(expected, x(k=k, i=i)(j=j))
+
+    assert_equiv(expected, x(i=i)(j=j, k=k))
+    assert_equiv(expected, x(j=j)(k=k, i=i))
+    assert_equiv(expected, x(k=k)(i=i, j=j))
+
+    assert_equiv(expected, x(i=i)(j=j)(k=k))
+    assert_equiv(expected, x(i=i)(k=k)(j=j))
+    assert_equiv(expected, x(j=j)(i=i)(k=k))
+    assert_equiv(expected, x(j=j)(k=k)(i=i))
+    assert_equiv(expected, x(k=k)(i=i)(j=j))
+    assert_equiv(expected, x(k=k)(j=j)(i=i))
+
+
+def test_align():
+    x = Array(np.random.randn(2, 3, 4), OrderedDict([
+        ('i', bint(2)),
+        ('j', bint(3)),
+        ('k', bint(4)),
+    ]))
+    y = x.align(('j', 'k', 'i'))
+    assert isinstance(y, Array)
+    assert tuple(y.inputs) == ('j', 'k', 'i')
+    for i in range(2):
+        for j in range(3):
+            for k in range(4):
+                assert x(i=i, j=j, k=k) == y(i=i, j=j, k=k)

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -177,35 +177,6 @@ def test_advanced_indexing_lazy(output_shape):
     assert_equiv(expected, x(k=k)(j=j)(i=i))
 
 
-def unary_eval(symbol, x):
-    if symbol in ['~', '-']:
-        return eval('{} x'.format(symbol))
-    elif isinstance(x, np.ndarray) or np.isscalar(x):
-        return getattr(np, symbol)(x)
-    else:
-        return getattr(x, symbol)()
-
-
-@pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
-@pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
-])
-def test_unary(symbol, dims):
-    sizes = {'a': 3, 'b': 4}
-    shape = tuple(sizes[d] for d in dims)
-    inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
-    dtype = 'real'
-    data = np.random.uniform(size=shape) + 0.5
-    if symbol == '~':
-        data = data.astype(np.uint8)
-        dtype = 2
-    expected_data = unary_eval(symbol, data)
-
-    x = Array(data, inputs, dtype)
-    actual = unary_eval(symbol, x)
-    check_funsor(actual, inputs, funsor.Domain((), dtype), expected_data)
-
-
 def test_align():
     x = Array(np.random.randn(2, 3, 4), OrderedDict([
         ('i', bint(2)),

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -147,9 +147,9 @@ def test_advanced_indexing_lazy(output_shape):
     k = u + v
 
     expected_data = np.empty((2, 3) + output_shape)
-    i_data = funsor.numpy.materialize(i).data
-    j_data = funsor.numpy.materialize(j).data
-    k_data = funsor.numpy.materialize(k).data
+    i_data = funsor.numpy.materialize(i).data.astype(np.int64)
+    j_data = funsor.numpy.materialize(j).data.astype(np.int64)
+    k_data = funsor.numpy.materialize(k).data.astype(np.int64)
     for u in range(2):
         for v in range(3):
             expected_data[u, v] = x.data[i_data[u], j_data[v], k_data[u, v]]

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import pytest
 
 import funsor
-from funsor import bint, reals, Variable
+from funsor import bint, reals, Variable, Number
 from funsor.numpy import Array
 import numpy as np
 
@@ -142,8 +142,8 @@ def test_advanced_indexing_lazy(output_shape):
     ]))
     u = Variable('u', bint(2))
     v = Variable('v', bint(3))
-    i = 1 - u
-    j = 2 - v
+    i = Number(1, 2) - u
+    j = Number(2, 3) - v
     k = u + v
 
     expected_data = np.empty((2, 3) + output_shape)

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -47,14 +47,14 @@ def test_indexing():
 
 
 def test_advanced_indexing_shape():
-    I, J, M, N = 4, 5, 2, 3
-    x = Array(np.random.normal(size=(4, 5)), OrderedDict([
+    I, J, M, N = 4, 4, 2, 3
+    x = Array(np.random.normal(size=(I, J)), OrderedDict([
         ('i', bint(I)),
         ('j', bint(J)),
     ]))
-    m = Array(np.array([2, 3]), OrderedDict([('m', bint(M))]), 4)
-    n = Array(np.array([0, 1, 1]), OrderedDict([('n', bint(N))]), 5)
-    assert x.data.shape == (4, 5)
+    m = Array(np.array([2, 3]), OrderedDict([('m', bint(M))]), I)
+    n = Array(np.array([0, 1, 1]), OrderedDict([('n', bint(N))]), J)
+    assert x.data.shape == (I, J)
 
     check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
     check_funsor(x(i=m, j=n), {'m': bint(M), 'n': bint(N)}, reals())


### PR DESCRIPTION
This adds a `funsor.numpy` backend in correspondence with the `funsor.torch` backend. I am surprised how easy it was to do this, and loved the design! 😄 
 - I'll comment on the places where I had to make some (very minor) changes.
 - The biggest difference in the API is that `np.ndarray` doesn't have attributes like `abs`, `log`, etc. and we need to dispatch to `np.abs`, `np.log` instead. I am still trying to get a better handle on the changes needed to support this in a clean way.
 - Currently, the code in `funsor.numpy` is very similar to `funsor.torch`, and we can discuss whether it makes sense to share more code and also tests (the only flipside is tighter coupling since the API of numpy and torch while largely very similar has some subtle differences).
 - I did not want to clutter this by using jax with its own dependencies, but we should be able to swap that out later with some minor changes.