### PR TITLE
 Assert that args to Tensor.eager_subs have bounded int type

### DIFF
--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -7,6 +7,7 @@ import torch
 
 import funsor
 import funsor.distributions as dist
+from funsor import Tensor
 
 
 def main(args):
@@ -40,7 +41,7 @@ def main(args):
             if isinstance(x_prev, funsor.Variable):
                 log_prob = log_prob.logsumexp(x_prev.name)
 
-            log_prob += emit(latent=x_curr, value=y)
+            log_prob += emit(latent=x_curr, value=Tensor(y, dtype=2))
 
         log_prob = log_prob.logsumexp()
         return log_prob

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -139,10 +139,10 @@ class Tensor(Funsor):
         data = self.data.permute(tuple(old_dims.index(d) for d in new_dims))
         return Tensor(data, inputs, self.dtype)
 
-    def eager_subs(self, subs_idxs):
-        assert isinstance(subs_idxs, tuple)
+    def eager_subs(self, dim_subs):
+        assert isinstance(dim_subs, tuple)
         subs = {}
-        for k, v in subs_idxs:
+        for k, v in dim_subs:
             if k in self.inputs:
                 if not isinstance(v, Number):
                     assert v.output != reals(), "subs for dim {} must be of bounded integer (bint) type.".format(k)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -139,9 +139,14 @@ class Tensor(Funsor):
         data = self.data.permute(tuple(old_dims.index(d) for d in new_dims))
         return Tensor(data, inputs, self.dtype)
 
-    def eager_subs(self, subs):
-        assert isinstance(subs, tuple)
-        subs = {k: materialize(v) for k, v in subs if k in self.inputs}
+    def eager_subs(self, subs_idxs):
+        assert isinstance(subs_idxs, tuple)
+        subs = {}
+        for k, v in subs_idxs:
+            if k in self.inputs:
+                if not isinstance(v, Number):
+                    assert v.output != reals(), "subs for dim {} must be of bounded integer (bint) type.".format(k)
+                subs[k] = materialize(v)
         if not subs:
             return self
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8,7 +8,7 @@ import torch
 
 import funsor
 from funsor.domains import Domain, bint, reals
-from funsor.terms import Variable
+from funsor.terms import Variable, Number
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import Tensor, align_tensors, torch_einsum
 
@@ -55,8 +55,8 @@ def test_advanced_indexing_shape():
         ('i', bint(I)),
         ('j', bint(J)),
     ]))
-    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', bint(M))]))
-    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', bint(N))]))
+    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', bint(M))]), 4)
+    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', bint(N))]), 5)
     assert x.data.shape == (4, 5)
 
     check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
@@ -145,8 +145,8 @@ def test_advanced_indexing_lazy(output_shape):
     ]))
     u = Variable('u', bint(2))
     v = Variable('v', bint(3))
-    i = 1 - u
-    j = 2 - v
+    i = Number(1, 2) - u
+    j = Number(2, 3) - v
     k = u + v
 
     expected_data = torch.empty((2, 3) + output_shape)


### PR DESCRIPTION
Refer to the discussion in #58. 

This adds a check in `eager_subs` to assert that the dtype of any substitution value is an int and not "real". This is more important for the numpy backend where `np.ndarray`s have their dtype promoted due to various binary operations, and therefore results of expressions such as `1 + Array(np.array([1])`  (which would have dtype="real" and `.data` backed by a np.float64 array) shouldn't be allowed as argument to `eager_subs`. This adds a little bit of verbosity in the call, so just opening this for discussion.