### PR TITLE
Change to_funsor's second arg from dtype to Domain

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -104,16 +104,12 @@ class Categorical(Distribution):
     dist_class = dist.Categorical
 
     @staticmethod
-    def _fill_defaults(probs, value=None):
+    def _fill_defaults(probs, value='value'):
         probs = to_funsor(probs)
-        if value is None:
-            size = probs.output.shape[0]
-            value = Variable('value', bint(size))
-        else:
-            value = to_funsor(value)
+        value = to_funsor(value, bint(probs.output.shape[0]))
         return probs, value
 
-    def __init__(self, probs, value=None):
+    def __init__(self, probs, value='value'):
         super(Categorical, self).__init__(probs, value)
 
 
@@ -137,16 +133,13 @@ class Delta(Distribution):
     dist_class = dist.Delta
 
     @staticmethod
-    def _fill_defaults(v, log_density=0, value=None):
+    def _fill_defaults(v, log_density=0, value='value'):
         v = to_funsor(v)
         log_density = to_funsor(log_density)
-        if value is None:
-            value = Variable('value', reals())
-        else:
-            value = to_funsor(value, v.dtype)
+        value = to_funsor(value, v.output)
         return v, log_density, value
 
-    def __init__(self, v, log_density=0, value=None):
+    def __init__(self, v, log_density=0, value='value'):
         return super(Delta, self).__init__(v, log_density, value)
 
 
@@ -174,7 +167,7 @@ def eager_delta(v, log_density, value):
     return funsor.delta.Delta(v.name, value, log_density)
 
 
-def LogNormal(loc, scale, value=None):
+def LogNormal(loc, scale, value='value'):
     loc, scale, y = Normal._fill_defaults(loc, scale, value)
     t = ops.exp
     x = t.inv(y)
@@ -186,19 +179,15 @@ class Normal(Distribution):
     dist_class = dist.Normal
 
     @staticmethod
-    def _fill_defaults(loc, scale, value=None):
+    def _fill_defaults(loc, scale, value='value'):
         loc = to_funsor(loc)
         scale = to_funsor(scale)
         assert loc.output == reals()
         assert scale.output == reals()
-        if value is None:
-            value = Variable('value', reals())
-        else:
-            value = to_funsor(value)
-        assert value.output == loc.output
+        value = to_funsor(value, loc.output)
         return loc, scale, value
 
-    def __init__(self, loc, scale, value=None):
+    def __init__(self, loc, scale, value='value'):
         super(Normal, self).__init__(loc, scale, value)
 
 
@@ -231,7 +220,7 @@ def eager_normal(loc, scale, value):
 def eager_normal(loc, scale, value):
     if not isinstance(loc, Tensor):
         loc, value = value, loc
-    return Normal(loc, scale, None)(value=value)
+    return Normal(loc, scale, 'value')(value=value)
 
 
 # Create a Gaussian from a noisy identity transform.
@@ -257,7 +246,7 @@ class MultivariateNormal(Distribution):
     dist_class = dist.MultivariateNormal
 
     @staticmethod
-    def _fill_defaults(loc, scale_tril, value=None):
+    def _fill_defaults(loc, scale_tril, value='value'):
         loc = to_funsor(loc)
         scale_tril = to_funsor(scale_tril)
         assert loc.dtype == 'real'
@@ -265,14 +254,10 @@ class MultivariateNormal(Distribution):
         assert len(loc.output.shape) == 1
         dim = loc.output.shape[0]
         assert scale_tril.output.shape == (dim, dim)
-        if value is None:
-            value = Variable('value', reals(dim))
-        else:
-            value = to_funsor(value)
-        assert value.output == loc.output
+        value = to_funsor(value, loc.output)
         return loc, scale_tril, value
 
-    def __init__(self, loc, scale_tril, value=None):
+    def __init__(self, loc, scale_tril, value='value'):
         super(MultivariateNormal, self).__init__(loc, scale_tril, value)
 
 

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -196,9 +196,13 @@ def to_funsor(x):
     return Array(x)
 
 
-@dispatch(np.ndarray, object)
-def to_funsor(x, dtype):
-    return Array(x, dtype=dtype)
+@dispatch(np.ndarray, Domain)
+def to_funsor(x, output):
+    result = Array(x, dtype=output.dtype)
+    if result.output != output:
+        raise ValueError("Invalid shape: expected {}, actual {}"
+                         .format(output.shape, result.output.shape))
+    return result
 
 
 @to_data.register(Array)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -311,9 +311,13 @@ def to_funsor(x):
     return Tensor(x)
 
 
-@dispatch(torch.Tensor, object)
-def to_funsor(x, dtype):
-    return Tensor(x, dtype=dtype)
+@dispatch(torch.Tensor, Domain)
+def to_funsor(x, output):
+    result = Tensor(x, dtype=output.dtype)
+    if result.output != output:
+        raise ValueError("Invalid shape: expected {}, actual {}"
+                         .format(output.shape, result.output.shape))
+    return result
 
 
 @to_data.register(Tensor)
@@ -553,7 +557,7 @@ def _nested_function(fn, args, output):
             fn_i.__name__ = "{}_{}".format(fn_i, i)
             result.append(_nested_function(fn_i, args, output_i))
         return LazyTuple(result)
-    raise TypeError("Invalid output: {}".format(output))
+    raise ValueError("Invalid output: {}".format(output))
 
 
 class _Memoized(object):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -51,7 +51,7 @@ def test_delta_defaults():
     log_density = Variable('log_density', reals())
     assert isinstance(dist.Delta(v, log_density), dist.Delta)
     value = Variable('value', reals())
-    assert dist.Delta(v, log_density, None) is dist.Delta(v, log_density, value)
+    assert dist.Delta(v, log_density, 'value') is dist.Delta(v, log_density, value)
 
 
 @pytest.mark.parametrize('event_shape', [(), (4,), (3, 2)], ids=str)
@@ -154,7 +154,7 @@ def test_normal_gaussian_1(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.Normal(loc, scale, None)
+    g = dist.Normal(loc, scale, 'value')
     assert isinstance(g, Joint)
     actual = g(value=value)
     check_funsor(actual, inputs, reals())
@@ -196,7 +196,7 @@ def test_normal_gaussian_3(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.Normal(Variable('loc', reals()), scale, None)
+    g = dist.Normal(Variable('loc', reals()), scale, 'value')
     assert isinstance(g, Joint)
     actual = g(loc=loc, value=value)
     check_funsor(actual, inputs, reals())
@@ -251,7 +251,7 @@ def test_mvn_gaussian(batch_shape):
     assert isinstance(expected, Tensor)
     check_funsor(expected, inputs, reals())
 
-    g = dist.MultivariateNormal(loc, scale_tril, None)
+    g = dist.MultivariateNormal(loc, scale_tril, 'value')
     assert isinstance(g, Joint)
     actual = g(value=value)
     check_funsor(actual, inputs, reals())

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -15,6 +15,9 @@ def test_to_funsor(shape, dtype):
     t = np.random.normal(size=shape).astype(dtype)
     f = funsor.to_funsor(t)
     assert isinstance(f, Array)
+    assert funsor.to_funsor(t, reals(*shape)) is f
+    with pytest.raises(ValueError):
+        funsor.to_funsor(t, reals(5, *shape))
 
 
 def test_to_data():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -20,6 +20,9 @@ def test_to_funsor(shape, dtype):
     t = torch.randn(shape).type(dtype)
     f = funsor.to_funsor(t)
     assert isinstance(f, Tensor)
+    assert funsor.to_funsor(t, reals(*shape)) is f
+    with pytest.raises(ValueError):
+        funsor.to_funsor(t, reals(5, *shape))
 
 
 def test_to_data():


### PR DESCRIPTION
This changes the second arg of `to_funsor` from a dtype to a `Domain` object (= dtype+shape).

After this PR we can do a kludgey sort of type inference and type checking of arguments:
- strings can be promoted to `Variable`s of appropriate `.output` (not only correct dtype)
- `Tensor`s and `Array`s can do early type checking when being converted
- `Distribution` type promotion can be simpler

This is motivated by code in `Lambda` #97 in service of the VAE example #95 . This PR makes `Lambda` and `Uncurry` code and tests much simpler. 

## Tested

- [x] refactoring is exercised by existing tests
- [x] added new assertions for `Array` and `Tensor` tests
