### PR TITLE
Make reduction methods operate over events

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ def pyro_sample(name, dist, obs=None):
     return value
 
 # ...later during inference...
-log_prob = trace_log_prob.logsumexp()  # collapses delayed variables
-loss = -funsor.eval(log_prob)          # performs variable elimination
+log_prob = trace_log_prob.reduce(logsaddexp)  # collapses delayed variables
+loss = -funsor.eval(log_prob)                 # performs variable elimination
 ```
 See [examples/minipyro.py](examples/minipyro.py) for a more complete example.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def pyro_sample(name, dist, obs=None):
     return value
 
 # ...later during inference...
-log_prob = trace_log_prob.reduce(logsaddexp)  # collapses delayed variables
+log_prob = trace_log_prob.reduce(logaddexp)  # collapses delayed variables
 loss = -funsor.eval(log_prob)                 # performs variable elimination
 ```
 See [examples/minipyro.py](examples/minipyro.py) for a more complete example.

--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -7,7 +7,7 @@ import torch
 
 import funsor
 import funsor.distributions as dist
-
+import funsor.ops as ops
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 from funsor.terms import lazy
@@ -42,11 +42,11 @@ def main(args):
             log_prob += trans(prev=x_prev, value=x_curr)
 
             if not args.lazy and isinstance(x_prev, funsor.Variable):
-                log_prob = log_prob.logsumexp(x_prev.name)
+                log_prob = log_prob.reduce(ops.logaddexp, x_prev.name)
 
             log_prob += emit(latent=x_curr, value=funsor.Tensor(y, dtype=2))
 
-        log_prob = log_prob.logsumexp()
+        log_prob = log_prob.reduce(ops.logaddexp)
         return log_prob
 
     # Train model parameters.

--- a/examples/kalman_filter.py
+++ b/examples/kalman_filter.py
@@ -6,7 +6,7 @@ import torch
 
 import funsor
 import funsor.distributions as dist
-
+import funsor.ops as ops
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 from funsor.terms import lazy
@@ -31,11 +31,11 @@ def main(args):
             log_prob += dist.Normal(x_prev, trans_noise, value=x_curr)
 
             if not args.lazy and isinstance(x_prev, funsor.Variable):
-                log_prob = log_prob.logsumexp(x_prev.name)
+                log_prob = log_prob.reduce(ops.logaddexp, x_prev.name)
 
             log_prob += dist.Normal(x_curr, emit_noise, value=y)
 
-        log_prob = log_prob.logsumexp()
+        log_prob = log_prob.reduce(ops.logaddexp)
         return log_prob
 
     # Train model parameters.

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -7,6 +7,7 @@ import torch
 import funsor
 import funsor.distributions as dist
 import funsor.minipyro as pyro
+import funsor.ops as ops
 
 
 def main(args):
@@ -57,7 +58,7 @@ def main(args):
                        if node["type"] == "sample")
 
         # integrate out deferred variables
-        log_prob = log_prob.logsumexp()
+        log_prob = log_prob.reduce(ops.logaddexp)
 
         loss = -funsor.eval(log_prob)  # does all the work
 

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -387,14 +387,14 @@ def elbo(model, guide, *args, **kwargs):
         guide(*args, **kwargs)
         # FIXME This is only correct for reparametrized sites.
         # FIXME do not marginalize; instead sample.
-        q = guide_joint.log_prob.logsumexp()
+        q = guide_joint.log_prob.reduce(ops.logaddexp)
     tr = guide_joint.samples
     tr.update(funsor.backward(ops.sample, q))  # force deferred samples?
 
     # replay model against guide
     with log_joint() as model_joint, replay(guide_trace=tr):
         model(*args, **kwargs)
-        p = funsor.eval(model_joint.log_prob.logsumexp())
+        p = funsor.eval(model_joint.log_prob.reduce(ops.logaddexp))
 
     elbo = p - q
     return -elbo  # negate, for use as loss

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -250,6 +250,8 @@ class Funsor(object):
 
         return None  # defer to default implementation
 
+    # The following methods conform to a standard array/tensor interface.
+
     def __invert__(self):
         return Unary(ops.invert, self)
 
@@ -270,6 +272,31 @@ class Funsor(object):
 
     def log1p(self):
         return Unary(ops.log1p, self)
+
+    # The following reductions are treated as Unary ops because they
+    # reduce over output shape while preserving all inputs.
+    # To reduce over inputs, instead call .reduce(op, reduced_vars).
+
+    def sum(self):
+        return Unary(ops.add, self)
+
+    def prod(self):
+        return Unary(ops.mul, self)
+
+    def logsumexp(self):
+        return Unary(ops.logaddexp, self)
+
+    def all(self):
+        return Unary(ops.and_, self)
+
+    def any(self):
+        return Unary(ops.or_, self)
+
+    def min(self):
+        return Unary(ops.min, self)
+
+    def max(self):
+        return Unary(ops.max, self)
 
     def __add__(self, other):
         return Binary(ops.add, self, to_funsor(other))
@@ -342,27 +369,6 @@ class Funsor(object):
 
     def __getitem__(self, other):
         return Binary(ops.getitem, self, to_funsor(other))
-
-    def sum(self, reduced_vars=None):
-        return self.reduce(ops.add, reduced_vars)
-
-    def prod(self, reduced_vars=None):
-        return self.reduce(ops.mul, reduced_vars)
-
-    def logsumexp(self, reduced_vars=None):
-        return self.reduce(ops.logaddexp, reduced_vars)
-
-    def all(self, reduced_vars=None):
-        return self.reduce(ops.and_, reduced_vars)
-
-    def any(self, reduced_vars=None):
-        return self.reduce(ops.or_, reduced_vars)
-
-    def min(self, reduced_vars=None):
-        return self.reduce(ops.min, reduced_vars)
-
-    def max(self, reduced_vars=None):
-        return self.reduce(ops.max, reduced_vars)
 
 
 interpreter.reinterpret.register(Funsor)(interpreter.reinterpret_funsor)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -194,6 +194,12 @@ class Tensor(Funsor):
         return Tensor(data, inputs, self.dtype)
 
     def eager_unary(self, op):
+        if op is ops.logaddexp:
+            # work around missing torch.Tensor.logsumexp()
+            batch_dim = len(self.data.shape) - len(self.output.shape)
+            data = self.data.reshape(self.data.shape[:batch_dim] + (-1,))
+            return Tensor(data.logsumexp(0), self.inputs, self.dtype)
+        op = ops.REDUCE_OP_TO_TORCH.get(op, op)
         return Tensor(op(self.data), self.inputs, self.dtype)
 
     def eager_reduce(self, op, reduced_vars):

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -194,12 +194,13 @@ class Tensor(Funsor):
         return Tensor(data, inputs, self.dtype)
 
     def eager_unary(self, op):
-        if op is ops.logaddexp:
-            # work around missing torch.Tensor.logsumexp()
+        if op in ops.REDUCE_OP_TO_TORCH:
             batch_dim = len(self.data.shape) - len(self.output.shape)
             data = self.data.reshape(self.data.shape[:batch_dim] + (-1,))
-            return Tensor(data.logsumexp(0), self.inputs, self.dtype)
-        op = ops.REDUCE_OP_TO_TORCH.get(op, op)
+            data = ops.REDUCE_OP_TO_TORCH[op](data, -1)
+            if op is ops.min or op is ops.max:
+                data = data[0]
+            return Tensor(data, self.inputs, self.dtype)
         return Tensor(op(self.data), self.inputs, self.dtype)
 
     def eager_reduce(self, op, reduced_vars):

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import pytest
 import torch
 
+import funsor.ops as ops
 from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.terms import Number
@@ -36,10 +37,10 @@ def id_from_inputs(inputs):
     ('(g1 + g2)(i=i0)', Gaussian),
     ('(g1 + g2)(x=x0, y=y0)', Tensor),
     ('(g2 + g1)(x=x0, y=y0)', Tensor),
-    ('g1.logsumexp("x")', Tensor),
-    ('(g1 + g2).logsumexp("x")', Gaussian),
-    ('(g1 + g2).logsumexp("y")', Gaussian),
-    ('(g1 + g2).logsumexp(frozenset(["x", "y"]))', Tensor),
+    ('g1.reduce(ops.logaddexp, "x")', Tensor),
+    ('(g1 + g2).reduce(ops.logaddexp, "x")', Gaussian),
+    ('(g1 + g2).reduce(ops.logaddexp, "y")', Gaussian),
+    ('(g1 + g2).reduce(ops.logaddexp, frozenset(["x", "y"]))', Tensor),
 ])
 def test_smoke(expr, expected_type):
     g1 = Gaussian(
@@ -228,6 +229,6 @@ def test_logsumexp(int_inputs, real_inputs):
     inputs.update(real_inputs)
 
     g = random_gaussian(inputs)
-    g_xy = g.logsumexp(frozenset(['x', 'y']))
-    assert_close(g_xy, g.logsumexp('x').logsumexp('y'), atol=1e-4, rtol=None)
-    assert_close(g_xy, g.logsumexp('y').logsumexp('x'), atol=1e-4, rtol=None)
+    g_xy = g.reduce(ops.logaddexp, frozenset(['x', 'y']))
+    assert_close(g_xy, g.reduce(ops.logaddexp, 'x').reduce(ops.logaddexp, 'y'), atol=1e-4, rtol=None)
+    assert_close(g_xy, g.reduce(ops.logaddexp, 'y').reduce(ops.logaddexp, 'x'), atol=1e-4, rtol=None)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -205,7 +205,7 @@ def test_stack_simple():
     assert xyz(i=Number(0, 3)) is x
     assert xyz(i=Number(1, 3)) is y
     assert xyz(i=Number(2, 3)) is z
-    assert xyz.sum('i') == 5.
+    assert xyz.reduce(ops.add, 'i') == 5.
 
 
 def test_stack_subs():
@@ -223,7 +223,7 @@ def test_stack_subs():
     assert f(i=Number(2, 3)) is y * z
     assert f(i=j) is Stack((Number(0), x, y * z), 'j')
     assert f(i='j') is Stack((Number(0), x, y * z), 'j')
-    assert f.sum('i') is Number(0) + x + (y * z)
+    assert f.reduce(ops.add, 'i') is Number(0) + x + (y * z)
 
     assert f(x=0) is Stack((Number(0), Number(0), y * z), 'i')
     assert f(y=x) is Stack((Number(0), x, x * z), 'i')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7,7 +7,9 @@ import pytest
 import torch
 
 import funsor
+import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
+from funsor.ops import REDUCE_OP_TO_TORCH
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import Tensor, align_tensors, torch_einsum
@@ -276,26 +278,26 @@ def test_binary_scalar_funsor(symbol, dims, scalar):
     check_funsor(actual, inputs, reals(), expected_data)
 
 
-REDUCE_OPS = ['sum', 'prod', 'logsumexp', 'all', 'any', 'min', 'max']
+REDUCE_OPS = [ops.add, ops.mul, ops.and_, ops.or_, ops.logaddexp, ops.min, ops.max]
 
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b'), ('b', 'a', 'c')])
-@pytest.mark.parametrize('op_name', REDUCE_OPS)
-def test_reduce_all(dims, op_name):
+@pytest.mark.parametrize('op', REDUCE_OPS, ids=str)
+def test_reduce_all(dims, op):
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
     inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data = torch.rand(shape) + 0.5
-    if op_name in ['all', 'any']:
+    if op in [ops.and_, ops.or_]:
         data = data.byte()
-    if op_name == 'logsumexp':
+    if op is ops.logaddexp:
         # work around missing torch.Tensor.logsumexp()
         expected_data = data.reshape(-1).logsumexp(0)
     else:
-        expected_data = getattr(data, op_name)()
+        expected_data = REDUCE_OP_TO_TORCH[op](data)
 
     x = Tensor(data, inputs)
-    actual = getattr(x, op_name)()
+    actual = x.reduce(op)
     check_funsor(actual, {}, reals(), expected_data)
 
 
@@ -305,19 +307,19 @@ def test_reduce_all(dims, op_name):
     for num_reduced in range(len(dims) + 2)
     for reduced_vars in itertools.combinations(dims, num_reduced)
 ])
-@pytest.mark.parametrize('op_name', REDUCE_OPS)
-def test_reduce_subset(dims, reduced_vars, op_name):
+@pytest.mark.parametrize('op', REDUCE_OPS)
+def test_reduce_subset(dims, reduced_vars, op):
     reduced_vars = frozenset(reduced_vars)
     sizes = {'a': 3, 'b': 4, 'c': 5}
     shape = tuple(sizes[d] for d in dims)
     inputs = OrderedDict((d, bint(sizes[d])) for d in dims)
     data = torch.rand(shape) + 0.5
     dtype = 'real'
-    if op_name in ['all', 'any']:
+    if op in [ops.and_, ops.or_]:
         data = data.byte()
         dtype = 2
     x = Tensor(data, inputs, dtype)
-    actual = getattr(x, op_name)(reduced_vars)
+    actual = x.reduce(op, reduced_vars)
     expected_inputs = OrderedDict(
         (d, bint(sizes[d])) for d in dims if d not in reduced_vars)
 
@@ -326,17 +328,16 @@ def test_reduce_subset(dims, reduced_vars, op_name):
         assert actual is x
     else:
         if reduced_vars == frozenset(dims):
-            if op_name == 'logsumexp':
+            if op is ops.logaddexp:
                 # work around missing torch.Tensor.logsumexp()
                 data = data.reshape(-1).logsumexp(0)
             else:
-                data = getattr(data, op_name)()
+                data = REDUCE_OP_TO_TORCH[op](data)
         else:
             for pos in reversed(sorted(map(dims.index, reduced_vars))):
-                if op_name in ('min', 'max'):
-                    data = getattr(data, op_name)(pos)[0]
-                else:
-                    data = getattr(data, op_name)(pos)
+                data = REDUCE_OP_TO_TORCH[op](data, pos)
+                if op in (ops.min, ops.max):
+                    data = data[0]
         check_funsor(actual, expected_inputs, Domain((), dtype))
         assert_close(actual, Tensor(data, expected_inputs, dtype),
                      atol=1e-5, rtol=1e-5)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -356,11 +356,9 @@ def test_reduce_event(op, event_shape, dims):
     dtype = 'real'
     if op in [ops.and_, ops.or_]:
         data = data.byte()
-    if op is ops.logaddexp:
-        # work around missing torch.Tensor.logsumexp()
-        expected_data = data.reshape(batch_shape + (-1,)).logsumexp(0)
-    else:
-        expected_data = torch_op(data)
+    expected_data = torch_op(data.reshape(batch_shape + (-1,)), -1)
+    if op in [ops.min, ops.max]:
+        expected_data = expected_data[0]
 
     x = Tensor(data, inputs, dtype=dtype)
     actual = getattr(x, torch_op.__name__)()


### PR DESCRIPTION
This repurposes the reduction ops (`.sum()`, `.all()`, etc.) to reduce over output events, rather than reduce over input variables. This is needed e.g. to implement delta via `(x == y).all()`. For example:
```py
x = Tensor(torch.randn(5,3,3), inputs=OrderedDict(i=bint(5)))
x.inputs  # OrderedDict(i=bint(5))
x.output  # reals(3,3)

# OLD behavior: reduce over the free variable i.
x.sum().inputs  # OrderedDict()
x.sum().output  # reals(3, 3)

# NEW behavior: reduce over the event shape.
x.sum().inputs  # OrderedDict(i=bint(5))
x.sum().output  # reals()
```
## Questions
- [x] Is this a good idea? It seems to me that we should fully expose the array interface for ground values, and use `.reduce(...)` for funsor-specific operations.
- [x] Should we add shorthand for the funsor-specific ops, e.g. `x.f.sum()` where `.f` exposes the funsor-specific interface? Or maybe `x.funsor_sum()`?

## Tasks
- [x] change method behavior
- [x] update old tests
- [x] update examples
- [x] update readme
- [x] add new tests
