### PR TITLE
Implement basic transformed distributions

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -164,6 +164,14 @@ def eager_delta(v, log_density, value):
     return funsor.delta.Delta(v.name, value, log_density)
 
 
+def LogNormal(loc, scale, value=None):
+    loc, scale, y = Normal._fill_defaults(loc, scale, value)
+    t = ops.exp
+    x = t.inv(y)
+    log_abs_det_jacobian = t.log_abs_det_jacobian(x, y)
+    return Normal(loc, scale, x) - log_abs_det_jacobian
+
+
 class Normal(Distribution):
     dist_class = dist.Normal
 
@@ -284,6 +292,7 @@ __all__ = [
     'Categorical',
     'Delta',
     'Distribution',
+    'LogNormal',
     'MultivariateNormal',
     'Normal',
 ]

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -185,17 +185,32 @@ class Gaussian(Funsor):
         if not subs:
             return self
 
-        # Constants are eagerly substituted, everything else is lazily substituted.
-        constant = (Number, Tensor)
-        lazy_subs = tuple((k, v) for k, v in subs if not isinstance(v, constant))
-        int_subs = tuple((k, v) for k, v in subs if isinstance(v, constant)
+        # Constants and Variables are eagerly substituted;
+        # everything else is lazily substituted.
+        lazy_subs = tuple((k, v) for k, v in subs
+                          if not isinstance(v, (Number, Tensor, Variable)))
+        var_subs = tuple((k, v) for k, v in subs if isinstance(v, Variable))
+        int_subs = tuple((k, v) for k, v in subs if isinstance(v, (Number, Tensor))
                          if v.dtype != 'real')
-        real_subs = tuple((k, v) for k, v in subs if isinstance(v, constant)
+        real_subs = tuple((k, v) for k, v in subs if isinstance(v, (Number, Tensor))
                           if v.dtype == 'real')
-        if not (int_subs or real_subs):
+        if not (var_subs or int_subs or real_subs):
             return None  # entirely lazy
 
-        # First perform any integer substitution, i.e. slicing into a batch.
+        # First perform any variable substitutions.
+        if var_subs:
+            rename = {k: v.name for k, v in var_subs}
+            targets = frozenset(rename.values())
+            for k, v in int_subs + real_subs + lazy_subs:
+                if not targets.isdisjoint(v.inputs):
+                    raise NotImplementedError('TODO alpha-convert')
+            inputs = OrderedDict((rename.get(k, k), d) for k, d in self.inputs.items())
+            if len(inputs) != len(self.inputs):
+                raise ValueError("Variable substitution name conflict")
+            var_result = Gaussian(self.loc, self.precision, inputs)
+            return Subs(var_result, int_subs + real_subs + lazy_subs)
+
+        # Next perform any integer substitution, i.e. slicing into a batch.
         if int_subs:
             int_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype != 'real')
             real_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype == 'real')

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -62,8 +62,6 @@ class Joint(Funsor):
         self.gaussian = gaussian
 
     def eager_subs(self, subs):
-        gaussian = Subs(self.gaussian, subs)
-        assert isinstance(gaussian, (Number, Tensor, Gaussian))
         discrete = Subs(self.discrete, subs)
         gaussian = Subs(self.gaussian, subs)
         deltas = []
@@ -129,9 +127,8 @@ class Joint(Funsor):
 
     def unscaled_sample(self, sampled_vars, sample_inputs=None):
         discrete_vars = sampled_vars.intersection(self.discrete.inputs)
-        gaussian_vars = frozenset(k for k in sampled_vars
-                                  if k in self.gaussian.inputs
-                                  if self.gaussian.inputs[k].dtype == 'real')
+        gaussian_vars = frozenset(k for k, v in self.gaussian.inputs.items()
+                                  if k in sampled_vars if v.dtype == 'real')
         result = self
         if discrete_vars:
             discrete = result.discrete.unscaled_sample(discrete_vars, sample_inputs)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -4,6 +4,7 @@ import functools
 import itertools
 import math
 import numbers
+import re
 from collections import Hashable, OrderedDict
 from weakref import WeakValueDictionary
 
@@ -155,7 +156,7 @@ class Funsor(object):
                 for x in arg:
                     x._pretty(lines, indent + 2)
             else:
-                lines.append((indent + 1, str(arg)))
+                lines.append((indent + 1, re.sub('\n\\s*', ' ', str(arg))))
 
     def pretty(self):
         lines = []
@@ -271,12 +272,13 @@ class Funsor(object):
     def unscaled_sample(self, sampled_vars, sample_inputs=None):
         """
         Internal method to draw an unscaled sample.
+        This should be overridden by subclasses.
         """
         assert self.output == reals()
         assert isinstance(sampled_vars, frozenset)
         if sampled_vars.isdisjoint(self.inputs):
             return self
-        raise NotImplementedError
+        raise TypeError("Cannot sample from a {}".format(type(self).__name__))
 
     def align(self, names):
         """
@@ -606,6 +608,13 @@ class Subs(Funsor):
         new_subs = tuple((k, v) for k, v in subs if k not in self.subs)
         subs = old_subs + new_subs
         return Subs(self.arg, subs) if subs else self.arg
+
+    def unscaled_sample(self, sampled_vars, sample_inputs=None):
+        if sample_inputs is not None:
+            if any(k in sample_inputs for k, v in self.subs):
+                raise NotImplementedError('TODO alpha-convert')
+        arg = self.arg.unscaled_sample(sampled_vars, sample_inputs)
+        return Subs(arg, self.subs)
 
 
 @lazy.register(Subs, Funsor, object)
@@ -952,6 +961,35 @@ def of_shape(*shape):
     per function arg.
     """
     return functools.partial(_of_shape, shape=shape)
+
+
+################################################################################
+# Register Ops
+################################################################################
+
+@ops.abs.register(Funsor)
+def _abs(x):
+    return Unary(ops.abs, x)
+
+
+@ops.sqrt.register(Funsor)
+def _sqrt(x):
+    return Unary(ops.sqrt, x)
+
+
+@ops.exp.register(Funsor)
+def _exp(x):
+    return Unary(ops.exp, x)
+
+
+@ops.log.register(Funsor)
+def _log(x):
+    return Unary(ops.log, x)
+
+
+@ops.log1p.register(Funsor)
+def _log1p(x):
+    return Unary(ops.log1p, x)
 
 
 __all__ = [

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -613,8 +613,19 @@ class Subs(Funsor):
         if sample_inputs is not None:
             if any(k in sample_inputs for k, v in self.subs):
                 raise NotImplementedError('TODO alpha-convert')
-        arg = self.arg.unscaled_sample(sampled_vars, sample_inputs)
-        return Subs(arg, self.subs)
+        subs_sampled_vars = set()
+        for name in sampled_vars:
+            if name in self.arg.inputs:
+                if any(name in v.inputs for k, v in self.subs.items()):
+                    raise ValueError("Cannot sample")
+                subs_sampled_vars.add(name)
+            else:
+                for k, v in self.subs.items():
+                    if name in v.inputs:
+                        subs_sampled_vars.add(k)
+        subs_sampled_vars = frozenset(subs_sampled_vars)
+        arg = self.arg.unscaled_sample(subs_sampled_vars, sample_inputs)
+        return Subs(arg, tuple(self.subs.items()))
 
 
 @lazy.register(Subs, Funsor, object)

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 from six.moves import reduce
 
+from funsor.delta import Delta
 from funsor.domains import Domain, bint, reals
 from funsor.gaussian import Gaussian
 from funsor.joint import Joint
@@ -55,15 +56,19 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
 
     if isinstance(actual, (Number, Tensor)):
         assert_close(actual.data, expected.data, atol=atol, rtol=rtol)
+    elif isinstance(actual, Delta):
+        assert actual.name == expected.name
+        assert_close(actual.point, expected.point, atol=atol, rtol=rtol)
+        assert_close(actual.log_density, expected.log_density, atol=atol, rtol=rtol)
     elif isinstance(actual, Gaussian):
         assert_close(actual.loc, expected.loc, atol=atol, rtol=rtol)
         assert_close(actual.precision, expected.precision, atol=atol, rtol=rtol)
     elif isinstance(actual, Joint):
-        actual_deltas = {d.name: d.point for d in actual.deltas}
-        expected_deltas = {d.name: d.point for d in expected.deltas}
+        actual_deltas = {d.name: d for d in actual.deltas}
+        expected_deltas = {d.name: d for d in expected.deltas}
         assert set(actual_deltas) == set(expected_deltas)
-        for name, actual_point in actual_deltas.items():
-            assert_close(actual_point, expected_deltas[name])
+        for name, actual_delta in actual_deltas.items():
+            assert_close(actual_delta, expected_deltas[name])
         assert_close(actual.discrete, expected.discrete, atol=atol, rtol=rtol)
         assert_close(actual.gaussian, expected.gaussian, atol=atol, rtol=rtol)
     elif isinstance(actual, torch.Tensor):

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -468,11 +468,8 @@ def materialize(x):
         return x
     subs = []
     for name, domain in x.inputs.items():
-        if not isinstance(domain.dtype, integer_types):
-            raise ValueError('materialize() requires integer free variables but found '
-                             '"{}" of domain {}'.format(name, domain))
-        assert not domain.shape
-        subs.append((name, arange(name, domain.dtype)))
+        if isinstance(domain.dtype, integer_types):
+            subs.append((name, arange(name, domain.dtype)))
     subs = tuple(subs)
     return Subs(x, subs)
 

--- a/test/test_delta.py
+++ b/test/test_delta.py
@@ -7,7 +7,7 @@ import funsor.ops as ops
 from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.terms import Number, Variable
-from funsor.testing import check_funsor
+from funsor.testing import assert_close, check_funsor
 from funsor.torch import Tensor
 
 
@@ -49,3 +49,19 @@ def test_reduce_density(log_density):
     d = Delta('foo', point, log_density)
     # Note that log_density affects ground substitution but does not affect reduction.
     assert d.reduce(ops.logaddexp, frozenset(['foo'])) is Number(0)
+
+
+def test_transform_exp():
+    point = Tensor(torch.randn(10).abs())
+    x = Variable('x', reals(10))
+    actual = Delta('y', point)(y=ops.exp(x))
+    expected = Delta('x', point.log(), point.log().sum())
+    assert_close(actual, expected)
+
+
+def test_transform_log():
+    point = Tensor(torch.randn(10))
+    x = Variable('x', reals(10))
+    actual = Delta('y', point)(y=ops.log(x))
+    expected = Delta('x', point.exp(), -point.sum())
+    assert_close(actual, expected)

--- a/test/test_delta.py
+++ b/test/test_delta.py
@@ -51,17 +51,19 @@ def test_reduce_density(log_density):
     assert d.reduce(ops.logaddexp, frozenset(['foo'])) is Number(0)
 
 
-def test_transform_exp():
-    point = Tensor(torch.randn(10).abs())
-    x = Variable('x', reals(10))
+@pytest.mark.parametrize('shape', [(), (4,), (2, 3)], ids=str)
+def test_transform_exp(shape):
+    point = Tensor(torch.randn(shape).abs())
+    x = Variable('x', reals(*shape))
     actual = Delta('y', point)(y=ops.exp(x))
     expected = Delta('x', point.log(), point.log().sum())
     assert_close(actual, expected)
 
 
-def test_transform_log():
-    point = Tensor(torch.randn(10))
-    x = Variable('x', reals(10))
+@pytest.mark.parametrize('shape', [(), (4,), (2, 3)], ids=str)
+def test_transform_log(shape):
+    point = Tensor(torch.randn(shape))
+    x = Variable('x', reals(*shape))
     actual = Delta('y', point)(y=ops.log(x))
     expected = Delta('x', point.exp(), -point.sum())
     assert_close(actual, expected)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -119,6 +119,18 @@ def test_eager_subs(int_inputs, real_inputs):
         assert_close(actual, expected, atol=1e-4)
 
 
+def test_eager_subs_variable():
+    inputs = OrderedDict([('i', bint(2)), ('x', reals()), ('y', reals(2))])
+    g1 = random_gaussian(inputs)
+
+    g2 = g1(x='z')
+    assert set(g2.inputs) == {'i', 'y', 'z'}
+
+    g2 = g1(x='y', y='x')
+    assert set(g2.inputs) == {'i', 'x', 'y'}
+    assert g2.inputs['x'] == reals(2)
+
+
 @pytest.mark.parametrize('int_inputs', [
     {},
     {'i': bint(2)},


### PR DESCRIPTION
Addresses issues with #78, #100

This PR starts to implement transformed distributions as lazy substitution.
1. `Gaussian` now supports lazy substitution, e.g. `LogNormal(m,s)=Normal(m,s)(value=exp(value))`. This is implemented as new logic in `Gaussian.eager_subs`.
2. Sampling from transformed distributions is enabled by a new method `Subs.unscaled_sample()` and new logic in `Delta.eager_subs()`. The `Delta.eager_subs()` logic relies on a new `funsor.delta.solve()` function that computes inverses. Currently inverses are implemented only for `ops.exp()` and `ops.log()` analogous to `ExpTransform` and `ExpTransform().inv`; future inverse can be registered via `@solve.register(...)`.

This PR does not make changes to `Joint` that will be needed to perform inference with transformed distributions. We defer that restructuring of `Joint` to a future PR.

## Questions

- [x] Is `Delta.eager_subs()` the right place to insert `log_abs_det_jacobian`?

## Tests
- [x] tests for `Delta` substitution
- [x] tests for `Gaussian` substitution
- [x] tests for sampling from a transformed `Gaussian`
- [x] test for a `LogNormal` density

## Triaged
- ~~test  for `LogNormal` sampler~~
    I've added an xfailing test. `LogNormal(...).sample()` is blocked on `Joint` being able to incorporate transformed distributions, which I'll implement in a follow-up PR.