### PR TITLE
Add prototype funsor.adjoint module

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -5,7 +5,7 @@ from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor
 from funsor.torch import Function, Tensor, arange, torch_einsum, function
 
-from . import distributions, domains, einsum, gaussian, handlers, interpreter, minipyro, ops, terms, torch
+from . import adjoint, distributions, domains, einsum, gaussian, handlers, interpreter, minipyro, ops, terms, torch
 
 __all__ = [
     'Domain',
@@ -14,6 +14,7 @@ __all__ = [
     'Number',
     'Tensor',
     'Variable',
+    'adjoint',
     'arange',
     'backward',
     'bint',

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -5,7 +5,8 @@ from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor
 from funsor.torch import Function, Tensor, arange, function, torch_einsum
 
-from . import adjoint, contract, distributions, domains, einsum, gaussian, handlers, interpreter, minipyro, ops, terms, torch
+from . import adjoint, contract, distributions, domains, einsum, gaussian, \
+    handlers, interpreter, minipyro, ops, terms, torch
 
 __all__ = [
     'Domain',

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+import torch
+
+import funsor.ops as ops
+from funsor.interpreter import interpretation, reinterpret
+from funsor.ops import AssociativeOp
+from funsor.registry import KeyedRegistry
+from funsor.terms import Binary, Funsor, Number, Reduce, Variable, reflect
+from funsor.torch import Tensor
+
+
+class AdjointTape(object):
+
+    def __init__(self):
+        self.tape = []
+
+    def __call__(self, cls, *args):
+        result = reflect(cls, *args)
+        if cls in (Reduce, Binary, Tensor):
+            self.tape.append((result, cls, args))
+        return result
+
+
+def adjoint(expr, targets, start=Number(0.)):
+
+    adjoint_values = defaultdict(lambda: Number(0.))  # 1 in logspace
+    multiplicities = defaultdict(lambda: 0)
+
+    tape_recorder = AdjointTape()
+    with interpretation(tape_recorder):
+        adjoint_values[reinterpret(expr)] = start
+
+    while tape_recorder.tape:
+        output, fn, inputs = tape_recorder.tape.pop()
+        in_adjs = adjoint_ops(fn, adjoint_values[output], output, *inputs)
+        for v, adjv in in_adjs.items():
+            if isinstance(v, Variable):
+                multiplicities[v] += 1
+            adjoint_values[v] = adjoint_values[v] + adjv  # product in logspace
+
+    target_adjs = {}
+    for v in targets:
+        if isinstance(v, Variable):
+            target_adjs[v] = adjoint_values[v] / multiplicities[v]
+        else:
+            target_adjs[v] = adjoint_values[v] + v
+    return target_adjs
+
+
+# logaddexp/add
+def _fail_default(*args):
+    raise NotImplementedError("Should not be here! {}".format(args))
+
+
+adjoint_ops = KeyedRegistry(default=_fail_default)
+
+
+@adjoint_ops.register(Tensor, Funsor, Funsor, torch.Tensor, tuple, object)
+def adjoint_tensor(out_adj, out, data, inputs, dtype):
+    all_vars = frozenset(k for (k, v) in inputs)
+    in_adjs = {}
+    for (k, v) in inputs:
+        in_adj = (out_adj + out).reduce(ops.logaddexp, all_vars - {k})
+        in_adjs[Variable(k, v)] = in_adj
+    return in_adjs
+
+
+@adjoint_ops.register(Binary, Funsor, Funsor, AssociativeOp, Funsor, Funsor)
+def adjoint_binary(out_adj, out, op, lhs, rhs):
+    assert op is ops.add
+
+    lhs_reduced_vars = frozenset(rhs.inputs) - frozenset(lhs.inputs)
+    lhs_adj = (out_adj + rhs).reduce(ops.logaddexp, lhs_reduced_vars)
+
+    rhs_reduced_vars = frozenset(lhs.inputs) - frozenset(rhs.inputs)
+    rhs_adj = (out_adj + lhs).reduce(ops.logaddexp, rhs_reduced_vars)
+
+    return {lhs: lhs_adj, rhs: rhs_adj}
+
+
+@adjoint_ops.register(Reduce, Funsor, Funsor, AssociativeOp, Funsor, frozenset)
+def adjoint_reduce(out_adj, out, op, arg, reduced_vars):
+    assert op is ops.logaddexp
+    in_adj = out_adj + (0. * arg)  # XXX hack to simulate "expand"
+    return {arg: in_adj}

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -82,6 +82,8 @@ def adjoint_binary(out_adj, out, op, lhs, rhs):
 
 @adjoint_ops.register(Reduce, Funsor, Funsor, AssociativeOp, Funsor, frozenset)
 def adjoint_reduce(out_adj, out, op, arg, reduced_vars):
-    assert op is ops.logaddexp
-    in_adj = out_adj + (0. * arg)  # XXX hack to simulate "expand"
+    if op is ops.logaddexp:
+        in_adj = out_adj + (arg * 0.)  # XXX hack to simulate "expand"
+    elif op is ops.add:  # plate!
+        in_adj = out_adj + (out + -arg)
     return {arg: in_adj}

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -36,16 +36,14 @@ def adjoint(expr, targets, start=Number(0.)):
         output, fn, inputs = tape_recorder.tape.pop()
         in_adjs = adjoint_ops(fn, adjoint_values[output], output, *inputs)
         for v, adjv in in_adjs.items():
-            if isinstance(v, Variable):
-                multiplicities[v] += 1
+            multiplicities[v] += 1
             adjoint_values[v] = adjoint_values[v] + adjv  # product in logspace
 
     target_adjs = {}
     for v in targets:
-        if isinstance(v, Variable):
-            target_adjs[v] = adjoint_values[v] / multiplicities[v]
-        else:
-            target_adjs[v] = adjoint_values[v] + v
+        target_adjs[v] = adjoint_values[v] / multiplicities[v]
+        if not isinstance(v, Variable):
+            target_adjs[v] = target_adjs[v] + v
     return target_adjs
 
 
@@ -85,5 +83,5 @@ def adjoint_reduce(out_adj, out, op, arg, reduced_vars):
     if op is ops.logaddexp:
         in_adj = out_adj + (arg * 0.)  # XXX hack to simulate "expand"
     elif op is ops.add:  # plate!
-        in_adj = out_adj + (out + -arg)
+        in_adj = out_adj + (out - arg)
     return {arg: in_adj}

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -85,4 +85,4 @@ def adjoint_reduce(out_adj, out, op, arg, reduced_vars):
     if op is ops.logaddexp:
         return {arg: out_adj + (arg * 0.)}  # XXX hack to simulate "expand"
     elif op is ops.add:  # plate!
-        return {arg: out_adj + (out - arg)}
+        return {arg: out_adj + Binary(ops.safesub, out, arg)}

--- a/funsor/einsum.py
+++ b/funsor/einsum.py
@@ -13,7 +13,7 @@ def naive_einsum(eqn, *terms, **kwargs):
     backend = kwargs.pop('backend', 'torch')
     if backend == 'torch':
         sum_op, prod_op = ops.add, ops.mul
-    elif backend == 'pyro.ops.einsum.torch_log':
+    elif backend in ('pyro.ops.einsum.torch_log', 'pyro.ops.einsum.torch_marginal'):
         sum_op, prod_op = ops.logaddexp, ops.add
     else:
         raise ValueError("{} backend not implemented".format(backend))
@@ -74,7 +74,7 @@ def naive_plated_einsum(eqn, *terms, **kwargs):
     backend = kwargs.pop('backend', 'torch')
     if backend == 'torch':
         sum_op, prod_op = ops.add, ops.mul
-    elif backend == 'pyro.ops.einsum.torch_log':
+    elif backend in ('pyro.ops.einsum.torch_log', 'pyro.ops.einsum.torch_marginal'):
         sum_op, prod_op = ops.logaddexp, ops.add
     else:
         raise ValueError("{} backend not implemented".format(backend))

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -125,7 +125,10 @@ def safesub(x, y):
     if isinstance(y, Number):
         return sub(x, y)
     assert isinstance(y, torch.Tensor)
-    return x + -y.clamp(max=torch.finfo(y.dtype).max)
+    try:
+        return x + -y.clamp(max=torch.finfo(y.dtype).max)
+    except TypeError:
+        return x + -y.clamp(max=torch.iinfo(y.dtype).max)
 
 
 @Op
@@ -133,7 +136,10 @@ def safediv(x, y):
     if isinstance(y, Number):
         return truediv(x, y)
     assert isinstance(y, torch.Tensor)
-    return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
+    try:
+        return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
+    except TypeError:
+        return x * y.reciprocal().clamp(max=torch.iinfo(y.dtype).max)
 
 
 # just a placeholder

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -120,6 +120,22 @@ def logaddexp(x, y):
     return log(exp(x - shift) + exp(y - shift)) + shift
 
 
+@Op
+def safesub(x, y):
+    if isinstance(y, Number):
+        return sub(x, y)
+    assert isinstance(y, torch.Tensor)
+    return x + -y.clamp(max=torch.finfo(y.dtype).max)
+
+
+@Op
+def safediv(x, y):
+    if isinstance(y, Number):
+        return truediv(x, y)
+    assert isinstance(y, torch.Tensor)
+    return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
+
+
 # just a placeholder
 @Op
 def marginal(x, y):
@@ -154,8 +170,8 @@ DISTRIBUTIVE_OPS = frozenset([
 
 
 PRODUCT_INVERSES = {
-    mul: truediv,
-    add: sub,
+    mul: safediv,
+    add: safesub,
 }
 
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -143,6 +143,17 @@ def reciprocal(x):
     raise ValueError("No reciprocal for type {}".format(type(x)))
 
 
+@Op
+def _neg_logprobs(x):
+    if isinstance(x, Number):
+        return -x
+    if isinstance(x, torch.Tensor):
+        result = -x
+        result.clamp_(max=torch.finfo(result.dtype).max)
+        return result
+    raise ValueError("No neg for type {}".format(type(x)))
+
+
 REDUCE_OP_TO_TORCH = {
     add: torch.sum,
     mul: torch.prod,
@@ -166,7 +177,7 @@ DISTRIBUTIVE_OPS = frozenset([
 
 PRODUCT_INVERSES = {
     mul: reciprocal,
-    add: neg,
+    add: _neg_logprobs,
 }
 
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -202,6 +202,8 @@ __all__ = [
     'neg',
     'or_',
     'pow',
+    'safediv',
+    'safesub',
     'sample',
     'sqrt',
     'sub',

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -132,28 +132,6 @@ def sample(x, y):
     raise ValueError
 
 
-@Op
-def reciprocal(x):
-    if isinstance(x, Number):
-        return 1. / x
-    if isinstance(x, torch.Tensor):
-        result = x.reciprocal()
-        result.clamp_(max=torch.finfo(result.dtype).max)
-        return result
-    raise ValueError("No reciprocal for type {}".format(type(x)))
-
-
-@Op
-def _neg_logprobs(x):
-    if isinstance(x, Number):
-        return -x
-    if isinstance(x, torch.Tensor):
-        result = -x
-        result.clamp_(max=torch.finfo(result.dtype).max)
-        return result
-    raise ValueError("No neg for type {}".format(type(x)))
-
-
 REDUCE_OP_TO_TORCH = {
     add: torch.sum,
     mul: torch.prod,
@@ -176,8 +154,8 @@ DISTRIBUTIVE_OPS = frozenset([
 
 
 PRODUCT_INVERSES = {
-    mul: reciprocal,
-    add: _neg_logprobs,
+    mul: truediv,
+    add: sub,
 }
 
 
@@ -208,7 +186,6 @@ __all__ = [
     'neg',
     'or_',
     'pow',
-    'reciprocal',
     'sample',
     'sqrt',
     'sub',

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -7,6 +7,7 @@ from collections import OrderedDict, namedtuple
 
 import pytest
 import torch
+import opt_einsum
 from six.moves import reduce
 
 from funsor.domains import Domain, bint, reals
@@ -145,3 +146,36 @@ def random_gaussian(inputs):
     prec_sqrt = torch.randn(batch_shape + event_shape + event_shape)
     precision = torch.matmul(prec_sqrt, prec_sqrt.transpose(-1, -2))
     return Gaussian(log_density, loc, precision, inputs)
+
+
+def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
+
+    assert num_obs_plates >= num_hidden_plates
+    t0 = num_obs_plates + 1
+
+    obs_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_obs_plates))
+    hidden_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_hidden_plates))
+
+    inputs = [str(opt_einsum.get_symbol(t0))]
+    for t in range(t0, num_steps+t0):
+        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)) + hidden_plates)
+        inputs.append(str(opt_einsum.get_symbol(t+1)) + obs_plates)
+    equation = ",".join(inputs) + "->"
+    return (equation, ''.join(set(obs_plates + hidden_plates)))
+
+
+def make_chain_einsum(num_steps):
+    inputs = [str(opt_einsum.get_symbol(0))]
+    for t in range(num_steps):
+        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
+    equation = ",".join(inputs) + "->"
+    return equation
+
+
+def make_hmm_einsum(num_steps):
+    inputs = [str(opt_einsum.get_symbol(0))]
+    for t in range(num_steps):
+        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
+        inputs.append(str(opt_einsum.get_symbol(t+1)))
+    equation = ",".join(inputs) + "->"
+    return equation

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -16,7 +16,10 @@ from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to
 def _clamp_infs(x):
     """helper to ensure (-inf) - (-inf) == (-inf) and 0 / 0 == 0"""
     assert isinstance(x, torch.Tensor)
-    x.clamp_(max=torch.finfo(x.dtype).max)
+    try:
+        x.clamp_(max=torch.finfo(x.dtype).max)
+    except TypeError:
+        pass
     return x
 
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -13,16 +13,6 @@ from funsor.six import getargspec
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor
 
 
-def _clamp_infs(x):
-    """helper to ensure (-inf) - (-inf) == (-inf) and 0 / 0 == 0"""
-    assert isinstance(x, torch.Tensor)
-    try:
-        x.clamp_(max=torch.finfo(x.dtype).max)
-    except TypeError:
-        pass
-    return x
-
-
 def align_tensor(new_inputs, x):
     r"""
     Permute and expand a tensor to match desired ``new_inputs``.
@@ -247,16 +237,12 @@ def eager_binary_tensor_number(op, lhs, rhs):
         data = lhs.data[index]
     else:
         data = op(lhs.data, rhs.data)
-    if op in (ops.sub, ops.truediv):
-        data = _clamp_infs(data)
     return Tensor(data, lhs.inputs, lhs.dtype)
 
 
 @eager.register(Binary, Op, Number, Tensor)
 def eager_binary_number_tensor(op, lhs, rhs):
     data = op(lhs.data, rhs.data)
-    if op in (ops.sub, ops.truediv):
-        data = _clamp_infs(data)
     return Tensor(data, rhs.inputs, rhs.dtype)
 
 
@@ -282,8 +268,6 @@ def eager_binary_tensor_tensor(op, lhs, rhs):
     else:
         data = op(lhs_data, rhs_data)
 
-    if op in (ops.sub, ops.truediv):
-        data = _clamp_infs(data)
     return Tensor(data, inputs, dtype)
 
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -12,9 +12,9 @@ import funsor
 from funsor.domains import bint
 from funsor.terms import reflect, Variable
 from funsor.interpreter import interpretation, reinterpret
-from funsor.testing import make_einsum_example
+from funsor.testing import make_einsum_example  # , xfail_param
 
-from funsor.einsum import naive_einsum, einsum
+from funsor.einsum import naive_einsum, naive_plated_einsum, einsum
 from funsor.adjoint import adjoint
 
 
@@ -38,19 +38,19 @@ EINSUM_EXAMPLES = [
 
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_einsum_adjoint(einsum_impl, equation, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
 
     with interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    actuals = adjoint(fwd_expr, funsor_operands)
+        actuals = adjoint(fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)
     expected_out = pyro_einsum(equation, *operands,
                                modulo_total=True,
-                               backend="pyro.ops.einsum.torch_marginal")[0]
+                               backend=backend)[0]
     expected_out._pyro_backward()
 
     for i, (inp, tv, fv) in enumerate(zip(inputs, operands, funsor_operands)):
@@ -65,21 +65,62 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
 
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_einsum_adjoint_unary_marginals(einsum_impl, equation, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
     equation = ",".join(inputs) + "->"
 
+    targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
     with interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
-    actuals = adjoint(fwd_expr, targets)
+        actuals = adjoint(fwd_expr, targets)
 
     for target in targets:
         actual = reinterpret(actuals[target])
 
         expected = opt_einsum.contract(equation + target.name, *operands,
                                        backend=backend)
+        assert isinstance(actual, funsor.Tensor)
+        assert expected.shape == actual.data.shape
+        assert torch.allclose(expected, actual.data, atol=1e-7)
+
+
+PLATED_EINSUM_EXAMPLES = [
+    ('i->', 'i'),
+    (',i->', 'i'),
+    ('ai->', 'i'),
+    (',ai,abij->', 'ij'),
+    ('a,ai,bij->', 'ij'),
+    ('ai,abi,bci,cdi->', 'i'),
+    ('aij,abij,bcij->', 'ij'),
+    ('a,abi,bcij,cdij->', 'ij'),
+]
+
+
+@pytest.mark.parametrize('einsum_impl', [naive_plated_einsum, einsum])
+@pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
+def test_plated_einsum_adjoint(einsum_impl, equation, plates, backend):
+    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
+
+    with interpretation(reflect):
+        fwd_expr = einsum_impl(equation, *funsor_operands, plates=plates, backend=backend)
+        actuals = adjoint(fwd_expr, funsor_operands)
+
+    for operand in operands:
+        pyro_require_backward(operand)
+    expected_out = pyro_einsum(equation, *operands,
+                               modulo_total=False,
+                               plates=plates,
+                               backend=backend)[0]
+    expected_out._pyro_backward()
+
+    for i, (inp, tv, fv) in enumerate(zip(inputs, operands, funsor_operands)):
+        print(actuals[fv])
+        actual = reinterpret(actuals[fv])
+        expected = tv._pyro_backward_result
+        if inp:
+            actual = actual.align(tuple(inp))
         assert isinstance(actual, funsor.Tensor)
         assert expected.shape == actual.data.shape
         assert torch.allclose(expected, actual.data, atol=1e-7)

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -142,22 +142,6 @@ def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
     return (equation, ''.join(set(obs_plates + hidden_plates)))
 
 
-def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
-
-    assert num_obs_plates >= num_hidden_plates
-    t0 = num_obs_plates + 1
-
-    obs_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_obs_plates))
-    hidden_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_hidden_plates))
-
-    inputs = [str(opt_einsum.get_symbol(t0))]
-    for t in range(t0, num_steps+t0):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)) + hidden_plates)
-        inputs.append(str(opt_einsum.get_symbol(t+1)) + obs_plates)
-    equation = ",".join(inputs) + "->"
-    return (equation, ''.join(set(obs_plates + hidden_plates)))
-
-
 OPTIMIZED_PLATED_EINSUM_EXAMPLES = [
     make_plated_hmm_einsum(num_steps, num_obs_plates=b, num_hidden_plates=a)
     for num_steps in [40, 50]  # range(20, 50, 6)

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+import opt_einsum
+import torch
+from pyro.ops.contract import einsum as pyro_einsum
+from pyro.ops.einsum.adjoint import require_backward as pyro_require_backward
+
+import funsor
+
+from funsor.domains import bint
+from funsor.terms import reflect, Variable
+from funsor.interpreter import interpretation, reinterpret
+from funsor.testing import make_einsum_example
+
+from funsor.einsum import naive_einsum, einsum
+from funsor.adjoint import adjoint
+
+
+EINSUM_EXAMPLES = [
+    "a->",
+    "ab->",
+    ",->",
+    ",,->",
+    "a,a->a",
+    "a,a,a->a",
+    "a,b->",
+    "ab,a->",
+    "a,b,c->",
+    "a,a->",
+    "a,a,a,ab->",
+    "abc,bcd,cde->",
+    "ab,bc,cd->",
+    "ab,b,bc,c,cd,d->",
+]
+
+
+@pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
+@pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+def test_einsum_adjoint(einsum_impl, equation, backend):
+    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
+
+    with interpretation(reflect):
+        fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
+    actuals = adjoint(fwd_expr, funsor_operands)
+
+    for operand in operands:
+        pyro_require_backward(operand)
+    expected_out = pyro_einsum(equation, *operands,
+                               modulo_total=True,
+                               backend="pyro.ops.einsum.torch_marginal")[0]
+    expected_out._pyro_backward()
+
+    for i, (inp, tv, fv) in enumerate(zip(inputs, operands, funsor_operands)):
+        actual = reinterpret(actuals[fv])
+        expected = tv._pyro_backward_result
+        if inp:
+            actual = actual.align(tuple(inp))
+        assert isinstance(actual, funsor.Tensor)
+        assert expected.shape == actual.data.shape
+        assert torch.allclose(expected, actual.data, atol=1e-7)
+
+
+@pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
+@pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
+@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+def test_einsum_adjoint_unary_marginals(einsum_impl, equation, backend):
+    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
+    equation = ",".join(inputs) + "->"
+
+    with interpretation(reflect):
+        fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
+    targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
+    actuals = adjoint(fwd_expr, targets)
+
+    for target in targets:
+        actual = reinterpret(actuals[target])
+
+        expected = opt_einsum.contract(equation + target.name, *operands,
+                                       backend=backend)
+        assert isinstance(actual, funsor.Tensor)
+        assert expected.shape == actual.data.shape
+        assert torch.allclose(expected, actual.data, atol=1e-7)

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -16,25 +16,9 @@ from funsor.optimizer import apply_optimizer
 from funsor.terms import reflect, Variable
 from funsor.torch import Tensor
 
-from funsor.testing import make_einsum_example, assert_close
+from funsor.testing import assert_close, make_einsum_example, \
+    make_chain_einsum, make_hmm_einsum, make_plated_hmm_einsum
 from funsor.einsum import naive_einsum, naive_plated_einsum, einsum
-
-
-def make_chain_einsum(num_steps):
-    inputs = [str(opt_einsum.get_symbol(0))]
-    for t in range(num_steps):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
-    equation = ",".join(inputs) + "->"
-    return equation
-
-
-def make_hmm_einsum(num_steps):
-    inputs = [str(opt_einsum.get_symbol(0))]
-    for t in range(num_steps):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)))
-        inputs.append(str(opt_einsum.get_symbol(t+1)))
-    equation = ",".join(inputs) + "->"
-    return equation
 
 
 OPTIMIZED_EINSUM_EXAMPLES = [
@@ -103,22 +87,6 @@ def test_nested_einsum(eqn1, eqn2, optimize1, optimize2, backend1, backend2):
 
     assert torch.allclose(expected1, actual1.data)
     assert torch.allclose(expected2, actual2.data)
-
-
-def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
-
-    assert num_obs_plates >= num_hidden_plates
-    t0 = num_obs_plates + 1
-
-    obs_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_obs_plates))
-    hidden_plates = ''.join(opt_einsum.get_symbol(i) for i in range(num_hidden_plates))
-
-    inputs = [str(opt_einsum.get_symbol(t0))]
-    for t in range(t0, num_steps+t0):
-        inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)) + hidden_plates)
-        inputs.append(str(opt_einsum.get_symbol(t+1)) + obs_plates)
-    equation = ",".join(inputs) + "->"
-    return (equation, ''.join(set(obs_plates + hidden_plates)))
 
 
 PLATED_EINSUM_EXAMPLES = [


### PR DESCRIPTION
Addresses #50.  Pair coded with @fritzo 

This PR adds a `funsor.adjoint` module for forward-backward tensor variable elimination algorithms.  Currently it only supports plated forward-filter backward-marginal computations.