### PR TITLE
 Separate out ops implementations based on backend

### DIFF
--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -128,22 +128,12 @@ def logaddexp(x, y):
 def safesub(x, y):
     if isinstance(y, Number):
         return sub(x, y)
-    assert isinstance(y, torch.Tensor)
-    try:
-        return x + -y.clamp(max=torch.finfo(y.dtype).max)
-    except TypeError:
-        return x + -y.clamp(max=torch.iinfo(y.dtype).max)
 
 
 @Op
 def safediv(x, y):
     if isinstance(y, Number):
         return truediv(x, y)
-    assert isinstance(y, torch.Tensor)
-    try:
-        return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
-    except TypeError:
-        return x * y.reciprocal().clamp(max=torch.iinfo(y.dtype).max)
 
 
 # just a placeholder

--- a/funsor/registry.py
+++ b/funsor/registry.py
@@ -1,3 +1,4 @@
+
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
@@ -12,22 +13,20 @@ class KeyedRegistry(object):
         self.registry = defaultdict(lambda: Dispatcher('f'))
 
     def register(self, key, *types):
+        register = self.registry[key].register
         if self.default:
             objects = (object,) * len(types)
             if objects != types:
-                self.register_impl(key, self.default, *objects)
+                register(*objects)(self.default)
 
         # This decorator supports stacking multiple decorators, which is not
         # supported by multipledipatch (which returns a Dispatch object rather
         # than the original function).
         def decorator(fn):
-            self.register_impl(key, fn, *types)
+            register(*types)(fn)
             return fn
 
         return decorator
-
-    def register_impl(self, key, impl, *types):
-        self.registry[key].register(*types)(impl)
 
     def __call__(self, key, *args, **kwargs):
         if self.default is None or key in self.registry:

--- a/funsor/registry.py
+++ b/funsor/registry.py
@@ -12,20 +12,22 @@ class KeyedRegistry(object):
         self.registry = defaultdict(lambda: Dispatcher('f'))
 
     def register(self, key, *types):
-        register = self.registry[key].register
         if self.default:
             objects = (object,) * len(types)
             if objects != types:
-                register(*objects)(self.default)
+                self.register_impl(key, self.default, *objects)
 
         # This decorator supports stacking multiple decorators, which is not
         # supported by multipledipatch (which returns a Dispatch object rather
         # than the original function).
         def decorator(fn):
-            register(*types)(fn)
+            self.register_impl(key, fn, *types)
             return fn
 
         return decorator
+
+    def register_impl(self, key, impl, *types):
+        self.registry[key].register(*types)(impl)
 
     def __call__(self, key, *args, **kwargs):
         if self.default is None or key in self.registry:

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -491,6 +491,22 @@ def _reciprocal(x):
     return result
 
 
+@Op.register(ops.safesub, object, torch.Tensor)
+def safesub(x, y):
+    try:
+        return x + -y.clamp(max=torch.finfo(y.dtype).max)
+    except TypeError:
+        return x + -y.clamp(max=torch.iinfo(y.dtype).max)
+
+
+@Op.register(ops.safesub, object, torch.Tensor)
+def safediv(x, y):
+    try:
+        return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
+    except TypeError:
+        return x * y.reciprocal().clamp(max=torch.iinfo(y.dtype).max)
+
+
 REDUCE_OP_TO_TORCH = {
     ops.add: torch.sum,
     ops.mul: torch.prod,

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -433,6 +433,8 @@ def _exp(x):
 
 @Op.register(ops.log, torch.Tensor)
 def _log(x):
+    if x.dtype in (torch.uint8, torch.long):
+        x = x.float()
     return x.log()
 
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -494,15 +494,15 @@ def _reciprocal(x):
 
 
 @Op.register(ops.safesub, object, torch.Tensor)
-def safesub(x, y):
+def _safesub(x, y):
     try:
         return x + -y.clamp(max=torch.finfo(y.dtype).max)
     except TypeError:
         return x + -y.clamp(max=torch.iinfo(y.dtype).max)
 
 
-@Op.register(ops.safesub, object, torch.Tensor)
-def safediv(x, y):
+@Op.register(ops.safediv, object, torch.Tensor)
+def _safediv(x, y):
     try:
         return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)
     except TypeError:

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -8,7 +8,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.ops import Op, AssociativeOp
+from funsor.ops import Op
 from funsor.six import getargspec
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor
 
@@ -416,84 +416,84 @@ def torch_einsum(equation, *operands):
 
 # Register Ops
 
-@Op.register(ops.abs, torch.Tensor)
+@ops.abs.register(torch.Tensor)
 def _abs(x):
     return x.abs()
 
 
-@Op.register(ops.sqrt, torch.Tensor)
+@ops.sqrt.register(torch.Tensor)
 def _sqrt(x):
     return x.sqrt()
 
 
-@Op.register(ops.exp, torch.Tensor)
+@ops.exp.register(torch.Tensor)
 def _exp(x):
     return x.exp()
 
 
-@Op.register(ops.log, torch.Tensor)
+@ops.log.register(torch.Tensor)
 def _log(x):
     if x.dtype in (torch.uint8, torch.long):
         x = x.float()
     return x.log()
 
 
-@Op.register(ops.log1p, torch.Tensor)
+@ops.log1p.register(torch.Tensor)
 def _log1p(x):
     return x.log1p()
 
 
-@Op.register(ops.pow, object, torch.Tensor)
+@ops.pow.register(object, torch.Tensor)
 def _pow(x, y):
     result = x ** y
     # work around shape bug https://github.com/pytorch/pytorch/issues/16685
     return result.reshape(y.shape)
 
 
-@Op.register(ops.pow, torch.Tensor, torch.Tensor)
-@Op.register(ops.pow, torch.Tensor, object)
+@ops.pow.register(torch.Tensor, torch.Tensor)
+@ops.pow.register(torch.Tensor, object)
 def _pow(x, y):
     return x ** y
 
 
-@AssociativeOp.register(ops.min, torch.Tensor, torch.Tensor)
+@ops.min.register(torch.Tensor, torch.Tensor)
 def _min(x, y):
     return torch.min(x, y)
 
 
-@AssociativeOp.register(ops.min, object, torch.Tensor)
+@ops.min.register(object, torch.Tensor)
 def _min(x, y):
     return y.clamp(max=x)
 
 
-@AssociativeOp.register(ops.min, torch.Tensor, object)
+@ops.min.register(torch.Tensor, object)
 def _min(x, y):
     return x.clamp(max=y)
 
 
-@AssociativeOp.register(ops.max, torch.Tensor, torch.Tensor)
+@ops.max.register(torch.Tensor, torch.Tensor)
 def _max(x, y):
     return torch.max(x, y)
 
 
-@AssociativeOp.register(ops.max, object, torch.Tensor)
+@ops.max.register(object, torch.Tensor)
 def _max(x, y):
     return y.clamp(min=x)
 
 
-@AssociativeOp.register(ops.max, torch.Tensor, object)
+@ops.max.register(torch.Tensor, object)
 def _max(x, y):
     return x.clamp(min=y)
 
 
-@Op.register(ops.reciprocal, torch.Tensor)
+@ops.reciprocal.register(torch.Tensor)
 def _reciprocal(x):
     result = x.reciprocal()
     result.clamp_(max=torch.finfo(result.dtype).max)
     return result
 
 
-@Op.register(ops.safesub, object, torch.Tensor)
+@ops.safesub.register(object, torch.Tensor)
 def _safesub(x, y):
     try:
         return x + -y.clamp(max=torch.finfo(y.dtype).max)
@@ -501,7 +501,7 @@ def _safesub(x, y):
         return x + -y.clamp(max=torch.iinfo(y.dtype).max)
 
 
-@Op.register(ops.safediv, object, torch.Tensor)
+@ops.safediv.register(object, torch.Tensor)
 def _safediv(x, y):
     try:
         return x * y.reciprocal().clamp(max=torch.finfo(y.dtype).max)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -450,8 +450,7 @@ def _pow(x, y):
     return result.reshape(y.shape)
 
 
-@ops.pow.register(torch.Tensor, torch.Tensor)
-@ops.pow.register(torch.Tensor, object)
+@ops.pow.register(torch.Tensor, (object, torch.Tensor))
 def _pow(x, y):
     return x ** y
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -443,7 +443,7 @@ def _log1p(x):
     return x.log1p()
 
 
-@Op.register(ops.pow, Number, torch.Tensor)
+@Op.register(ops.pow, object, torch.Tensor)
 def _pow(x, y):
     result = x ** y
     # work around shape bug https://github.com/pytorch/pytorch/issues/16685
@@ -451,7 +451,7 @@ def _pow(x, y):
 
 
 @Op.register(ops.pow, torch.Tensor, torch.Tensor)
-@Op.register(ops.pow, torch.Tensor, Number)
+@Op.register(ops.pow, torch.Tensor, object)
 def _pow(x, y):
     return x ** y
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -11,6 +11,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.terms import Binary, Number, Stack, Variable, to_funsor
 from funsor.testing import check_funsor
+from funsor.torch import REDUCE_OP_TO_TORCH
 
 np.seterr(all='ignore')
 
@@ -141,8 +142,8 @@ def test_binary(symbol, data1, data2):
     check_funsor(actual, {}, Domain((), dtype), expected_data)
 
 
-@pytest.mark.parametrize('op', ops.REDUCE_OP_TO_TORCH,
-                         ids=[op.__name__ for op in ops.REDUCE_OP_TO_TORCH])
+@pytest.mark.parametrize('op', REDUCE_OP_TO_TORCH,
+                         ids=[op.__name__ for op in REDUCE_OP_TO_TORCH])
 def test_reduce_all(op):
     x = Variable('x', bint(2))
     y = Variable('y', bint(3))
@@ -168,8 +169,8 @@ def test_reduce_all(op):
     for num_reduced in range(3 + 1)
     for reduced_vars in itertools.combinations('xyz', num_reduced)
 ])
-@pytest.mark.parametrize('op', ops.REDUCE_OP_TO_TORCH,
-                         ids=[op.__name__ for op in ops.REDUCE_OP_TO_TORCH])
+@pytest.mark.parametrize('op', REDUCE_OP_TO_TORCH,
+                         ids=[op.__name__ for op in REDUCE_OP_TO_TORCH])
 def test_reduce_subset(op, reduced_vars):
     reduced_vars = frozenset(reduced_vars)
     x = Variable('x', bint(2))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,7 +9,7 @@ import torch
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
-from funsor.ops import REDUCE_OP_TO_TORCH
+from funsor.torch import REDUCE_OP_TO_TORCH
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import Tensor, align_tensors, torch_einsum
@@ -190,7 +190,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
+    'abs', 'sqrt', 'exp', 'log', 'log1p',
 ])
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -190,7 +190,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
-    'abs', 'sqrt', 'exp', 'log', 'log1p',
+    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
 ])
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}


### PR DESCRIPTION
As discussed in #61, this refactors `funsor.ops` to move any torch specific ops to the `torch` module. Once this is merged, we can implement the corresponding operations for the `numpy` backend. The Op class now inherits from `Dispatcher`.

Some questions:
 - The default dispatcher for object types currently defaults to numpy for dispatching. I believe that we can save a small amount of time if we were to dispatch directly via `obj.sqrt()` instead of `np.sqrt(obj)`. Is this worth doing, i.e. separating out the dispatchers for Number and object type?
 - In `torch.py` file, for binary operators with distinct types, I had to keep the other type as `object` (consistent with our earlier implementation). Am I correct in understanding that for all operations - we expect raw (i.e. non Funsor wrapped) types except for `funsor.Number` where we can either get a wrapper `Number` or a python numeric type? My guess is yes based on the tests, but just wondering if this is a conscious decision.