### PR TITLE
Implement MultivariateNormal distribution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -157,10 +157,13 @@ class Normal(Distribution):
     def _fill_defaults(loc, scale, value=None):
         loc = to_funsor(loc)
         scale = to_funsor(scale)
+        assert loc.output == reals()
+        assert scale.output == reals()
         if value is None:
             value = Variable('value', reals())
         else:
             value = to_funsor(value)
+        assert value.output == loc.output
         return loc, scale, value
 
     def __init__(self, loc, scale, value=None):
@@ -174,21 +177,11 @@ def eager_normal(loc, scale, value):
 
 # Create a Gaussian from a ground observation.
 @eager.register(Normal, Variable, Tensor, Tensor)
-def eager_normal(loc, scale, value):
-    assert loc.output == reals()
-    inputs, (scale, value) = align_tensors(scale, value)
-    inputs.update(loc.inputs)
-
-    log_density = -0.5 * math.log(2 * math.pi) - scale.log()
-    loc = value.unsqueeze(-1)
-    precision = scale.pow(-2).unsqueeze(-1).unsqueeze(-1)
-    return Gaussian(log_density, loc, precision, inputs)
-
-
-# Create a Gaussian from a ground observation.
 @eager.register(Normal, Tensor, Tensor, Variable)
 def eager_normal(loc, scale, value):
-    assert value.output == reals()
+    if isinstance(loc, Variable):
+        loc, value = value, loc
+
     inputs, (loc, scale) = align_tensors(loc, scale)
     inputs.update(value.inputs)
 
@@ -216,9 +209,55 @@ def eager_normal(loc, scale, value):
     return Gaussian(log_density, loc, precision, inputs)
 
 
+class MultivariateNormal(Distribution):
+    dist_class = dist.MultivariateNormal
+
+    @staticmethod
+    def _fill_defaults(loc, scale_tril, value=None):
+        loc = to_funsor(loc)
+        scale_tril = to_funsor(scale_tril)
+        assert loc.dtype == 'real'
+        assert scale_tril.dtype == 'real'
+        assert len(loc.output.shape) == 1
+        dim = loc.output.shape[0]
+        assert scale_tril.output.shape == (dim, dim)
+        if value is None:
+            value = Variable('value', reals(dim))
+        else:
+            value = to_funsor(value)
+        assert value.output == loc.output
+        return loc, scale_tril, value
+
+    def __init__(self, loc, scale_tril, value=None):
+        super(MultivariateNormal, self).__init__(loc, scale_tril, value)
+
+
+@eager.register(MultivariateNormal, Tensor, Tensor, Tensor)
+def eager_mvn(loc, scale_tril, value):
+    return MultivariateNormal.eager_log_prob(loc=loc, scale_tril=scale_tril, value=value)
+
+
+# Create a Gaussian from a ground observation.
+@eager.register(MultivariateNormal, Tensor, Tensor, Variable)
+@eager.register(MultivariateNormal, Variable, Tensor, Tensor)
+def eager_mvn(loc, scale_tril, value):
+    if isinstance(loc, Variable):
+        loc, value = value, loc
+
+    dim, = loc.output.shape
+    inputs, (loc, scale_tril) = align_tensors(loc, scale_tril)
+    inputs.update(value.inputs)
+
+    log_density = -0.5 * dim * math.log(2 * math.pi) - scale_tril.diagonal(dim1=-1, dim2=-2).log().sum(-1)
+    inv_scale_tril = torch.inverse(scale_tril)
+    precision = torch.matmul(inv_scale_tril.transpose(-1, -2), inv_scale_tril)
+    return Gaussian(log_density, loc, precision, inputs)
+
+
 __all__ = [
     'Categorical',
     'Delta',
     'Distribution',
+    'MultivariateNormal',
     'Normal',
 ]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -80,7 +80,7 @@ def test_delta_density(batch_shape, event_shape):
         assert_close(actual, expected)
 
 
-def test_normal_defaults():
+def test_mvn_defaults():
     loc = Variable('loc', reals())
     scale = Variable('scale', reals())
     value = Variable('value', reals())
@@ -88,20 +88,20 @@ def test_normal_defaults():
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_normal_density(batch_shape):
+def test_mvn_density(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
     @funsor.of_shape(reals(), reals(), reals())
-    def normal(loc, scale, value):
+    def mvn(loc, scale, value):
         return -((value - loc) ** 2) / (2 * scale ** 2) - scale.log() - math.log(math.sqrt(2 * math.pi))
 
-    check_funsor(normal, {'loc': reals(), 'scale': reals(), 'value': reals()}, reals())
+    check_funsor(mvn, {'loc': reals(), 'scale': reals(), 'value': reals()}, reals())
 
     loc = Tensor(torch.randn(batch_shape), inputs)
     scale = Tensor(torch.randn(batch_shape).exp(), inputs)
     value = Tensor(torch.randn(batch_shape), inputs)
-    expected = normal(loc, scale, value)
+    expected = mvn(loc, scale, value)
     check_funsor(expected, inputs, reals())
 
     actual = dist.Normal(loc, scale, value)
@@ -110,7 +110,7 @@ def test_normal_density(batch_shape):
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_normal_gaussian_1(batch_shape):
+def test_mvn_gaussian_1(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
@@ -131,7 +131,7 @@ def test_normal_gaussian_1(batch_shape):
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_normal_gaussian_2(batch_shape):
+def test_mvn_gaussian_2(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
@@ -152,7 +152,7 @@ def test_normal_gaussian_2(batch_shape):
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_normal_gaussian_3(batch_shape):
+def test_mvn_gaussian_3(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
@@ -167,6 +167,61 @@ def test_normal_gaussian_3(batch_shape):
     g = dist.Normal(Variable('loc', reals()), scale)
     assert isinstance(g, Gaussian)
     actual = g(loc=loc, value=value)
+    check_funsor(actual, inputs, reals())
+
+    assert_close(actual, expected, atol=1e-4)
+
+
+def test_mvn_defaults():
+    loc = Variable('loc', reals(3))
+    scale_tril = Variable('scale', reals(3, 3))
+    value = Variable('value', reals(3))
+    assert dist.MultivariateNormal(loc, scale_tril) is dist.MultivariateNormal(loc, scale_tril, value)
+
+
+def _random_scale_tril(shape):
+    data = torch.randn(shape)
+    return torch.distributions.transform_to(torch.distributions.constraints.lower_cholesky)(data)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_mvn_density(batch_shape):
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    @funsor.function(reals(3), reals(3, 3), reals(3), reals())
+    def mvn(loc, scale_tril, value):
+        return torch.distributions.MultivariateNormal(loc, scale_tril=scale_tril).log_prob(value)
+
+    check_funsor(mvn, {'loc': reals(3), 'scale_tril': reals(3, 3), 'value': reals(3)}, reals())
+
+    loc = Tensor(torch.randn(batch_shape + (3,)), inputs)
+    scale_tril = Tensor(_random_scale_tril(batch_shape + (3, 3)), inputs)
+    value = Tensor(torch.randn(batch_shape + (3,)), inputs)
+    expected = mvn(loc, scale_tril, value)
+    check_funsor(expected, inputs, reals())
+
+    actual = dist.MultivariateNormal(loc, scale_tril, value)
+    check_funsor(actual, inputs, reals())
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_mvn_gaussian(batch_shape):
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    loc = Tensor(torch.randn(batch_shape + (4,)), inputs)
+    scale_tril = Tensor(_random_scale_tril(batch_shape + (4, 4)), inputs)
+    value = Tensor(torch.randn(batch_shape + (4,)), inputs)
+
+    expected = dist.MultivariateNormal(loc, scale_tril, value)
+    assert isinstance(expected, Tensor)
+    check_funsor(expected, inputs, reals())
+
+    g = dist.MultivariateNormal(loc, scale_tril)
+    assert isinstance(g, Gaussian)
+    actual = g(value=value)
     check_funsor(actual, inputs, reals())
 
     assert_close(actual, expected, atol=1e-4)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -211,9 +211,9 @@ def test_mvn_gaussian(batch_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
-    loc = Tensor(torch.randn(batch_shape + (4,)), inputs)
-    scale_tril = Tensor(_random_scale_tril(batch_shape + (4, 4)), inputs)
-    value = Tensor(torch.randn(batch_shape + (4,)), inputs)
+    loc = Tensor(torch.randn(batch_shape + (3,)), inputs)
+    scale_tril = Tensor(_random_scale_tril(batch_shape + (3, 3)), inputs)
+    value = Tensor(torch.randn(batch_shape + (3,)), inputs)
 
     expected = dist.MultivariateNormal(loc, scale_tril, value)
     assert isinstance(expected, Tensor)
@@ -224,4 +224,4 @@ def test_mvn_gaussian(batch_shape):
     actual = g(value=value)
     check_funsor(actual, inputs, reals())
 
-    assert_close(actual, expected, atol=1e-4)
+    assert_close(actual, expected, atol=1e-3, rtol=1e-4)


### PR DESCRIPTION
This also slightly simplifies `Normal` logic to match `MultivariateNormal` logic.

This eagerly converts to a precision matrix. We'll probably want to refactor this to use GPyTorch's LazyTensor at some point #48 .

This does not implement recognition of affine transforms #72, and has only very simple conversions to `Gaussian`.

## Tested

- added test of density
- added test of conversion to `Gaussian`