### PR TITLE
Simplify .unscaled_sample() interface

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -347,7 +347,7 @@ class Gaussian(Funsor):
 
         return None  # defer to default implementation
 
-    def unscaled_sample(self, sampled_vars, sample_inputs=None):
+    def unscaled_sample(self, sampled_vars, sample_inputs):
         # Sample only the real variables.
         sampled_vars = frozenset(k for k, v in self.inputs.items()
                                  if k in sampled_vars if v.dtype == 'real')
@@ -355,11 +355,8 @@ class Gaussian(Funsor):
             return self
 
         # Partition inputs into sample_inputs + int_inputs + real_inputs.
-        if sample_inputs is None:
-            sample_inputs = OrderedDict()
-        else:
-            sample_inputs = OrderedDict((k, d) for k, d in sample_inputs.items()
-                                        if k not in self.inputs)
+        sample_inputs = OrderedDict((k, d) for k, d in sample_inputs.items()
+                                    if k not in self.inputs)
         sample_shape = tuple(int(d.dtype) for d in sample_inputs.values())
         int_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype != 'real')
         real_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if d.dtype == 'real')

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -128,10 +128,7 @@ class Joint(Funsor):
 
         return None  # defer to default implementation
 
-    def unscaled_sample(self, sampled_vars, sample_inputs=None):
-        if sample_inputs is None:
-            sample_inputs = OrderedDict()
-
+    def unscaled_sample(self, sampled_vars, sample_inputs):
         discrete_vars = sampled_vars.intersection(self.discrete.inputs)
         gaussian_vars = frozenset(k for k, v in self.gaussian.inputs.items()
                                   if k in sampled_vars if v.dtype == 'real')

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -256,6 +256,9 @@ class Funsor(object):
         """
         assert self.output == reals()
         assert isinstance(sampled_vars, frozenset)
+        if sample_inputs is None:
+            sample_inputs = OrderedDict()
+        assert isinstance(sample_inputs, OrderedDict)
         if sampled_vars.isdisjoint(self.inputs):
             return self
 
@@ -269,13 +272,14 @@ class Funsor(object):
                 result += log_scale
         return result
 
-    def unscaled_sample(self, sampled_vars, sample_inputs=None):
+    def unscaled_sample(self, sampled_vars, sample_inputs):
         """
         Internal method to draw an unscaled sample.
         This should be overridden by subclasses.
         """
         assert self.output == reals()
         assert isinstance(sampled_vars, frozenset)
+        assert isinstance(sample_inputs, OrderedDict)
         if sampled_vars.isdisjoint(self.inputs):
             return self
         raise TypeError("Cannot sample from a {}".format(type(self).__name__))
@@ -609,10 +613,9 @@ class Subs(Funsor):
         subs = old_subs + new_subs
         return Subs(self.arg, subs) if subs else self.arg
 
-    def unscaled_sample(self, sampled_vars, sample_inputs=None):
-        if sample_inputs is not None:
-            if any(k in sample_inputs for k, v in self.subs):
-                raise NotImplementedError('TODO alpha-convert')
+    def unscaled_sample(self, sampled_vars, sample_inputs):
+        if any(k in sample_inputs for k, v in self.subs):
+            raise NotImplementedError('TODO alpha-convert')
         subs_sampled_vars = set()
         for name in sampled_vars:
             if name in self.arg.inputs:

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -242,18 +242,15 @@ class Tensor(Funsor):
             return Tensor(data, inputs, self.dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 
-    def unscaled_sample(self, sampled_vars, sample_inputs=None):
+    def unscaled_sample(self, sampled_vars, sample_inputs):
         assert self.output == reals()
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self
 
         # Partition inputs into sample_inputs + batch_inputs + event_inputs.
-        if sample_inputs is None:
-            sample_inputs = OrderedDict()
-        else:
-            sample_inputs = OrderedDict((k, d) for k, d in sample_inputs.items()
-                                        if k not in self.inputs)
+        sample_inputs = OrderedDict((k, d) for k, d in sample_inputs.items()
+                                    if k not in self.inputs)
         sample_shape = tuple(int(d.dtype) for d in sample_inputs.values())
         batch_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if k not in sampled_vars)
         event_inputs = OrderedDict((k, d) for k, d in self.inputs.items() if k in sampled_vars)


### PR DESCRIPTION
This refactors the `.unscaled_sample()` interface to be simpler in that it assumes `sample_inputs` is not None. This makes internal `.unscaled_sample()` implementations simpler, since they can hide behind the user-facing `.sample()` interface.

This also fixes a logic bug that arose up in #97 