### PR TITLE
Add interpretation logging controlled by FUNSOR_DEBUG=1

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -11,23 +11,24 @@ from funsor.domains import Domain
 from funsor.ops import Op
 from funsor.registry import KeyedRegistry
 from funsor.six import singledispatch
-from funsor.util import get_stack_size
 
 _DEBUG = int(os.environ.get("FUNSOR_DEBUG", 0))
-_MIN_STACK_SIZE = float('inf')
+_STACK_SIZE = 0
 
 _INTERPRETATION = None  # To be set later in funsor.terms
 
 
 if _DEBUG:
     def interpret(cls, *args):
-        global _MIN_STACK_SIZE
-        stack_size = get_stack_size()
-        _MIN_STACK_SIZE = min(_MIN_STACK_SIZE, stack_size)
-        indent = ' ' * (stack_size - _MIN_STACK_SIZE)
+        global _STACK_SIZE
+        indent = '  ' * _STACK_SIZE
         typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
         print(indent + ' '.join(typenames))
-        result = _INTERPRETATION(cls, *args)
+        _STACK_SIZE += 1
+        try:
+            result = _INTERPRETATION(cls, *args)
+        finally:
+            _STACK_SIZE -= 1
         print(indent + '-> ' + type(result).__name__)
         return result
 else:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -149,6 +149,10 @@ class Funsor(object):
         for arg in self._ast_values:
             if isinstance(arg, Funsor):
                 arg._pretty(lines, indent + 1)
+            elif type(arg) is tuple and all(isinstance(x, Funsor) for x in arg):
+                lines.append((indent + 1, 'tuple'))
+                for x in arg:
+                    x._pretty(lines, indent + 2)
             else:
                 lines.append((indent + 1, str(arg)))
 

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
+import sys
 
 
 class lazy_property(object):
@@ -14,3 +15,17 @@ class lazy_property(object):
         value = self.fn(obj)
         setattr(obj, self.fn.__name__, value)
         return value
+
+
+# Source: https://stackoverflow.com/a/47956089/1224437
+def get_stack_size():
+    """
+    Get stack size for caller's frame.
+    """
+    size = 2  # current frame and caller's frame always exist
+    while True:
+        try:
+            sys._getframe(size)
+            size += 1
+        except ValueError:
+            return size - 1  # subtract current frame

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import functools
-import sys
 
 
 class lazy_property(object):
@@ -15,17 +14,3 @@ class lazy_property(object):
         value = self.fn(obj)
         setattr(obj, self.fn.__name__, value)
         return value
-
-
-# Source: https://stackoverflow.com/a/47956089/1224437
-def get_stack_size():
-    """
-    Get stack size for caller's frame.
-    """
-    size = 2  # current frame and caller's frame always exist
-    while True:
-        try:
-            sys._getframe(size)
-            size += 1
-        except ValueError:
-            return size - 1  # subtract current frame


### PR DESCRIPTION
This adds simple debug logging of `interpret()`.

To enable debug logging during a failing test, run with an environment variable set:
```sh
FUNSOR_DEBUG=1 pytest -v tests/test_joint.py
```
This produces output like
```
test/test_joint.py::test_smoke[(t + g).reduce(ops.logaddexp, "x")-Tensor] Tensor Tensor tuple str
-> Tensor
Number int str
-> Number
Delta str Tensor Number
-> Delta
Tensor Tensor tuple str
-> Tensor
Number int str
-> Number
Delta str Tensor Number
-> Delta
Tensor Tensor tuple str
-> Tensor
Gaussian Tensor Tensor tuple
-> Gaussian
Number int int
-> Number
Tensor Tensor tuple str
-> Tensor
Binary AddOp Tensor Gaussian
  Joint tuple Tensor Gaussian
    Number int str
    -> Number
    Number int str
    -> Number
    Number int str
    -> Number
  -> Joint
-> Joint
Reduce AssociativeOp Joint frozenset
  Reduce AssociativeOp Gaussian frozenset
    Tensor Tensor tuple str
    -> Tensor
  -> Tensor
  Number int str
  -> Number
  Joint tuple Tensor Number
    Number int str
    -> Number
  -> Tensor
  Binary AddOp Tensor Tensor
    Tensor Tensor tuple str
    -> Tensor
  -> Tensor
-> Tensor
```
This PR also improves `.pretty()` printing of `Stack` and `Joint` but recursing into tuples that contain Funsors.