### PR TITLE
Add type check in Funsor.__call__()

### DIFF
--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -40,7 +40,7 @@ def main(args):
             if isinstance(x_prev, funsor.Variable):
                 log_prob = log_prob.logsumexp(x_prev.name)
 
-            log_prob += emit(latent=x_curr, value=y)
+            log_prob += emit(latent=x_curr, value=funsor.Tensor(y, dtype=2))
 
         log_prob = log_prob.logsumexp()
         return log_prob

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -147,9 +147,13 @@ class Funsor(object):
         for k, v in subs.items():
             if isinstance(v, str):
                 # Allow renaming of inputs via syntax x(y="z").
-                subs[k] = Variable(v, self.inputs[k])
+                v = Variable(v, self.inputs[k])
             else:
-                subs[k] = to_funsor(v)
+                v = to_funsor(v)
+            if v.output != self.inputs[k]:
+                raise TypeError('Expected substitution of {} to have type {}, but got {}'
+                                .format(repr(k), v.output, self.inputs[k]))
+            subs[k] = v
         return self.eager_subs(tuple(subs.items()))
 
     def __bool__(self):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -148,6 +148,8 @@ class Funsor(object):
             if isinstance(v, str):
                 # Allow renaming of inputs via syntax x(y="z").
                 v = Variable(v, self.inputs[k])
+            elif isinstance(v, numbers.Number):
+                v = Number(v, self.inputs[k].dtype)
             else:
                 v = to_funsor(v)
             if v.output != self.inputs[k]:

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -61,7 +61,6 @@ def test_variable(domain):
     x4 = Variable('x', bint(4))
     assert x4 is not x
     assert x4('x') is x4
-    assert x(x=x4) is x4
     assert x(y=x4) is x
 
     xp1 = x + 1.

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8,7 +8,7 @@ import torch
 
 import funsor
 from funsor.domains import Domain, bint, reals
-from funsor.terms import Variable
+from funsor.terms import Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import Tensor, align_tensors, torch_einsum
 
@@ -50,14 +50,14 @@ def test_indexing():
 
 
 def test_advanced_indexing_shape():
-    I, J, M, N = 4, 5, 2, 3
-    x = Tensor(torch.randn(4, 5), OrderedDict([
+    I, J, M, N = 4, 4, 2, 3
+    x = Tensor(torch.randn(I, J), OrderedDict([
         ('i', bint(I)),
         ('j', bint(J)),
     ]))
-    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', bint(M))]))
-    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', bint(N))]))
-    assert x.data.shape == (4, 5)
+    m = Tensor(torch.tensor([2, 3]), OrderedDict([('m', bint(M))]), I)
+    n = Tensor(torch.tensor([0, 1, 1]), OrderedDict([('n', bint(N))]), J)
+    assert x.data.shape == (I, J)
 
     check_funsor(x(i=m), {'j': bint(J), 'm': bint(M)}, reals())
     check_funsor(x(i=m, j=n), {'m': bint(M), 'n': bint(N)}, reals())
@@ -145,8 +145,8 @@ def test_advanced_indexing_lazy(output_shape):
     ]))
     u = Variable('u', bint(2))
     v = Variable('v', bint(3))
-    i = 1 - u
-    j = 2 - v
+    i = Number(1, 2) - u
+    j = Number(2, 3) - v
     k = u + v
 
     expected_data = torch.empty((2, 3) + output_shape)


### PR DESCRIPTION
Replaces #59 (Thanks @neerajprad for pointing out failing tests!)

This adds a type check in `__call__()` to ensure substituted values are appropriate. To allow convenient indexing by integers, it also allows conversion to bounded `Number` (similar to previous conversion of strings).

By doing this check in the user-facing `__call__()` rather than the internal `.eager_subs()` we ensure it only needs to happen once, and that it applies to all `Funsor` subclasses.