### PR TITLE
Implement advanced indexing in Funsor.__getitem__()

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -79,9 +79,9 @@ def find_domain(op, *domains):
         return Domain(shape, dtype)
 
     lhs, rhs = domains
-    if op is ops.getitem:
+    if isinstance(op, ops.GetitemOp):
         dtype = lhs.dtype
-        shape = lhs.shape[rhs.num_elements:]
+        shape = lhs.shape[:op.offset] + lhs.shape[1 + op.offset:]
         return Domain(shape, dtype)
 
     if lhs.dtype == 'real' or rhs.dtype == 'real':

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from collections import OrderedDict
 
 import numpy as np
+from multipledispatch import dispatch
 from six import add_metaclass, integer_types
 
 import funsor.ops as ops
@@ -76,7 +77,6 @@ class ArrayMeta(FunsorMeta):
         return super(ArrayMeta, cls).__call__(data, inputs, dtype)
 
 
-@to_funsor.register(np.ndarray)
 @add_metaclass(ArrayMeta)
 class Array(Funsor):
     """
@@ -189,6 +189,16 @@ class Array(Funsor):
 
         data = self.data[tuple(index)]
         return Array(data, inputs, self.dtype)
+
+
+@dispatch(np.ndarray)
+def to_funsor(x):
+    return Array(x)
+
+
+@dispatch(np.ndarray, object)
+def to_funsor(x, dtype):
+    return Array(x, dtype=dtype)
 
 
 @to_data.register(Array)

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -24,6 +24,9 @@ class Op(Dispatcher):
     def __repr__(self):
         return self.__name__
 
+    def __str__(self):
+        return self.__name__
+
 
 class AssociativeOp(Op):
     pass

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from numbers import Number
 import operator
+from numbers import Number
 
 import numpy as np
 from multipledispatch import Dispatcher
-
+from six import add_metaclass
 
 _builtin_abs = abs
 _builtin_max = max
@@ -33,9 +33,39 @@ class AddOp(AssociativeOp):
     pass
 
 
+class GetitemMeta(type):
+    _cache = {}
+
+    def __call__(cls, offset):
+        try:
+            return GetitemMeta._cache[offset]
+        except KeyError:
+            instance = super(GetitemMeta, cls).__call__(offset)
+            GetitemMeta._cache[offset] = instance
+            return instance
+
+
+@add_metaclass(GetitemMeta)
+class GetitemOp(Op):
+    """
+    Op encoding an index into one dime, e.g. ``x[:,:,:,y]`` for offset of 3.
+    """
+    def __init__(self, offset):
+        assert isinstance(offset, int)
+        assert offset >= 0
+        self.offset = offset
+        self._prefix = (slice(None),) * offset
+        self.__name__ = 'GetitemOp({})'.format(offset)
+        super(GetitemOp, self).__init__(self._default)
+
+    def _default(self, x, y):
+        return x[self._prefix + (y,)] if self.offset else x[y]
+
+
+getitem = GetitemOp(0)
+
 eq = Op(operator.eq)
 ge = Op(operator.ge)
-getitem = Op(operator.getitem)
 gt = Op(operator.gt)
 invert = Op(operator.invert)
 le = Op(operator.le)
@@ -149,6 +179,7 @@ PRODUCT_INVERSES = {
 __all__ = [
     'AssociativeOp',
     'DISTRIBUTIVE_OPS',
+    'GetitemOp',
     'Op',
     'PRODUCT_INVERSES',
     'abs',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -546,6 +546,11 @@ class Variable(Funsor):
         return self
 
 
+@dispatch(str, integer_types)
+def to_funsor(name, dtype):
+    return Variable(name, bint(dtype))
+
+
 _PREFIX = {
     ops.neg: '-',
     ops.invert: '~',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -687,7 +687,8 @@ class Number(Funsor):
         assert isinstance(data, numbers.Number)
         if isinstance(dtype, integer_types):
             data = type(dtype)(data)
-            assert 0 <= data and data < dtype
+            if dtype != 2:  # booleans have bitwise interpretation
+                assert 0 <= data and data < dtype
         else:
             assert isinstance(dtype, str) and dtype == "real"
             data = float(data)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -4,13 +4,14 @@ import functools
 from collections import OrderedDict
 
 import torch
+from multipledispatch import dispatch
 from six import add_metaclass, integer_types
 from six.moves import reduce
 
 import funsor.ops as ops
 from funsor.delta import Delta
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.ops import Op
+from funsor.ops import GetitemOp, Op
 from funsor.six import getargspec
 from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, to_data, to_funsor
 
@@ -81,7 +82,6 @@ class TensorMeta(FunsorMeta):
         return super(TensorMeta, cls).__call__(data, inputs, dtype)
 
 
-@to_funsor.register(torch.Tensor)
 @add_metaclass(TensorMeta)
 class Tensor(Funsor):
     """
@@ -300,6 +300,16 @@ class Tensor(Funsor):
         return reduce(ops.add, results)
 
 
+@dispatch(torch.Tensor)
+def to_funsor(x):
+    return Tensor(x)
+
+
+@dispatch(torch.Tensor, object)
+def to_funsor(x, dtype):
+    return Tensor(x, dtype=dtype)
+
+
 @to_data.register(Tensor)
 def _to_data_tensor(x):
     if x.inputs:
@@ -310,14 +320,7 @@ def _to_data_tensor(x):
 
 @eager.register(Binary, Op, Tensor, Number)
 def eager_binary_tensor_number(op, lhs, rhs):
-    if op is ops.getitem:
-        # Shift by that Funsor is using for inputs.
-        index = [slice(None)] * len(lhs.inputs)
-        index.append(rhs.data)
-        index = tuple(index)
-        data = lhs.data[index]
-    else:
-        data = op(lhs.data, rhs.data)
+    data = op(lhs.data, rhs.data)
     return Tensor(data, lhs.inputs, lhs.dtype)
 
 
@@ -337,18 +340,54 @@ def eager_binary_tensor_tensor(op, lhs, rhs):
     else:
         inputs, (lhs_data, rhs_data) = align_tensors(lhs, rhs)
 
-    if op is ops.getitem:
-        # getitem has special shape semantics.
-        if rhs.output.shape:
-            raise NotImplementedError('TODO support vector indexing')
-        assert lhs.output.shape == (rhs.dtype,)
-        index = [torch.arange(size).reshape((-1,) + (1,) * (lhs_data.dim() - pos - 2))
-                 for pos, size in enumerate(lhs_data.shape)]
-        index[-1] = rhs_data
-        data = lhs_data[tuple(index)]
-    else:
-        data = op(lhs_data, rhs_data)
+    data = op(lhs_data, rhs_data)
+    return Tensor(data, inputs, dtype)
 
+
+@eager.register(Binary, GetitemOp, Tensor, Number)
+def eager_getitem_tensor_number(op, lhs, rhs):
+    index = [slice(None)] * (len(lhs.inputs) + op.offset)
+    index.append(rhs.data)
+    index = tuple(index)
+    data = lhs.data[index]
+    return Tensor(data, lhs.inputs, lhs.dtype)
+
+
+@eager.register(Binary, GetitemOp, Tensor, Variable)
+def eager_getitem_tensor_variable(op, lhs, rhs):
+    assert op.offset < len(lhs.output.shape)
+    assert rhs.output == bint(lhs.output.shape[op.offset])
+    assert rhs.name not in lhs.inputs
+
+    # Convert a positional event dimension to a named batch dimension.
+    inputs = lhs.inputs.copy()
+    inputs[rhs.name] = rhs.output
+    data = lhs.data
+    target_dim = len(lhs.inputs)
+    source_dim = target_dim + op.offset
+    if target_dim != source_dim:
+        data = data.permute(source_dim, target_dim)
+    return Tensor(data, inputs, lhs.dtype)
+
+
+@eager.register(Binary, GetitemOp, Tensor, Tensor)
+def eager_getitem_tensor_tensor(op, lhs, rhs):
+    assert op.offset < len(lhs.output.shape)
+    assert rhs.output == bint(lhs.output.shape[op.offset])
+
+    # Compute inputs and outputs.
+    dtype = find_domain(op, lhs.output, rhs.output).dtype
+    if lhs.inputs == rhs.inputs:
+        inputs = lhs.inputs
+        lhs_data, rhs_data = lhs.data, rhs.data
+    else:
+        inputs, (lhs_data, rhs_data) = align_tensors(lhs, rhs)
+
+    # Perform advanced indexing.
+    index = [torch.arange(size).reshape((-1,) + (1,) * (lhs_data.dim() - pos - 2))
+             for pos, size in enumerate(lhs_data.shape)]
+    index[len(lhs.inputs) + op.offset] = rhs_data
+    data = lhs_data[tuple(index)]
     return Tensor(data, inputs, dtype)
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -290,6 +290,50 @@ def test_binary_scalar_funsor(symbol, dims, scalar):
     check_funsor(actual, inputs, reals(), expected_data)
 
 
+def test_getitem_number_0_inputs():
+    data = torch.randn((5, 4, 3, 2))
+    x = Tensor(data)
+    assert_close(x[2], Tensor(data[2]))
+    assert_close(x[:, 1], Tensor(data[:, 1]))
+    assert_close(x[2, 1], Tensor(data[2, 1]))
+    assert_close(x[2, :, 1], Tensor(data[2, :, 1]))
+    assert_close(x[3, ...], Tensor(data[3, ...]))
+    assert_close(x[3, 2, ...], Tensor(data[3, 2, ...]))
+    assert_close(x[..., 1], Tensor(data[..., 1]))
+    assert_close(x[..., 2, 1], Tensor(data[..., 2, 1]))
+    assert_close(x[3, ..., 1], Tensor(data[3, ..., 1]))
+
+
+def test_getitem_number_1_inputs():
+    data = torch.randn((3, 5, 4, 3, 2))
+    inputs = OrderedDict([('i', bint(3))])
+    x = Tensor(data, inputs)
+    assert_close(x[2], Tensor(data[:, 2], inputs))
+    assert_close(x[:, 1], Tensor(data[:, :, 1], inputs))
+    assert_close(x[2, 1], Tensor(data[:, 2, 1], inputs))
+    assert_close(x[2, :, 1], Tensor(data[:, 2, :, 1], inputs))
+    assert_close(x[3, ...], Tensor(data[:, 3, ...], inputs))
+    assert_close(x[3, 2, ...], Tensor(data[:, 3, 2, ...], inputs))
+    assert_close(x[..., 1], Tensor(data[..., 1], inputs))
+    assert_close(x[..., 2, 1], Tensor(data[..., 2, 1], inputs))
+    assert_close(x[3, ..., 1], Tensor(data[:, 3, ..., 1], inputs))
+
+
+def test_getitem_number_2_inputs():
+    data = torch.randn((3, 4, 5, 4, 3, 2))
+    inputs = OrderedDict([('i', bint(3)), ('j', bint(4))])
+    x = Tensor(data, inputs)
+    assert_close(x[2], Tensor(data[:, :, 2], inputs))
+    assert_close(x[:, 1], Tensor(data[:, :, :, 1], inputs))
+    assert_close(x[2, 1], Tensor(data[:, :, 2, 1], inputs))
+    assert_close(x[2, :, 1], Tensor(data[:, :, 2, :, 1], inputs))
+    assert_close(x[3, ...], Tensor(data[:, :, 3, ...], inputs))
+    assert_close(x[3, 2, ...], Tensor(data[:, :, 3, 2, ...], inputs))
+    assert_close(x[..., 1], Tensor(data[..., 1], inputs))
+    assert_close(x[..., 2, 1], Tensor(data[..., 2, 1], inputs))
+    assert_close(x[3, ..., 1], Tensor(data[:, :, 3, ..., 1], inputs))
+
+
 REDUCE_OPS = [ops.add, ops.mul, ops.and_, ops.or_, ops.logaddexp, ops.min, ops.max]
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -334,6 +334,36 @@ def test_getitem_number_2_inputs():
     assert_close(x[3, ..., 1], Tensor(data[:, :, 3, ..., 1], inputs))
 
 
+def test_getitem_variable():
+    data = torch.randn((5, 4, 3, 2))
+    x = Tensor(data)
+    i = Variable('i', bint(5))
+    j = Variable('j', bint(4))
+    assert x[i] is Tensor(data, OrderedDict([('i', bint(5))]))
+    assert x[i, j] is Tensor(data, OrderedDict([('i', bint(5)), ('j', bint(4))]))
+
+
+def test_getitem_tensor():
+    data = torch.randn((5, 4, 3, 2))
+    x = Tensor(data)
+    i = Variable('i', bint(5))
+    j = Variable('j', bint(4))
+    k = Variable('k', bint(3))
+    l = Variable('l', bint(2))
+
+    y = random_tensor(OrderedDict(), bint(5))
+    assert_close(x[i](i=y), x[y])
+
+    y = random_tensor(OrderedDict(), bint(4))
+    assert_close(x[:, j](j=y), x[:, y])
+
+    y = random_tensor(OrderedDict(), bint(3))
+    assert_close(x[:, :, k](k=y), x[:, :, y])
+
+    y = random_tensor(OrderedDict(), bint(2))
+    assert_close(x[:, :, :, l](l=y), x[:, :, :, y])
+
+
 REDUCE_OPS = [ops.add, ops.mul, ops.and_, ops.or_, ops.logaddexp, ops.min, ops.max]
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -349,7 +349,7 @@ def test_getitem_tensor():
     i = Variable('i', bint(5))
     j = Variable('j', bint(4))
     k = Variable('k', bint(3))
-    l = Variable('l', bint(2))
+    m = Variable('m', bint(2))
 
     y = random_tensor(OrderedDict(), bint(5))
     assert_close(x[i](i=y), x[y])
@@ -361,7 +361,15 @@ def test_getitem_tensor():
     assert_close(x[:, :, k](k=y), x[:, :, y])
 
     y = random_tensor(OrderedDict(), bint(2))
-    assert_close(x[:, :, :, l](l=y), x[:, :, :, y])
+    assert_close(x[:, :, :, m](m=y), x[:, :, :, y])
+
+    y = random_tensor(OrderedDict([('i', i.output)]),
+                      bint(j.dtype))
+    assert_close(x[i, j](j=y), x[i, y])
+
+    y = random_tensor(OrderedDict([('i', i.output), ('j', j.output)]),
+                      bint(k.dtype))
+    assert_close(x[i, j, k](k=y), x[i, j, y])
 
 
 REDUCE_OPS = [ops.add, ops.mul, ops.and_, ops.or_, ops.logaddexp, ops.min, ops.max]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -343,6 +343,13 @@ def test_getitem_variable():
     assert x[i, j] is Tensor(data, OrderedDict([('i', bint(5)), ('j', bint(4))]))
 
 
+def test_getitem_string():
+    data = torch.randn((5, 4, 3, 2))
+    x = Tensor(data)
+    assert x['i'] is Tensor(data, OrderedDict([('i', bint(5))]))
+    assert x['i', 'j'] is Tensor(data, OrderedDict([('i', bint(5)), ('j', bint(4))]))
+
+
 def test_getitem_tensor():
     data = torch.randn((5, 4, 3, 2))
     x = Tensor(data)


### PR DESCRIPTION
This implements advanced `.__getitem__()` including:
- support for multiple arguments, e.g. `x[i, j]`
- support for trivial slices, e.g. `x[:, i, :, :, j]`
- support for ellipsis, e.g. `x[..., i, j]`

Funsors may be indexed by `slice`, `Ellipsis`, `Funsor`s of dtype `bint(...)`, integers, or strings. The new mechanism is a family of `GetitemOp`s, one per offset:
```py
GetitemOp(0)(x, y) == x[y]
GetitemOp(1)(x, y) == x[:, y]
GetitemOp(2)(x, y) == x[:, :, y]
```

This PR also adds a second optional argument to `to_funsor(x, dtype)` so that bint metadata can be correctly added to integers and torch.Tensors whenever this metadata is available (e.g. in `.__getitem__()` where the shape bound is known).


## Motivation

#54's [examples/vae.py](https://github.com/pyro-ppl/funsor/blob/montecarlo/examples/vae.py) simulates a `pyro.plate` by using `.__getitem__()` to convert "event dimensions" to "batch dimensions". After this PR, this op is very cheap, indeed leaving the underlying `torch.Tensor` untouched and merely changing the `funsor.torch.Tensor` metadata.

## Tests

- [x] added new size check assertions
- [x] test integer indexing
- [x] test variable indexing
- [x] test string indexing
- [x] test tensor indexing