### PR TITLE
Implement sequential interpretation

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -8,6 +8,7 @@ from contextlib2 import contextmanager
 
 from funsor.domains import Domain
 from funsor.ops import Op
+from funsor.registry import KeyedRegistry
 from funsor.six import singledispatch
 
 _INTERPRETATION = None  # To be set later in funsor.terms
@@ -91,7 +92,18 @@ def _reinterpret_ordereddict(x):
     return OrderedDict((key, reinterpret(value)) for key, value in x.items())
 
 
+def dispatched_interpretation(fn):
+    """
+    Decorator to create a dispatched interpretation function.
+    """
+    registry = KeyedRegistry(default=lambda *args: None)
+    fn.register = registry.register
+    fn.dispatch = registry.__call__
+    return fn
+
+
 __all__ = [
+    'dispatched_interpretation',
     'interpret',
     'interpretation',
     'reinterpret',

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -6,9 +6,8 @@ from opt_einsum.paths import greedy
 from six.moves import reduce
 
 from funsor.domains import find_domain
-from funsor.interpreter import interpretation, reinterpret
+from funsor.interpreter import dispatched_interpretation, interpretation, reinterpret
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp
-from funsor.registry import KeyedRegistry
 from funsor.terms import Binary, Funsor, Reduce, eager, reflect
 
 
@@ -47,15 +46,12 @@ def eager_finitary(op, operands):
     return reduce(op, operands)
 
 
+@dispatched_interpretation
 def associate(cls, *args):
-    result = _associate(cls, *args)
+    result = associate.dispatch(cls, *args)
     if result is None:
         result = reflect(cls, *args)
     return result
-
-
-_associate = KeyedRegistry(default=lambda *args: None)
-associate.register = _associate.register
 
 
 @associate.register(Binary, AssociativeOp, Funsor, Funsor)
@@ -91,15 +87,12 @@ def associate_reduce(op, arg, reduced_vars):
     return None
 
 
+@dispatched_interpretation
 def distribute(cls, *args):
-    result = _distribute(cls, *args)
+    result = distribute.dispatch(cls, *args)
     if result is None:
         result = reflect(cls, *args)
     return result
-
-
-_distribute = KeyedRegistry(default=lambda *args: None)
-distribute.register = _distribute.register
 
 
 @distribute.register(Finitary, AssociativeOp, tuple)
@@ -133,15 +126,12 @@ def distribute_finitary(op, operands):
     return None
 
 
+@dispatched_interpretation
 def optimize(cls, *args):
-    result = _optimize(cls, *args)
+    result = optimize.dispatch(cls, *args)
     if result is None:
         result = reflect(cls, *args)
     return result
-
-
-_optimize = KeyedRegistry(default=lambda *args: None)
-optimize.register = _optimize.register
 
 
 # TODO set a better value for this
@@ -211,15 +201,12 @@ def optimize_reduction(op, arg, reduced_vars):
     return path_end
 
 
+@dispatched_interpretation
 def desugar(cls, *args):
-    result = _desugar(cls, *args)
+    result = desugar.dispatch(cls, *args)
     if result is None:
         result = reflect(cls, *args)
     return result
-
-
-_desugar = KeyedRegistry(default=lambda *args: None)
-desugar.register = _desugar.register
 
 
 @desugar.register(Finitary, AssociativeOp, tuple)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -9,7 +9,8 @@ from six.moves import reduce
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
-from funsor.terms import Binary, Number, Stack, Variable, to_funsor
+from funsor.interpreter import interpretation
+from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor
 from funsor.testing import check_funsor
 from funsor.torch import REDUCE_OP_TO_TORCH
 
@@ -154,7 +155,8 @@ def test_reduce_all(op):
     if op is ops.logaddexp:
         pytest.skip()
 
-    actual = f.reduce(op)
+    with interpretation(sequential):
+        actual = f.reduce(op)
 
     values = [f(x=i, y=j, z=k)
               for i in x.output
@@ -182,7 +184,8 @@ def test_reduce_subset(op, reduced_vars):
     if op is ops.logaddexp:
         pytest.skip()
 
-    actual = f.reduce(op, reduced_vars)
+    with interpretation(sequential):
+        actual = f.reduce(op, reduced_vars)
 
     expected = f
     for v in [x, y, z]:


### PR DESCRIPTION
This PR does two things:
1. implements a `sequential` interpretation and moves sequential logic from `eager_reduce` to `sequential_reduce`. This logic was only being used in tests (which after this PR will use the sequential interpretation). The `sequential_reduce` logic has proven to be dangerous in general, because it opts to unroll large tensors into deeply nested `Binary`s.
2. Add a `@dispatched_interpretation` decorator since the interpretation boilerplate was becoming onerous. We'll eventually switch to a more flexible interpretation, but for now this decorator cleans up code nicely.

## Tested
- pure refactoring is exercised by existing tests
- updated two tests to use the new `sequential` interpretation