### PR TITLE
Make distributions lazy when used Pyro-style

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -11,7 +11,8 @@ import funsor.delta
 import funsor.ops as ops
 from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
-from funsor.terms import Funsor, FunsorMeta, Number, Subs, Variable, eager, to_funsor
+from funsor.interpreter import interpretation
+from funsor.terms import Funsor, FunsorMeta, Number, Subs, Variable, eager, lazy, to_funsor
 from funsor.torch import Tensor, align_tensors, materialize
 
 
@@ -36,9 +37,18 @@ class DistributionMeta(FunsorMeta):
     Wrapper to fill in default values and convert Numbers to Tensors.
     """
     def __call__(cls, *args, **kwargs):
-        args = cls._fill_defaults(*args, **kwargs)
+        kwargs.update(zip(cls._ast_fields, args))
+        args = cls._fill_defaults(**kwargs)
         args = numbers_to_tensors(*args)
-        return super(DistributionMeta, cls).__call__(*args)
+
+        # If value was explicitly specified, evaluate under current interpretation.
+        if 'value' in kwargs:
+            return super(DistributionMeta, cls).__call__(*args)
+
+        # Otherwise lazily construct a distribution instance.
+        # This makes it cheaper to construct observations in minipyro.
+        with interpretation(lazy):
+            return super(DistributionMeta, cls).__call__(*args)
 
 
 @add_metaclass(DistributionMeta)
@@ -133,7 +143,7 @@ class Delta(Distribution):
         if value is None:
             value = Variable('value', reals())
         else:
-            value = to_funsor(value)
+            value = to_funsor(value, v.dtype)
         return v, log_density, value
 
     def __init__(self, v, log_density=0, value=None):
@@ -205,6 +215,7 @@ def eager_normal(loc, scale, value):
         loc, value = value, loc
 
     inputs, (loc, scale) = align_tensors(loc, scale)
+    loc, scale = torch.broadcast_tensors(loc, scale)
     inputs.update(value.inputs)
     int_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype != 'real')
 
@@ -220,7 +231,7 @@ def eager_normal(loc, scale, value):
 def eager_normal(loc, scale, value):
     if not isinstance(loc, Tensor):
         loc, value = value, loc
-    return Normal(loc, scale)(value=value)
+    return Normal(loc, scale, None)(value=value)
 
 
 # Create a Gaussian from a noisy identity transform.

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -49,8 +49,9 @@ def test_categorical_density(size, batch_shape):
 def test_delta_defaults():
     v = Variable('v', reals())
     log_density = Variable('log_density', reals())
+    assert isinstance(dist.Delta(v, log_density), dist.Delta)
     value = Variable('value', reals())
-    assert dist.Delta(v, log_density) is dist.Delta(v, log_density, value)
+    assert dist.Delta(v, log_density, None) is dist.Delta(v, log_density, value)
 
 
 @pytest.mark.parametrize('event_shape', [(), (4,), (3, 2)], ids=str)
@@ -153,7 +154,7 @@ def test_normal_gaussian_1(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.Normal(loc, scale)
+    g = dist.Normal(loc, scale, None)
     assert isinstance(g, Joint)
     actual = g(value=value)
     check_funsor(actual, inputs, reals())
@@ -195,7 +196,7 @@ def test_normal_gaussian_3(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.Normal(Variable('loc', reals()), scale)
+    g = dist.Normal(Variable('loc', reals()), scale, None)
     assert isinstance(g, Joint)
     actual = g(loc=loc, value=value)
     check_funsor(actual, inputs, reals())
@@ -250,7 +251,7 @@ def test_mvn_gaussian(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.MultivariateNormal(loc, scale_tril)
+    g = dist.MultivariateNormal(loc, scale_tril, None)
     assert isinstance(g, Joint)
     actual = g(value=value)
     check_funsor(actual, inputs, reals())


### PR DESCRIPTION
Unblocks #57 

This makes distributions lazy when used Pyro-style, but keeps them eager when used Funsor-style.

In Pyro we construct distributions without specifying the variable name:
```py
fn = dist.Normal(0, 1)    # from a pyro.sample statement
log_prob += fn(value)     # from an internal elbo computation
```
Whereas in Funsor we idiomatically name the variate
```py
factor = dist.Normal(0, 1, Variable('x', reals()))
log_prob += factor
```
Prior to this PR, `dist.Normal(0,1)` would eagerly compile to a `Gaussian`. After this PR, `dist.Normal(0,1)` remains an inspectable `Normal` distribution until its value is substituted (possibly for another variable), e.g. in the second line above.

Advantage of this PR include:
1. We can avoid some computation (currently not even implemented, and inevitable numerically unstable) in pyro observe statements whose parameters are delayed variables, since a large (rank deficient) Gaussian will never be constructed. Instead we will wait until an observation is available as in the above example elbo computation.
2. Pyro statements will be a little more debuggable since the original distribution will be available.

This may seem a little gross, but I see it as a way for funsor.distributions to be used in both older pyro-style and newer funsor-style with no conflict (e.g. no funsor.compat.distributions shim).

## Questions

- [x] Should we instead simply disallow specifying the variate in the `__init__` method?
    This way all distributions would be lazily constructed, and could be converted to e.g. `Gaussian` or `Joint` by substitution of `variable`.

## Tested
- updated existing tests
- added a new delta check
- ran in `pyro/examples/minipyro.py --backend=funsor`