### PR TITLE
Log function and filename when FUNSOR_DEBUG=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ format: FORCE
 
 test: lint FORCE
 	pytest -v test
+	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	python examples/discrete_hmm.py -n 2
 	python examples/discrete_hmm.py -n 2 -t 50 --lazy
 	python examples/kalman_filter.py --xfail-if-not-implemented

--- a/funsor/contract.py
+++ b/funsor/contract.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import functools
 from collections import OrderedDict
 
+import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.optimizer import Finitary, optimize
 from funsor.sum_product import _partition
@@ -51,6 +52,7 @@ def contractor(fn):
     """
     Decorator for contract implementations to simplify inputs.
     """
+    fn = interpreter.debug_logged(fn)
     return functools.partial(_simplify_contract, fn)
 
 

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import functools
 from collections import OrderedDict
 
+import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.contract import Contract
 from funsor.terms import Funsor, Reduce, eager
@@ -58,6 +59,7 @@ def integrator(fn):
     """
     Decorator for integration implementations.
     """
+    fn = interpreter.debug_logged(fn)
     return functools.partial(_simplify_integrate, fn)
 
 

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from six import add_metaclass
 from six.moves import reduce
 
+import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.delta import Delta
 from funsor.domains import reals
@@ -293,6 +294,7 @@ def _joint_integrator(fn):
     """
     Decorator for Integrate(Joint(...), ...) patterns.
     """
+    fn = interpreter.debug_logged(fn)
     return integrator(functools.partial(_simplify_integrate, fn))
 
 

--- a/funsor/registry.py
+++ b/funsor/registry.py
@@ -1,4 +1,3 @@
-
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -258,7 +258,7 @@ class Funsor(object):
         if sampled_vars.isdisjoint(self.inputs):
             return self
 
-        result = self.unscaled_sample(sampled_vars, sample_inputs)
+        result = interpreter.debug_logged(self.unscaled_sample)(sampled_vars, sample_inputs)
         if sample_inputs is not None:
             log_scale = 0
             for var, domain in sample_inputs.items():
@@ -735,7 +735,7 @@ def eager_reduce(op, arg, reduced_vars):
 
 @sequential.register(Reduce, AssociativeOp, Funsor, frozenset)
 def sequential_reduce(op, arg, reduced_vars):
-    return arg.sequential_reduce(op, reduced_vars)
+    return interpreter.debug_logged(arg.sequential_reduce)(op, reduced_vars)
 
 
 class NumberMeta(FunsorMeta):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -614,7 +614,7 @@ def eager_subs(arg, subs):
     assert isinstance(subs, tuple)
     if not any(k in arg.inputs for k, v in subs):
         return arg
-    return arg.eager_subs(subs)
+    return interpreter.debug_logged(arg.eager_subs)(subs)
 
 
 _PREFIX = {
@@ -647,14 +647,14 @@ class Unary(Funsor):
 
 @eager.register(Unary, Op, Funsor)
 def eager_unary(op, arg):
-    return arg.eager_unary(op)
+    return interpreter.debug_logged(arg.eager_unary)(op)
 
 
 @eager.register(Unary, AssociativeOp, Funsor)
 def eager_unary(op, arg):
     if not arg.output.shape:
         return arg
-    return arg.eager_unary(op)
+    return interpreter.debug_logged(arg.eager_unary)(op)
 
 
 _INFIX = {
@@ -730,7 +730,7 @@ class Reduce(Funsor):
 
 @eager.register(Reduce, AssociativeOp, Funsor, frozenset)
 def eager_reduce(op, arg, reduced_vars):
-    return arg.eager_reduce(op, reduced_vars)
+    return interpreter.debug_logged(arg.eager_reduce)(op, reduced_vars)
 
 
 @sequential.register(Reduce, AssociativeOp, Funsor, frozenset)


### PR DESCRIPTION
This adds lines indicating which function was used during `FUNSOR_DEBUG` logging. The file paths can be clicked in most terminal emulators.

For example:
```
$ FUNSOR_DEBUG=1 python examples/vae.py
Number float str
-> Number
Variable str Domain
-> Variable
Function partial Domain tuple
  eager_function file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 521
-> Function
Function partial Domain tuple
  eager_function file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 521
-> Function
Variable str Domain
-> Variable
Function Decoder Domain tuple
  eager_function file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 521
-> Function
Tensor Tensor tuple str
-> Tensor
Subs Function tuple
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 611
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 514
  Subs Variable tuple
    eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 611
    eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 567
  -> Tensor
  Function partial Domain tuple
    eager_function file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 521
    Tensor Tensor tuple str
    -> Tensor
  -> Tensor
-> Tensor
Subs Function tuple
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 611
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 514
  Subs Variable tuple
    eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 611
    eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 567
  -> Tensor
  Function partial Domain tuple
    eager_function file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 521
    Tensor Tensor tuple str
    -> Tensor
  -> Tensor
-> Tensor
...
```
## Tests
- added a smoke test to the makefile