### PR TITLE
Add a to_data() helper

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
     'sum_product',
     'terms',
     'to_funsor',
-    'to_nonfunsor,
+    'to_nonfunsor',
     'torch',
     'torch_einsum',
 ]

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import reinterpret
-from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor, to_nonfunsor
+from funsor.terms import Funsor, Number, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange, torch_einsum
 
 from . import (adjoint, delta, distributions, domains, einsum, gaussian, handlers, interpreter, joint,
@@ -34,8 +34,8 @@ __all__ = [
     'reinterpret',
     'sum_product',
     'terms',
+    'to_data',
     'to_funsor',
-    'to_nonfunsor',
     'torch',
     'torch_einsum',
 ]

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import reinterpret
-from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor
+from funsor.terms import Funsor, Number, Variable, of_shape, to_funsor, to_nonfunsor
 from funsor.torch import Function, Tensor, arange, function, torch_einsum
 
 from . import (adjoint, delta, distributions, domains, einsum, gaussian, handlers, interpreter, joint,
@@ -37,6 +37,7 @@ __all__ = [
     'sum_product',
     'terms',
     'to_funsor',
+    'to_nonfunsor,
     'torch',
     'torch_einsum',
 ]

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -7,7 +7,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_funsor, to_nonfunsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_data, to_funsor
 
 
 def align_array(new_inputs, x):
@@ -191,10 +191,10 @@ class Array(Funsor):
         return Array(data, inputs, self.dtype)
 
 
-@to_nonfunsor.register(Array)
-def _to_nonfunsor_array(x):
+@to_data.register(Array)
+def _to_data_array(x):
     if x.inputs:
-        raise ValueError("cannot convert Array to a nonfunsor due to lazy inputs: {}"
+        raise ValueError("cannot convert Array to a data due to lazy inputs: {}"
                          .format(set(x.inputs)))
     return x.data
 

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -7,7 +7,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_funsor, to_nonfunsor
 
 
 def align_array(new_inputs, x):
@@ -189,6 +189,14 @@ class Array(Funsor):
 
         data = self.data[tuple(index)]
         return Array(data, inputs, self.dtype)
+
+
+@to_nonfunsor.register(Array)
+def _to_nonfunsor_array(x):
+    if x.inputs:
+        raise ValueError("cannot convert Array to a nonfunsor due to lazy inputs: {}"
+                         .format(set(x.inputs)))
+    return x.data
 
 
 @eager.register(Binary, object, Array, Number)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -141,6 +141,9 @@ class Funsor(object):
     def __repr__(self):
         return '{}({})'.format(type(self).__name__, ', '.join(map(repr, self._ast_values)))
 
+    def __str__(self):
+        return '{}({})'.format(type(self).__name__, ', '.join(map(str, self._ast_values)))
+
     def _pretty(self, lines, indent=0):
         lines.append((indent, type(self).__name__))
         for arg in self._ast_values:
@@ -445,12 +448,31 @@ def to_funsor(x):
     :rtype: Funsor
     :raises: ValueError
     """
-    raise ValueError("cannot convert to Funsor: {}".format(x))
+    raise ValueError("cannot convert to Funsor: {}".format(repr(x)))
 
 
 @to_funsor.register(Funsor)
 def _to_funsor_funsor(x):
     return x
+
+
+@singledispatch
+def to_nonfunsor(x):
+    """
+    Extract a python object from a :class:`Funsor`.
+
+    Raises a ``ValueError`` if free variables remain or if the funsor is lazy.
+
+    :param x: An object, possibly a :class:`Funsor`.
+    :return: A non-funsor equivalent to ``x``.
+    :raises: ValueError
+    """
+    return x
+
+
+@to_nonfunsor.register(Funsor)
+def _to_nonfunsor_funsor(x):
+    raise ValueError("cannot convert to a non-Funsor: {}".format(repr(x)))
 
 
 class Variable(Funsor):
@@ -655,6 +677,11 @@ class Number(Funsor):
 
     def eager_unary(self, op):
         return Number(op(self.data), self.dtype)
+
+
+@to_nonfunsor.register(Number)
+def _to_nonfunsor_number(x):
+    return x.data
 
 
 @eager.register(Binary, Op, Number, Number)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -457,7 +457,7 @@ def _to_funsor_funsor(x):
 
 
 @singledispatch
-def to_nonfunsor(x):
+def to_data(x):
     """
     Extract a python object from a :class:`Funsor`.
 
@@ -470,8 +470,8 @@ def to_nonfunsor(x):
     return x
 
 
-@to_nonfunsor.register(Funsor)
-def _to_nonfunsor_funsor(x):
+@to_data.register(Funsor)
+def _to_data_funsor(x):
     raise ValueError("cannot convert to a non-Funsor: {}".format(repr(x)))
 
 
@@ -679,8 +679,8 @@ class Number(Funsor):
         return Number(op(self.data), self.dtype)
 
 
-@to_nonfunsor.register(Number)
-def _to_nonfunsor_number(x):
+@to_data.register(Number)
+def _to_data_number(x):
     return x.data
 
 
@@ -838,5 +838,6 @@ __all__ = [
     'of_shape',
     'reflect',
     'sequential',
+    'to_data',
     'to_funsor',
 ]

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -12,7 +12,7 @@ from funsor.delta import Delta
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.ops import Op
 from funsor.six import getargspec
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor, to_nonfunsor
 
 
 def align_tensor(new_inputs, x):
@@ -297,6 +297,14 @@ class Tensor(Funsor):
             results.append(Tensor(flat_logits.logsumexp(-1), batch_inputs))
 
         return reduce(ops.add, results)
+
+
+@to_nonfunsor.register(Tensor)
+def _to_nonfunsor_tensor(x):
+    if x.inputs:
+        raise ValueError("cannot convert Tensor to a nonfunsor due to lazy inputs: {}"
+                         .format(set(x.inputs)))
+    return x.data
 
 
 @eager.register(Binary, Op, Tensor, Number)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -12,7 +12,7 @@ from funsor.delta import Delta
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.ops import Op
 from funsor.six import getargspec
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_funsor, to_nonfunsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_data, to_funsor
 
 
 def align_tensor(new_inputs, x):
@@ -300,10 +300,10 @@ class Tensor(Funsor):
         return reduce(ops.add, results)
 
 
-@to_nonfunsor.register(Tensor)
-def _to_nonfunsor_tensor(x):
+@to_data.register(Tensor)
+def _to_data_tensor(x):
     if x.inputs:
-        raise ValueError("cannot convert Tensor to a nonfunsor due to lazy inputs: {}"
+        raise ValueError("cannot convert Tensor to a data due to lazy inputs: {}"
                          .format(set(x.inputs)))
     return x.data
 

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -18,6 +18,19 @@ def test_to_funsor(shape, dtype):
     assert isinstance(f, Array)
 
 
+def test_to_nonfunsor():
+    data = np.zeros((3, 3))
+    x = Array(data)
+    assert funsor.to_nonfunsor(x) is data
+
+
+def test_to_nonfunsor_error():
+    data = np.zeros((3, 3))
+    x = Array(data, OrderedDict(i=bint(3)))
+    with pytest.raises(ValueError):
+        funsor.to_nonfunsor(x)
+
+
 def test_cons_hash():
     x = np.random.randn(3, 3)
     assert Array(x) is Array(x)

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -18,17 +18,17 @@ def test_to_funsor(shape, dtype):
     assert isinstance(f, Array)
 
 
-def test_to_nonfunsor():
+def test_to_data():
     data = np.zeros((3, 3))
     x = Array(data)
-    assert funsor.to_nonfunsor(x) is data
+    assert funsor.to_data(x) is data
 
 
-def test_to_nonfunsor_error():
+def test_to_data_error():
     data = np.zeros((3, 3))
     x = Array(data, OrderedDict(i=bint(3)))
     with pytest.raises(ValueError):
-        funsor.to_nonfunsor(x)
+        funsor.to_data(x)
 
 
 def test_cons_hash():

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -10,7 +10,7 @@ import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
-from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor
+from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor, to_nonfunsor
 from funsor.testing import check_funsor
 from funsor.torch import REDUCE_OP_TO_TORCH
 
@@ -22,9 +22,23 @@ def test_to_funsor():
 
 
 @pytest.mark.parametrize('x', ["foo", list(), tuple(), set(), dict()])
-def test_to_funsor_undefined(x):
+def test_to_funsor_error(x):
     with pytest.raises(ValueError):
         to_funsor(x)
+
+
+def test_to_nonfunsor():
+    actual = to_nonfunsor(Number(0.))
+    expected = 0.
+    assert type(actual) == type(expected)
+    assert actual == expected
+
+
+def test_to_nonfunsor_error():
+    with pytest.raises(ValueError):
+        to_nonfunsor(Variable('x', reals()))
+    with pytest.raises(ValueError):
+        to_nonfunsor(Variable('y', bint(12)))
 
 
 def test_cons_hash():

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -10,7 +10,7 @@ import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
-from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor, to_nonfunsor
+from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor, to_data
 from funsor.testing import check_funsor
 from funsor.torch import REDUCE_OP_TO_TORCH
 
@@ -27,18 +27,18 @@ def test_to_funsor_error(x):
         to_funsor(x)
 
 
-def test_to_nonfunsor():
-    actual = to_nonfunsor(Number(0.))
+def test_to_data():
+    actual = to_data(Number(0.))
     expected = 0.
     assert type(actual) == type(expected)
     assert actual == expected
 
 
-def test_to_nonfunsor_error():
+def test_to_data_error():
     with pytest.raises(ValueError):
-        to_nonfunsor(Variable('x', reals()))
+        to_data(Variable('x', reals()))
     with pytest.raises(ValueError):
-        to_nonfunsor(Variable('y', bint(12)))
+        to_data(Variable('y', bint(12)))
 
 
 def test_cons_hash():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -22,17 +22,17 @@ def test_to_funsor(shape, dtype):
     assert isinstance(f, Tensor)
 
 
-def test_to_nonfunsor():
+def test_to_data():
     data = torch.zeros(3, 3)
     x = Tensor(data)
-    assert funsor.to_nonfunsor(x) is data
+    assert funsor.to_data(x) is data
 
 
-def test_to_nonfunsor_error():
+def test_to_data_error():
     data = torch.zeros(3, 3)
     x = Tensor(data, OrderedDict(i=bint(3)))
     with pytest.raises(ValueError):
-        funsor.to_nonfunsor(x)
+        funsor.to_data(x)
 
 
 def test_cons_hash():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,10 +9,9 @@ import torch
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
-from funsor.torch import REDUCE_OP_TO_TORCH
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
-from funsor.torch import Tensor, align_tensors, torch_einsum
+from funsor.torch import REDUCE_OP_TO_TORCH, Tensor, align_tensors, torch_einsum
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
@@ -21,6 +20,19 @@ def test_to_funsor(shape, dtype):
     t = torch.randn(shape).type(dtype)
     f = funsor.to_funsor(t)
     assert isinstance(f, Tensor)
+
+
+def test_to_nonfunsor():
+    data = torch.zeros(3, 3)
+    x = Tensor(data)
+    assert funsor.to_nonfunsor(x) is data
+
+
+def test_to_nonfunsor_error():
+    data = torch.zeros(3, 3)
+    x = Tensor(data, OrderedDict(i=bint(3)))
+    with pytest.raises(ValueError):
+        funsor.to_nonfunsor(x)
 
 
 def test_cons_hash():


### PR DESCRIPTION
Addresses #83

This adds a `to_data()` helper that is intended to be used in Pyro programs just after a `pyro.ground` statement.

## Tested
- added tests for `Number`, `Tensor`, and `Array`