### PR TITLE
Add lazy option to HMM examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ lint: FORCE
 test: lint FORCE
 	pytest -v test
 	python examples/discrete_hmm.py -n 2
+	python examples/discrete_hmm.py -n 2 -t 50 --lazy
 	python examples/kalman_filter.py --xfail-if-not-implemented
+	python examples/kalman_filter.py -n 2 -t 50 --lazy
 	@#python examples/ss_vae_delayed.py --xfail-if-not-implemented
 	@#python examples/minipyro.py --xfail-if-not-implemented
 	@echo PASS

--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -8,6 +8,10 @@ import torch
 import funsor
 import funsor.distributions as dist
 
+from funsor.interpreter import interpretation, reinterpret
+from funsor.optimizer import apply_optimizer
+from funsor.terms import lazy
+
 
 def main(args):
     # Declare parameters.
@@ -37,7 +41,7 @@ def main(args):
             x_curr = funsor.Variable('x_{}'.format(t), funsor.bint(args.hidden_dim))
             log_prob += trans(prev=x_prev, value=x_curr)
 
-            if isinstance(x_prev, funsor.Variable):
+            if not args.lazy and isinstance(x_prev, funsor.Variable):
                 log_prob = log_prob.logsumexp(x_prev.name)
 
             log_prob += emit(latent=x_curr, value=funsor.Tensor(y, dtype=2))
@@ -51,7 +55,12 @@ def main(args):
     optim = torch.optim.Adam(params, lr=args.learning_rate)
     for step in range(args.train_steps):
         optim.zero_grad()
-        log_prob = model(data)
+        if args.lazy:
+            with interpretation(lazy):
+                log_prob = apply_optimizer(model(data))
+            log_prob = reinterpret(log_prob)
+        else:
+            log_prob = model(data)
         assert not log_prob.inputs, 'free variables remain'
         loss = -log_prob.data
         loss.backward()
@@ -64,7 +73,7 @@ if __name__ == '__main__':
     parser.add_argument("-n", "--train-steps", default=101, type=int)
     parser.add_argument("-lr", "--learning-rate", default=0.05, type=float)
     parser.add_argument("-d", "--hidden-dim", default=2, type=int)
-    parser.add_argument("--eager", action='store_true')
+    parser.add_argument("--lazy", action='store_true')
     parser.add_argument("--filter", action='store_true')
     parser.add_argument("--xfail-if-not-implemented", action='store_true')
     args = parser.parse_args()

--- a/examples/kalman_filter.py
+++ b/examples/kalman_filter.py
@@ -7,6 +7,10 @@ import torch
 import funsor
 import funsor.distributions as dist
 
+from funsor.interpreter import interpretation, reinterpret
+from funsor.optimizer import apply_optimizer
+from funsor.terms import lazy
+
 
 def main(args):
     # Declare parameters.
@@ -26,7 +30,7 @@ def main(args):
             x_curr = funsor.Variable('x_{}'.format(t), funsor.reals())
             log_prob += dist.Normal(x_prev, trans_noise, value=x_curr)
 
-            if isinstance(x_prev, funsor.Variable):
+            if not args.lazy and isinstance(x_prev, funsor.Variable):
                 log_prob = log_prob.logsumexp(x_prev.name)
 
             log_prob += dist.Normal(x_curr, emit_noise, value=y)
@@ -40,7 +44,12 @@ def main(args):
     optim = torch.optim.Adam(params, lr=args.learning_rate)
     for step in range(args.train_steps):
         optim.zero_grad()
-        log_prob = model(data)
+        if args.lazy:
+            with interpretation(lazy):
+                log_prob = apply_optimizer(model(data))
+            log_prob = reinterpret(log_prob)
+        else:
+            log_prob = model(data)
         assert not log_prob.inputs, 'free variables remain'
         loss = -log_prob.data
         loss.backward()
@@ -52,7 +61,7 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--time-steps", default=10, type=int)
     parser.add_argument("-n", "--train-steps", default=101, type=int)
     parser.add_argument("-lr", "--learning-rate", default=0.05, type=float)
-    parser.add_argument("--eager", action='store_true')
+    parser.add_argument("--lazy", action='store_true')
     parser.add_argument("--filter", action='store_true')
     parser.add_argument("--xfail-if-not-implemented", action='store_true')
     args = parser.parse_args()


### PR DESCRIPTION
Addresses #8 

This PR adds the option to use the optimizer for marginal likelihood computation in `discrete_hmm.py` and `kalman_filter.py`.