### PR TITLE
Fix lazy reduction for Joint.reduce()

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -104,7 +104,9 @@ class Joint(Funsor):
             reduced_vars -= gaussian_vars
 
             # Scale to account for remaining reduced_vars that were inputs to dropped deltas.
-            eager_result = Joint(deltas, discrete) + gaussian
+            eager_result = Joint(deltas, discrete)
+            if gaussian is not Number(0):
+                eager_result += gaussian
             reduced_vars |= lazy_vars.difference(eager_result.inputs)
             lazy_vars = lazy_vars.intersection(eager_result.inputs)
             if reduced_vars:

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -165,6 +165,20 @@ def test_reduce_deltas_lazy():
     assert_close(x.reduce(ops.logaddexp), y.reduce(ops.logaddexp))
 
 
+def test_reduce_deltas_discrete_lazy():
+    a = Delta('a', Tensor(torch.randn(3, 2), OrderedDict(i=bint(3))))
+    b = Delta('b', Tensor(torch.randn(3), OrderedDict(i=bint(3))))
+    c = Tensor(torch.randn(3), OrderedDict(i=bint(3)))
+    x = a + b + c
+    assert isinstance(x, Joint)
+    assert set(x.inputs) == {'a', 'b', 'i'}
+
+    y = x.reduce(ops.logaddexp, 'i')
+    assert isinstance(y, Reduce)
+    assert set(y.inputs) == {'a', 'b'}
+    assert_close(x.reduce(ops.logaddexp), y.reduce(ops.logaddexp))
+
+
 def test_reduce_gaussian_lazy():
     a = random_gaussian(OrderedDict(i=bint(3), a=reals(2)))
     b = random_tensor(OrderedDict(i=bint(3), b=bint(2)))


### PR DESCRIPTION
This fixes detection of variables that must remain lazy in `Joint.reduce()`.

## Tested
- added three regression tests