### PR TITLE
Implement plate reductions for Gaussian, Joint

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -335,10 +335,13 @@ class Gaussian(Funsor):
             precision = Tensor(self.precision, old_ints).reduce(ops.add, reduced_vars)
             precision_loc = Tensor(_mv(self.precision, self.loc),
                                    old_ints).reduce(ops.add, reduced_vars)
+            assert precision.inputs == new_ints
+            assert precision_loc.inputs == new_ints
             loc = Tensor(_sym_solve_mv(precision.data, precision_loc.data), new_ints)
             expanded_loc = align_tensor(old_ints, loc)
             quadratic_term = Tensor(_vmv(self.precision, expanded_loc - self.loc),
                                     old_ints).reduce(ops.add, reduced_vars)
+            assert quadratic_term.inputs == new_ints
             likelihood = -0.5 * quadratic_term
             return likelihood + Gaussian(loc.data, precision.data, inputs)
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-import sys
+import warnings
 from collections import OrderedDict
 
-import six
 import torch
 from pyro.distributions.util import broadcast_shape
 from six import add_metaclass, integer_types
@@ -72,11 +71,15 @@ def _sym_solve_mv(mat, vec):
         tri = torch.inverse(torch.cholesky(mat))
         return _mv(tri.transpose(-1, -2), _mv(tri, vec))
     except RuntimeError as e:
-        if 'not positive definite' not in e.message:
-            _, exc_value, traceback = sys.exc_info()
-            six.reraise(RuntimeError, e, traceback)
+        warnings.warn(e.message, RuntimeWarning)
 
     # Fall back to pseudoinverse.
+    if mat.size(-1) == 1:
+        mat = mat.squeeze(-1)
+        mat, vec = torch.broadcast_tensors(mat, vec)
+        result = vec / mat
+        result[(mat != 0) == 0] = 0
+        return result
     return _mv(torch.pinverse(mat), vec)
 
 
@@ -270,6 +273,9 @@ class Gaussian(Funsor):
             assert result.output == reals()
             return Subs(result, lazy_subs)
 
+        # Perform a partial substution of a subset of real variables, resulting in a Joint.
+        # See "The Matrix Cookbook" (November 15, 2012) ss. 8.1.3 eq. 353.
+        # http://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf
         raise NotImplementedError('TODO implement partial substitution of real variables')
 
     @lazy_property
@@ -317,7 +323,24 @@ class Gaussian(Funsor):
             return result.reduce(ops.logaddexp, reduced_ints)
 
         elif op is ops.add:
-            raise NotImplementedError('TODO product-reduce along a plate dimension')
+            for v in reduced_vars:
+                if self.inputs[v].dtype == 'real':
+                    raise ValueError("Cannot sum along a real dimension: {}".format(repr(v)))
+
+            # Fuse Gaussians along a plate. Compare to eager_add_gaussian_gaussian().
+            old_ints = OrderedDict((k, v) for k, v in self.inputs.items() if v.dtype != 'real')
+            new_ints = OrderedDict((k, v) for k, v in old_ints.items() if k not in reduced_vars)
+            inputs = OrderedDict((k, v) for k, v in self.inputs.items() if k not in reduced_vars)
+
+            precision = Tensor(self.precision, old_ints).reduce(ops.add, reduced_vars)
+            precision_loc = Tensor(_mv(self.precision, self.loc),
+                                   old_ints).reduce(ops.add, reduced_vars)
+            loc = Tensor(_sym_solve_mv(precision.data, precision_loc.data), new_ints)
+            expanded_loc = align_tensor(old_ints, loc)
+            quadratic_term = Tensor(_vmv(self.precision, expanded_loc - self.loc),
+                                    old_ints).reduce(ops.add, reduced_vars)
+            likelihood = -0.5 * quadratic_term
+            return likelihood + Gaussian(loc.data, precision.data, inputs)
 
         return None  # defer to default implementation
 

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -121,7 +121,10 @@ class Joint(Funsor):
                 return eager_result.reduce(ops.logaddexp, lazy_vars)
 
         if op is ops.add:
-            raise NotImplementedError('TODO product-reduce along a plate dimension')
+            terms = list(self.deltas) + [self.discrete, self.gaussian]
+            for i, term in enumerate(terms):
+                terms[i] = term.reduce(ops.add, reduced_vars.intersection(term.inputs))
+            return reduce(ops.add, terms)
 
         return None  # defer to default implementation
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -222,6 +222,22 @@ def test_add_gaussian_gaussian(lhs_inputs, rhs_inputs):
     assert_close((g1 + g2)(**values), g1(**values) + g2(**values), atol=1e-4, rtol=None)
 
 
+@pytest.mark.parametrize('inputs', [
+    OrderedDict([('i', bint(2)), ('x', reals())]),
+    OrderedDict([('i', bint(3)), ('x', reals())]),
+    OrderedDict([('i', bint(2)), ('x', reals(2))]),
+    OrderedDict([('i', bint(2)), ('x', reals()), ('y', reals())]),
+    OrderedDict([('i', bint(3)), ('j', bint(4)), ('x', reals(2))]),
+], ids=id_from_inputs)
+def test_reduce_add(inputs):
+    g = random_gaussian(inputs)
+    actual = g.reduce(ops.add, 'i')
+
+    gs = [g(i=i) for i in range(g.inputs['i'].dtype)]
+    expected = reduce(ops.add, gs)
+    assert_close(actual, expected)
+
+
 @pytest.mark.parametrize('int_inputs', [
     {},
     {'i': bint(2)},
@@ -233,7 +249,7 @@ def test_add_gaussian_gaussian(lhs_inputs, rhs_inputs):
     {'x': reals(4), 'y': reals(2, 3), 'z': reals()},
     {'w': reals(5), 'x': reals(4), 'y': reals(2, 3), 'z': reals()},
 ], ids=id_from_inputs)
-def test_logsumexp(int_inputs, real_inputs):
+def test_reduce_logsumexp(int_inputs, real_inputs):
     int_inputs = OrderedDict(sorted(int_inputs.items()))
     real_inputs = OrderedDict(sorted(real_inputs.items()))
     inputs = int_inputs.copy()


### PR DESCRIPTION
Addresses #57 

This also adds a more stable scalar case for `_sym_solve_mv()`.

## Tested
- [x] ran under `pyro/examples/minipyro.py --backend=funsor`
- [x] unit test for `Gaussian` plate reduction
- [x] unit test for `Joint` plate reduction