### PR TITLE
Support event_dim kwarg in pyro.param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
           pip install https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl;
       fi
 
-    # Remove after public release of https://github.com/pyro-ppl/pyro/pull/1796
-    - pip install https://github.com/pyro-ppl/pyro/archive/local-param.zip
+    # Remove after public release of https://github.com/pyro-ppl/pyro/pull/1794
+    - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
 
     - pip install .[test]
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
           pip install https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl;
       fi
 
-    # Remove after public release of https://github.com/pyro-ppl/pyro/pull/1794
-    - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
+    # Remove after public release of https://github.com/pyro-ppl/pyro/pull/1796
+    - pip install https://github.com/pyro-ppl/pyro/archive/local-param.zip
 
     - pip install .[test]
     - pip freeze


### PR DESCRIPTION
Based on https://github.com/pyro-ppl/pyro/pull/1796

This supports local params via `pyro.param(..., event_dim=...)`.

This is needed in funsor.minipyro so that batched parameters can correctly receive a name, as in `test_local_param_ok` below.

One design choice in funsor.minipyro is whether we try to keep most objects `torch.Tensor`s or instead eagerly convert to `Funsor`s whenever possible. This PR moves towards the latter after this PR **all `pyro.sample` and `pyro.param` statements  return `Funsor`s**. This is motivated by our desire to overload as many ops as possible; e.g. we can only overload `x.__getitem__()` if x is a `Funsor`, so it helps for mixture models if the return values from `pyro.param()` are `Funsor`s.

Note the hack to support `pyro.param("name")` without `init_value` as used e.g. to extract params. The param store saves a `._funsor_cond_indep_stack` and `._funsor_output` on the initial value, so the initial call must be correctly placed in `pyro.plate` context. This doesn't support calling `pyro.param` in two differently named plate contexts (as pointed out by @eb8680), but I believe we never use that feature in user code.

## Tested
- added test for local param
- added check for `pyro.param("name")` after learning, outside of inference