### PR TITLE
Implement monte carlo .sample() methods

### DIFF
--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -8,7 +8,6 @@ import funsor.ops as ops
 from funsor.domains import reals
 from funsor.ops import Op
 from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor
-from funsor.torch import Tensor
 
 
 class DeltaMeta(FunsorMeta):
@@ -66,7 +65,7 @@ class Delta(Funsor):
         if value is not None:
             if isinstance(value, Variable):
                 name = value.name
-            elif isinstance(value, (Number, Tensor)) and isinstance(point, (Number, Tensor)):
+            elif not any(d.dtype == 'real' for side in (value, point) for d in side.inputs.values()):
                 return (value == point).all().log() + log_density
             else:
                 # TODO Compute a jacobian, update log_prob, and emit another Delta.
@@ -82,6 +81,10 @@ class Delta(Funsor):
         # TODO Implement ops.add to simulate .to_event().
 
         return None  # defer to default implementation
+
+    def sample(self, sampled_vars):
+        assert all(k == self.name for k in sampled_vars if k in self.inputs)
+        return self
 
 
 @eager.register(Binary, Op, Delta, (Funsor, Delta, Align))

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -72,7 +72,11 @@ def find_domain(op, *domains):
     assert callable(op), op
     assert all(isinstance(arg, Domain) for arg in domains)
     if len(domains) == 1:
-        return domains[0]
+        dtype = domains[0].dtype
+        shape = domains[0].shape
+        if op is ops.log or op is ops.exp:
+            dtype = 'real'
+        return Domain(shape, dtype)
 
     lhs, rhs = domains
     if op is ops.getitem:

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -6,8 +6,10 @@ from collections import OrderedDict
 import torch
 from pyro.distributions.util import broadcast_shape
 from six import add_metaclass, integer_types
+from six.moves import reduce
 
 import funsor.ops as ops
+from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.ops import AddOp
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager
@@ -249,6 +251,29 @@ class Gaussian(Funsor):
             raise NotImplementedError('TODO product-reduce along a plate dimension')
 
         return None  # defer to default implementation
+
+    def sample(self, sampled_vars, sample_inputs=None):
+        sampled_vars = sampled_vars.intersection(self.inputs)
+        if not sampled_vars:
+            return self
+        assert all(self.inputs[k].dtype == 'real' for k in sampled_vars)
+
+        int_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype != 'real')
+        real_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype == 'real')
+        if sampled_vars == frozenset(real_inputs):
+            scale_tril = torch.inverse(torch.cholesky(self.precision))
+            assert self.loc.shape == scale_tril.shape[:-1]
+            white_noise = torch.randn(self.loc.shape)
+            sample = self.loc + _mv(scale_tril, white_noise)
+            offsets, _ = _compute_offsets(real_inputs)
+            results = []
+            for key, domain in real_inputs.items():
+                data = sample[..., offsets[key]: offsets[key] + domain.num_elements]
+                point = Tensor(data, int_inputs, domain)
+                results.append(Delta(key, point))
+            return reduce(ops.add, results)
+
+        raise NotImplementedError('TODO implement partial sampling of real variables')
 
 
 @eager.register(Binary, AddOp, Gaussian, Gaussian)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -269,7 +269,9 @@ class Gaussian(Funsor):
             results = []
             for key, domain in real_inputs.items():
                 data = sample[..., offsets[key]: offsets[key] + domain.num_elements]
-                point = Tensor(data, int_inputs, domain)
+                data = data.reshape(self.loc.shape[:-1] + domain.shape)
+                point = Tensor(data, int_inputs)
+                assert point.output == domain
                 results.append(Delta(key, point))
             return reduce(ops.add, results)
 

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from collections import OrderedDict
 
 from six import add_metaclass
+from six.moves import reduce
 
 import funsor.ops as ops
 from funsor.delta import Delta
@@ -185,6 +186,14 @@ def eager_add(op, joint, other):
     if subs:
         return joint + other.eager_subs(subs)
     return Joint(joint.deltas, joint.discrete + other, joint.gaussian)
+
+
+@eager.register(Binary, Op, Joint, (Number, Tensor))
+def eager_add(op, joint, other):
+    if op is ops.sub:
+        return joint + -other
+
+    return None  # defer to default implementation
 
 
 @eager.register(Binary, AddOp, Joint, Gaussian)

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -389,7 +389,6 @@ def elbo(model, guide, *args, **kwargs):
         # FIXME do not marginalize; instead sample.
         q = guide_joint.log_prob.reduce(ops.logaddexp)
     tr = guide_joint.samples
-    tr.update(funsor.backward(ops.sample, q))  # force deferred samples?
 
     # replay model against guide
     with log_joint() as model_joint, replay(guide_trace=tr):

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -123,18 +123,6 @@ def safediv(x, y):
         return truediv(x, y)
 
 
-# just a placeholder
-@Op
-def marginal(x, y):
-    raise ValueError
-
-
-# just a placeholder
-@Op
-def sample(x, y):
-    raise ValueError
-
-
 @Op
 def reciprocal(x):
     if isinstance(x, Number):
@@ -176,7 +164,6 @@ __all__ = [
     'log',
     'log1p',
     'lt',
-    'marginal',
     'max',
     'min',
     'mul',
@@ -186,7 +173,6 @@ __all__ = [
     'pow',
     'safediv',
     'safesub',
-    'sample',
     'sqrt',
     'sub',
     'truediv',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -16,7 +16,7 @@ import functools
 import itertools
 import numbers
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict, Hashable
+from collections import Hashable, OrderedDict
 from weakref import WeakValueDictionary
 
 from six import add_metaclass, integer_types
@@ -24,7 +24,7 @@ from six.moves import reduce
 
 import funsor.interpreter as interpreter
 import funsor.ops as ops
-from funsor.domains import Domain, bint, find_domain
+from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import interpret
 from funsor.ops import AssociativeOp, Op
 from funsor.registry import KeyedRegistry
@@ -214,6 +214,35 @@ class Funsor(object):
         return Reduce(op, self, reduced_vars)
 
     def sample(self, sampled_vars, sample_inputs=None):
+        """
+        Create a Monte Carlo approximation to this funsor by replacing
+        functions of ``sampled_vars`` with :class:`~funsor.delta.Delta`s.
+
+        If ``sample_inputs`` is not provided, the result is a :class:`Funsor`
+        with the same ``.inputs`` and ``.output`` as the original funsor, so
+        that self can be replaced by the sample in expectation computations::
+
+            y = x.sample(sampled_vars)
+            assert y.inputs == x.inputs
+            assert y.output == x.output
+            exact = (x.exp() * integrand).reduce(ops.add)
+            approx = (y.exp() * integrand).reduce(ops.add)
+
+        If ``sample_inputs`` is provided, this creates a batch of samples
+        that are intended to be averaged, however this reduction is not
+        performed by the :meth:`sample` method::
+
+            y = x.sample(sampled_vars, sample_inputs)
+            total = reduce(ops.mul, d.num_elements) for d in sample_inputs.values())
+            exact = (x.exp() * integrand).reduce(ops.add)
+            approx = (y.exp() * integrand).reduce(ops.add) / total
+
+        :param frozenset sampled_vars: A set of input variables to sample.
+        :param OrderedDict sample_inputs: An optional mapping from variable
+            name to :class:`~funsor.domains.Domain` over which samples will
+            be batched.
+        """
+        assert self.output == reals()
         assert isinstance(sampled_vars, frozenset)
         if sampled_vars.isdisjoint(self.inputs):
             return self

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -213,6 +213,12 @@ class Funsor(object):
         assert reduced_vars.issubset(self.inputs)
         return Reduce(op, self, reduced_vars)
 
+    def sample(self, sampled_vars, sample_inputs=None):
+        assert isinstance(sampled_vars, frozenset)
+        if sampled_vars.isdisjoint(self.inputs):
+            return self
+        raise NotImplementedError
+
     def align(self, names):
         """
         Align this funsor to match given ``names``.

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import itertools
+import numbers
 import operator
 from collections import OrderedDict, namedtuple
 
@@ -15,7 +16,7 @@ from funsor.domains import Domain, bint, reals
 from funsor.gaussian import Gaussian
 from funsor.joint import Joint
 from funsor.numpy import Array
-from funsor.terms import Funsor
+from funsor.terms import Funsor, Number
 from funsor.torch import Tensor
 
 
@@ -52,7 +53,7 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
         assert actual.inputs == expected.inputs, (actual.inputs, expected.inputs)
         assert actual.output == expected.output, (actual.output, expected.output)
 
-    if isinstance(actual, Tensor):
+    if isinstance(actual, (Number, Tensor)):
         assert_close(actual.data, expected.data, atol=atol, rtol=rtol)
     elif isinstance(actual, Gaussian):
         assert_close(actual.loc, expected.loc, atol=atol, rtol=rtol)
@@ -81,6 +82,12 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
                 assert diff.max() < atol, msg
             if rtol is not None:
                 assert (diff / (atol + expected.detach().abs())).max() < rtol, msg
+    elif isinstance(actual, numbers.Number):
+        diff = abs(actual - expected)
+        if atol is not None:
+            assert diff < atol, msg
+        if rtol is not None:
+            assert diff < (atol + expected) * rtol, msg
     else:
         raise ValueError('cannot compare objects of type {}'.format(type(actual)))
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import contextlib
 import itertools
 import operator
 from collections import OrderedDict, namedtuple
 
+import contextlib2
 import numpy as np
 import opt_einsum
 import pytest
@@ -19,7 +19,7 @@ from funsor.terms import Funsor
 from funsor.torch import Tensor
 
 
-@contextlib.contextmanager
+@contextlib2.contextmanager
 def xfail_if_not_implemented(msg="Not implemented"):
     try:
         yield
@@ -33,6 +33,14 @@ class ActualExpected(namedtuple('LazyComparison', ['actual', 'expected'])):
     """
     def __repr__(self):
         return '\n'.join(['Expected:', str(self.expected), 'Actual:', str(self.actual)])
+
+
+def id_from_inputs(inputs):
+    if isinstance(inputs, (dict, OrderedDict)):
+        inputs = inputs.items()
+    if not inputs:
+        return '()'
+    return ','.join(k + ''.join(map(str, d.shape)) for k, d in inputs)
 
 
 def assert_close(actual, expected, atol=1e-6, rtol=1e-6):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
+import contextlib
 import itertools
 import operator
 from collections import OrderedDict, namedtuple
 
-import contextlib2
 import numpy as np
 import opt_einsum
 import pytest
@@ -19,7 +19,7 @@ from funsor.terms import Funsor
 from funsor.torch import Tensor
 
 
-@contextlib2.contextmanager
+@contextlib.contextmanager
 def xfail_if_not_implemented(msg="Not implemented"):
     try:
         yield

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -255,14 +255,14 @@ class Tensor(Funsor):
         sb_inputs.update(batch_inputs)
 
         # Sample all variables in a single Categorical call.
-        logits = align_tensor(be_inputs, self.data)
+        logits = align_tensor(be_inputs, self)
         flat_logits = logits.reshape(logits.shape[:len(batch_inputs)] + (-1,))
         sample_shape = tuple(d.dtype for d in sample_inputs.values())
         flat_sample = torch.distributions.Categorical(logits=flat_logits).sample(sample_shape)
         results = []
         for name, domain in reversed(list(event_inputs.items())):
             size = domain.dtype
-            point = Tensor(flat_sample % size, sb_inputs, bint(size))
+            point = Tensor(flat_sample % size, sb_inputs, size)
             flat_sample = flat_sample / size
             results.append(Delta(name, point))
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -11,14 +11,8 @@ from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.joint import Joint
 from funsor.terms import Number
-from funsor.testing import assert_close, random_gaussian, random_tensor, xfail_if_not_implemented
+from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor, xfail_if_not_implemented
 from funsor.torch import Tensor
-
-
-def id_from_inputs(inputs):
-    if not inputs:
-        return '()'
-    return ','.join(k + ''.join(map(str, d.shape)) for k, d in inputs.items())
 
 
 @pytest.mark.parametrize('expr,expected_type', [

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import pytest
 
 from funsor.domains import bint, reals
+from funsor.joint import Joint
 from funsor.testing import id_from_inputs, random_gaussian, random_tensor
 
 
@@ -31,9 +32,10 @@ def test_tensor_smoke(sample_inputs, batch_inputs, event_inputs):
     event_inputs = OrderedDict(event_inputs)
     x = random_tensor(be_inputs)
 
-    for num_sampled in range(len(event_inputs)):
+    for num_sampled in range(len(event_inputs) + 1):
         for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
             sampled_vars = frozenset(sampled_vars)
+            print('sampled_vars: {}'.format(', '.join(sampled_vars)))
             y = x.sample(sampled_vars, sample_inputs)
             if sampled_vars:
                 assert dict(y.inputs) == dict(expected_inputs), sampled_vars
@@ -65,9 +67,53 @@ def test_gaussian_smoke(sample_inputs, batch_inputs, event_inputs):
     x = random_gaussian(be_inputs)
 
     xfail = False
+    for num_sampled in range(len(event_inputs) + 1):
+        for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
+            sampled_vars = frozenset(sampled_vars)
+            print('sampled_vars: {}'.format(', '.join(sampled_vars)))
+            try:
+                y = x.sample(sampled_vars, sample_inputs)
+            except NotImplementedError:
+                xfail = True
+                continue
+            if sampled_vars:
+                assert dict(y.inputs) == dict(expected_inputs), sampled_vars
+            else:
+                assert y is x
+    if xfail:
+        pytest.xfail(reason='Not implemented')
+
+
+@pytest.mark.parametrize('sample_inputs', [
+    (),
+    (('s', bint(6)),),
+    (('s', bint(6)), ('t', bint(7))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('int_event_inputs', [
+    (),
+    (('d', bint(2)),),
+    (('d', bint(2)), ('e', bint(3))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('real_event_inputs', [
+    (('g', reals()),),
+    (('g', reals()), ('h', reals(4))),
+], ids=id_from_inputs)
+def test_joint_smoke(sample_inputs, int_event_inputs, real_event_inputs):
+    event_inputs = int_event_inputs + real_event_inputs
+    discrete_inputs = OrderedDict(int_event_inputs)
+    gaussian_inputs = OrderedDict(event_inputs)
+    expected_inputs = OrderedDict(sample_inputs + event_inputs)
+    sample_inputs = OrderedDict(sample_inputs)
+    event_inputs = OrderedDict(event_inputs)
+    t = random_tensor(discrete_inputs)
+    g = random_gaussian(gaussian_inputs)
+    x = Joint(discrete=t, gaussian=g)
+
+    xfail = False
     for num_sampled in range(len(event_inputs)):
         for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
             sampled_vars = frozenset(sampled_vars)
+            print('sampled_vars: {}'.format(', '.join(sampled_vars)))
             try:
                 y = x.sample(sampled_vars, sample_inputs)
             except NotImplementedError:

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -5,22 +5,21 @@ from collections import OrderedDict
 
 import pytest
 
-from funsor.domains import bint
-from funsor.testing import id_from_inputs, random_tensor
+from funsor.domains import bint, reals
+from funsor.testing import id_from_inputs, random_gaussian, random_tensor
 
 
 @pytest.mark.parametrize('sample_inputs', [
     (),
-    (('s', bint(2)),),
-    (('s', bint(2)), ('t', bint(3))),
+    (('s', bint(6)),),
+    (('s', bint(6)), ('t', bint(7))),
 ], ids=id_from_inputs)
 @pytest.mark.parametrize('batch_inputs', [
     (),
-    (('b', bint(2)),),
-    (('b', bint(2)), ('c', bint(3))),
+    (('b', bint(4)),),
+    (('b', bint(4)), ('c', bint(5))),
 ], ids=id_from_inputs)
 @pytest.mark.parametrize('event_inputs', [
-    (),
     (('e', bint(2)),),
     (('e', bint(2)), ('f', bint(3))),
 ], ids=id_from_inputs)
@@ -30,8 +29,8 @@ def test_tensor_smoke(sample_inputs, batch_inputs, event_inputs):
     sample_inputs = OrderedDict(sample_inputs)
     batch_inputs = OrderedDict(batch_inputs)
     event_inputs = OrderedDict(event_inputs)
-
     x = random_tensor(be_inputs)
+
     for num_sampled in range(len(event_inputs)):
         for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
             sampled_vars = frozenset(sampled_vars)
@@ -40,3 +39,43 @@ def test_tensor_smoke(sample_inputs, batch_inputs, event_inputs):
                 assert dict(y.inputs) == dict(expected_inputs), sampled_vars
             else:
                 assert y is x
+
+
+@pytest.mark.parametrize('sample_inputs', [
+    (),
+    (('s', bint(3)),),
+    (('s', bint(3)), ('t', bint(4))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('batch_inputs', [
+    (),
+    (('b', bint(2)),),
+    (('c', reals()),),
+    (('b', bint(2)), ('c', reals())),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('event_inputs', [
+    (('e', reals()),),
+    (('e', reals()), ('f', reals(2))),
+], ids=id_from_inputs)
+def test_gaussian_smoke(sample_inputs, batch_inputs, event_inputs):
+    be_inputs = OrderedDict(batch_inputs + event_inputs)
+    expected_inputs = OrderedDict(sample_inputs + batch_inputs + event_inputs)
+    sample_inputs = OrderedDict(sample_inputs)
+    batch_inputs = OrderedDict(batch_inputs)
+    event_inputs = OrderedDict(event_inputs)
+    x = random_gaussian(be_inputs)
+
+    xfail = False
+    for num_sampled in range(len(event_inputs)):
+        for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
+            sampled_vars = frozenset(sampled_vars)
+            try:
+                y = x.sample(sampled_vars, sample_inputs)
+            except NotImplementedError:
+                xfail = True
+                continue
+            if sampled_vars:
+                assert dict(y.inputs) == dict(expected_inputs), sampled_vars
+            else:
+                assert y is x
+    if xfail:
+        pytest.xfail(reason='Not implemented')

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -166,7 +166,6 @@ def test_tensor_distribution(event_inputs, batch_inputs, test_grad):
         assert_close(actual, expected, atol=0.1, rtol=None)
 
 
-@pytest.mark.skip(reason='infinite loop')
 @pytest.mark.parametrize('batch_inputs', [
     (),
     (('b', bint(4)),),
@@ -191,7 +190,9 @@ def test_gaussian_distribution(event_inputs, batch_inputs):
     # Check zeroth moment.
     assert_close(q.reduce(ops.logaddexp, q_vars),
                  p.reduce(ops.logaddexp, p_vars), atol=1e-6, rtol=None)
-    for k1, d1 in event_inputs.item():
+
+    pytest.xfail(reason='infinite loop')
+    for k1, d1 in event_inputs.items():
         x = Variable(k1, d1)
         # Check first moments.
         assert_close((q.exp() * x).reduce(ops.add, q_vars),

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function
+
+import itertools
+from collections import OrderedDict
+
+import pytest
+
+from funsor.domains import bint
+from funsor.testing import id_from_inputs, random_tensor
+
+
+@pytest.mark.parametrize('sample_inputs', [
+    (),
+    (('s', bint(2)),),
+    (('s', bint(2)), ('t', bint(3))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('batch_inputs', [
+    (),
+    (('b', bint(2)),),
+    (('b', bint(2)), ('c', bint(3))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('event_inputs', [
+    (),
+    (('e', bint(2)),),
+    (('e', bint(2)), ('f', bint(3))),
+], ids=id_from_inputs)
+def test_tensor_smoke(sample_inputs, batch_inputs, event_inputs):
+    be_inputs = OrderedDict(batch_inputs + event_inputs)
+    expected_inputs = OrderedDict(sample_inputs + batch_inputs + event_inputs)
+    sample_inputs = OrderedDict(sample_inputs)
+    batch_inputs = OrderedDict(batch_inputs)
+    event_inputs = OrderedDict(event_inputs)
+
+    x = random_tensor(be_inputs)
+    for num_sampled in range(len(event_inputs)):
+        for sampled_vars in itertools.combinations(list(event_inputs), num_sampled):
+            sampled_vars = frozenset(sampled_vars)
+            y = x.sample(sampled_vars, sample_inputs)
+            if sampled_vars:
+                assert dict(y.inputs) == dict(expected_inputs), sampled_vars
+            else:
+                assert y is x


### PR DESCRIPTION
Addresses #52 

This implements a low-level `Funsor.sample()` method that will be used in Monte Carlo approximation. This method returns a funsor of the same shape as the original funsor, indeed an unbiased estimator of the original funsor, in value and all derivatives. Samples are encoded as `Delta` distributions, and differentiability is achieved by either reparametrization (for `Gaussian`) or multiplying by Dice factors (for discrete samples of `Tensor`). Sampling from a `Delta` is a no-op. Multiple samples can be drawn by passing in a `sample_inputs`, analogous to the `sample_shape` of torch.distributions.

Note that `Distribution` objects do not implement `.sample()` because the only way we could draw samples would be with materialized tensors, and all current `Distribution` objects eagerly convert to other funsors (`Categorical` -> `Tensor`, `Normal` -> `Gaussian`, ...), and it is those other funsors that implement `.sample()` methods.

This PR also deletes the unused `ops.sample` and `ops.marginal` because we seem to be implementing that functionality elsewhere.

## Questions

- [x] I would have preferred the multiple sample result to be wrapped in a lazy `Reduce()` so as to maintain the property of unbiased estimation, however our current eager `Reduce()` semantics would unbind the resulting funsor and convert to a deeply nested `Binary()`. Suggestions welcome.

## Tasks
- [x] Implement `Tensor.sample()`
- [x] Implement `Gaussian.sample()`
- [x] Implement `Delta.sample()`
- [x] Implement `Joint.sample()`
- [x] test `Tensor.sample()` shapes
- [x] test `Gaussian.sample()` shapes
- [x] test `Joint.sample()` shapes
- [x] test `Tensor.sample()` distribution
- [x] test `Tensor.sample()` gradients
- ~~test `Gaussian.sample()` distribution~~ blocked by `Integrate`
- ~~test `Gaussian.sample()` gradient~~ blocked by `Integrate`