### PR TITLE
Add isort command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ install:
 lint: FORCE
 	flake8
 
+format: FORCE
+	isort -y
+
 test: lint FORCE
 	pytest -v test
 	python examples/discrete_hmm.py -n 2

--- a/examples/ss_vae_delayed.py
+++ b/examples/ss_vae_delayed.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, division, print_function
 import argparse
 from collections import OrderedDict
 
+import pyro.distributions as dist
 import torch
 import torch.nn as nn
 
 import funsor
 import funsor.minipyro as pyro
-import pyro.distributions as dist
 
 
 class Decoder(nn.Module):

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -5,8 +5,23 @@ from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Number, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange, torch_einsum
 
-from . import (adjoint, contract, delta, distributions, domains, einsum, gaussian, handlers, interpreter, joint,
-               minipyro, ops, sum_product, terms, torch)
+from . import (
+    adjoint,
+    contract,
+    delta,
+    distributions,
+    domains,
+    einsum,
+    gaussian,
+    handlers,
+    interpreter,
+    joint,
+    minipyro,
+    ops,
+    sum_product,
+    terms,
+    torch
+)
 
 __all__ = [
     'Domain',

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
+
 import torch
 
 import funsor.ops as ops

--- a/funsor/einsum.py
+++ b/funsor/einsum.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import OrderedDict
-from six import integer_types
-from six.moves import reduce
 
 import torch
+from six import integer_types
+from six.moves import reduce
 
 import funsor.ops as ops
 from funsor.contract import Contract

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from numbers import Number
 import operator
+from numbers import Number
 
 import numpy as np
 from multipledispatch import Dispatcher
-
 
 _builtin_abs = abs
 _builtin_max = max

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
+
 from six.moves import reduce
 
 from funsor.terms import Funsor

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ ignore = F811,E121,E123,E126,E226,E24,E704,W503,W504
 
 [isort]
 line_length = 120
+multi_line_output=3
 not_skip = __init__.py
 known_first_party = funsor, test
 known_third_party = opt_einsum, pyro, six, torch, torchvision

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -1,22 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 import opt_einsum
+import pytest
 import torch
 from pyro.ops.contract import einsum as pyro_einsum
 from pyro.ops.einsum.adjoint import require_backward as pyro_require_backward
 
 import funsor
-
-from funsor.domains import bint
-from funsor.terms import reflect, Variable
-from funsor.interpreter import interpretation
-from funsor.testing import make_einsum_example, make_plated_hmm_einsum
-
-from funsor.einsum import naive_einsum, naive_plated_einsum, einsum
 from funsor.adjoint import adjoint
-
+from funsor.domains import bint
+from funsor.einsum import einsum, naive_einsum, naive_plated_einsum
+from funsor.interpreter import interpretation
+from funsor.terms import Variable, reflect
+from funsor.testing import make_einsum_example, make_plated_hmm_einsum
 
 EINSUM_EXAMPLES = [
     "a->",

--- a/test/test_contract.py
+++ b/test/test_contract.py
@@ -1,22 +1,20 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import OrderedDict  # noqa: F401
+
 import pytest
 import torch  # noqa: F401
 
 import funsor
-
 import funsor.ops as ops
+from funsor.contract import Contract
 from funsor.domains import bint  # noqa: F401
+from funsor.einsum import einsum, naive_contract_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import Finitary, optimize
 from funsor.terms import reflect
 from funsor.testing import assert_close, make_einsum_example
 from funsor.torch import Tensor  # noqa: F401
-
-from funsor.einsum import einsum, naive_contract_einsum
-from funsor.contract import Contract
-
 
 EINSUM_EXAMPLES = [
     "a,b->",

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -1,24 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
 from collections import OrderedDict
 
 import opt_einsum
+import pytest
 import torch
 from pyro.ops.contract import naive_ubersum
 
 import funsor
-
 from funsor.distributions import Categorical
 from funsor.domains import bint
-from funsor.terms import reflect, Variable
-from funsor.torch import Tensor
+from funsor.einsum import naive_einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
+from funsor.terms import Variable, reflect
 from funsor.testing import assert_close, make_einsum_example
-
-from funsor.einsum import naive_einsum, naive_plated_einsum
-
+from funsor.torch import Tensor
 
 EINSUM_EXAMPLES = [
     "a,b->",

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,13 +1,12 @@
 from collections import OrderedDict
 
+import numpy as np
 import pytest
 
 import funsor
-from funsor import bint, reals, Variable, Number
+from funsor import Number, Variable, bint, reals
 from funsor.numpy import Array
-import numpy as np
-
-from funsor.testing import check_funsor, assert_equiv, random_array
+from funsor.testing import assert_equiv, check_funsor, random_array
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -1,25 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
 from collections import OrderedDict
 
 import opt_einsum
-import torch
 import pyro.ops.contract as pyro_einsum
+import pytest
+import torch
 
 import funsor
-
 from funsor.distributions import Categorical
 from funsor.domains import bint
+from funsor.einsum import einsum, naive_einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
-from funsor.terms import reflect, Variable
+from funsor.terms import Variable, reflect
+from funsor.testing import assert_close, make_chain_einsum, make_einsum_example, make_hmm_einsum, make_plated_hmm_einsum
 from funsor.torch import Tensor
-
-from funsor.testing import assert_close, make_einsum_example, \
-    make_chain_einsum, make_hmm_einsum, make_plated_hmm_einsum
-from funsor.einsum import naive_einsum, naive_plated_einsum, einsum
-
 
 OPTIMIZED_EINSUM_EXAMPLES = [
     make_chain_einsum(t) for t in range(2, 50, 10)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -6,8 +6,8 @@ import pytest
 from six.moves import reduce
 
 import funsor.ops as ops
-from funsor.sum_product import _partition, partial_sum_product, sum_product
 from funsor.domains import bint
+from funsor.sum_product import _partition, partial_sum_product, sum_product
 from funsor.testing import assert_close, random_tensor
 
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -10,7 +10,7 @@ import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
-from funsor.terms import Binary, Number, Stack, Variable, sequential, to_funsor, to_data
+from funsor.terms import Binary, Number, Stack, Variable, sequential, to_data, to_funsor
 from funsor.testing import check_funsor
 from funsor.torch import REDUCE_OP_TO_TORCH
 


### PR DESCRIPTION
This adds a `make format` command to the makefile and tweaks our isort config.

We've been having lots of trivial merge conflicts due to the long `from . import ...` in `__init__.py`, which is needed to ensure all dispatched implementations are registered at library load. This PR tweaks our isort config in `setup.cfg` to split that line into multiple lines, which can be handled more easily during `git merge`.

Note it's easy to trigger isort from most editors [docs](https://github.com/timothycrosley/isort/wiki/isort-Plugins).