### PR TITLE
Add an Affine term to represent multilinear functions of real Variables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,6 @@ import sys
 
 import sphinx_rtd_theme
 
-
 # import pkg_resources
 
 # -*- coding: utf-8 -*-

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -8,6 +8,7 @@ from funsor.torch import Tensor, arange, torch_einsum
 
 from . import (
     adjoint,
+    affine,
     contract,
     delta,
     distributions,
@@ -36,6 +37,7 @@ __all__ = [
     'Tensor',
     'Variable',
     'adjoint',
+    'affine',
     'arange',
     'backward',
     'bint',

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -8,6 +8,7 @@ from funsor.terms import (
     Binary,
     Funsor,
     Number,
+    Subs,
     Unary,
     Variable,
     eager,
@@ -33,7 +34,11 @@ class Affine(Funsor):
         self.const = const
 
     def eager_subs(self, subs):
-        raise NotImplementedError("TODO")
+        if any(name in self.coeffs for name, sub in subs):
+            raise NotImplementedError("TODO handle coefficient substitution")
+        const = Subs(self.const, subs)
+        coeffs = tuple((name, Subs(coeff, subs)) for name, coeff in self.coeffs.items())
+        return Affine(const, coeffs)
 
 
 @eager.register(Affine, (Number, Tensor), tuple)

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -5,15 +5,7 @@ from collections import OrderedDict
 import funsor.ops as ops
 from funsor.domains import find_domain
 from funsor.ops import NegOp, Op
-from funsor.terms import (
-    Binary,
-    Funsor,
-    Number,
-    Subs,
-    Unary,
-    Variable,
-    eager,
-)
+from funsor.terms import Binary, Funsor, Number, Subs, Unary, Variable, eager
 from funsor.torch import Tensor
 
 
@@ -135,7 +127,7 @@ def eager_binary_variable_affine(op, other, affine):
         return affine + other
 
     if op is ops.sub:
-        return other + -affine
+        return -affine + other
 
     return None
 
@@ -195,7 +187,7 @@ def eager_binary(op, other, var):
     if op is ops.add or op is ops.mul:
         return op(var, other)
     elif op is ops.sub:
-        return other + -var
+        return -var + other
     return None
 
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -1,0 +1,172 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import OrderedDict
+
+import funsor.ops as ops
+from funsor.ops import NegOp, Op
+from funsor.terms import (
+    Binary,
+    Funsor,
+    Number,
+    Unary,
+    Variable,
+    eager,
+)
+from funsor.torch import Tensor
+
+
+class Affine(Funsor):
+
+    def __init__(self, const, coeffs):
+        assert isinstance(const, (Number, Tensor))
+        assert isinstance(coeffs, tuple)
+        inputs = const.inputs.copy()
+        for name, coeff in coeffs:
+            assert isinstance(name, str)
+            assert isinstance(coeff, (Number, Tensor))
+            inputs.update(coeff.inputs)
+            inputs[name] = coeff.output
+
+        output = const.output
+        super(Affine, self).__init__(inputs, output)
+        self.coeffs = OrderedDict(coeffs)
+        self.const = const
+
+    def eager_subs(self, subs):
+        raise NotImplementedError("TODO")
+
+
+@eager.register(Affine, (Number, Tensor), tuple)
+def eager_affine(const, coeffs):
+    if not coeffs:
+        return const
+    return None
+
+
+@eager.register(Binary, Op, Affine, (Number, Tensor))
+def eager_binary_affine(op, lhs, rhs):
+    if op is ops.add or op is ops.sub:
+        const = op(lhs.const, rhs)
+        return Affine(const, tuple(lhs.coeffs.items()))
+    if op is ops.mul or op is ops.div:
+        const = op(lhs.const, rhs)
+        coeffs = tuple((name, op(coeff, rhs)) for name, coeff in lhs.coeffs.items())
+        return Affine(const, coeffs)
+    return None
+
+
+@eager.register(Binary, Op, (Number, Tensor), Affine)
+def eager_binary_affine(op, lhs, rhs):
+    if op is ops.add:
+        const = lhs + rhs.const
+        return Affine(const, tuple(rhs.coeffs.items()))
+    elif op is ops.sub:
+        return lhs + -rhs
+    if op is ops.mul:
+        const = lhs * rhs.const
+        coeffs = tuple((name, lhs * coeff) for name, coeff in rhs.coeffs.items())
+        return Affine(const, coeffs)
+    return None
+
+
+@eager.register(Binary, Op, Affine, Affine)
+def eager_binary_affine_affine(op, lhs, rhs):
+    if op is ops.add:
+        const = lhs.const + rhs.const
+        coeffs = lhs.coeffs.copy()
+        for name, coeff in rhs.coeffs.items():
+            if name in coeffs:
+                coeffs[name] += coeff
+            else:
+                coeffs[name] = coeff
+        return Affine(const, tuple(coeffs.items()))
+
+    if op is ops.sub:
+        return lhs + -rhs
+
+    return None
+
+
+@eager.register(Binary, Op, Affine, Variable)
+def eager_binary_affine_variable(op, affine, other):
+    if op is ops.add:
+        const = affine.const
+        coeffs = affine.coeffs.copy()
+        if other.name in affine.inputs:
+            coeffs[other.name] += 1.
+        else:
+            coeffs[other.name] = Number(1.)
+        return Affine(const, tuple(coeffs.items()))
+
+    if op is ops.sub:
+        return affine + -other
+
+    return None
+
+
+@eager.register(Binary, Op, Variable, Affine)
+def eager_binary_variable_affine(op, other, affine):
+    if op is ops.add:
+        return affine + other
+
+    if op is ops.sub:
+        return other + -affine
+
+    return None
+
+
+@eager.register(Unary, NegOp, Affine)
+def eager_negate_affine(op, affine):
+    const = -affine.const
+    coeffs = affine.coeffs.copy()
+    for name, coeff in coeffs.items():
+        coeffs[name] = -coeff
+    return Affine(const, tuple(coeffs.items()))
+
+
+#########################################
+# patterns for creating new Affine terms
+#########################################
+
+@eager.register(Binary, Op, Variable, (Number, Tensor))
+def eager_binary(op, var, other):
+    if op is ops.add:
+        const = other
+        coeffs = ((var.name, Number(1.)),)
+        return Affine(const, coeffs)
+    elif op is ops.mul:
+        const = Number(0.)
+        coeffs = ((var.name, other),)
+        return Affine(const, coeffs)
+    elif op is ops.sub:
+        return var + -other
+    elif op is ops.div:
+        return var * ops.invert(other)
+    return None
+
+
+@eager.register(Binary, Op, Variable, Variable)
+def eager_binary(op, lhs, rhs):
+    if op is ops.add:
+        const = Number(0.)
+        coeffs = ((lhs.name, Number(1.)), (rhs.name, Number(1.)))
+        return Affine(const, coeffs)
+    elif op is ops.sub:
+        return lhs + -rhs
+    return None
+
+
+@eager.register(Binary, Op, (Number, Tensor), Variable)
+def eager_binary(op, other, var):
+    if op is ops.add or op is ops.mul:
+        return op(var, other)
+    elif op is ops.sub:
+        return other + -var
+    return None
+
+
+@eager.register(Unary, NegOp, Variable)
+def eager_negate_variable(op, var):
+    const = Number(0.)
+    coeffs = ((var.name, Number(-1.)),)
+    return Affine(const, coeffs)

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -6,7 +6,7 @@ from contextlib2 import contextmanager
 
 from funsor.integrate import Integrate, integrator
 from funsor.interpreter import dispatched_interpretation, interpretation
-from funsor.terms import eager, Funsor
+from funsor.terms import Funsor, eager
 
 
 @dispatched_interpretation

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -8,6 +8,7 @@ import torch
 from funsor.affine import Affine
 from funsor.domains import bint, reals
 from funsor.terms import Number, Variable
+from funsor.testing import check_funsor
 from funsor.torch import Tensor
 
 
@@ -40,3 +41,36 @@ def test_smoke(expr, expected_type):
 
     result = eval(expr)
     assert isinstance(result, expected_type)
+
+
+SUBS_TESTS = [
+    ("(t * x)(i=1)", Affine, {"j": bint(3), "x": reals()}, reals()),
+    ("(t * x)(i=1, x=y)", Affine, {"j": bint(3), "y": reals()}, reals()),
+    ("(t * x + n)(x=y)", Affine, {"y": reals(), "i": bint(2), "j": bint(3)}, reals()),
+    ("(x + y)(y=z)", Affine, {"x": reals(), "z": reals()}, reals()),
+    ("(-x)(x=y+z)", Affine, {"y": reals(), "z": reals()}, reals()),
+    ("(t * x + t * y)(x=z)", Affine, {"y": reals(), "z": reals(), "i": bint(2), "j": bint(3)}, reals()),
+]
+
+
+@pytest.mark.parametrize("expr,expected_type,expected_inputs,expected_output", SUBS_TESTS)
+def test_affine_subs(expr, expected_type, expected_inputs, expected_output):
+
+    t = Tensor(torch.randn(2, 3), OrderedDict([('i', bint(2)), ('j', bint(3))]))
+    assert isinstance(t, Tensor)
+
+    n = Number(2.)
+    assert isinstance(n, Number)
+
+    x = Variable('x', reals())
+    assert isinstance(x, Variable)
+
+    y = Variable('y', reals())
+    assert isinstance(y, Variable)
+
+    z = Variable('z', reals())
+    assert isinstance(z, Variable)
+
+    result = eval(expr)
+    assert isinstance(result, expected_type)
+    check_funsor(result, expected_inputs, expected_output)

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -11,7 +11,6 @@ from funsor.terms import Number, Variable
 from funsor.testing import check_funsor
 from funsor.torch import Tensor
 
-
 SMOKE_TESTS = [
     ('t+x', Affine),
     ('x+t', Affine),
@@ -44,17 +43,19 @@ def test_smoke(expr, expected_type):
 
 
 SUBS_TESTS = [
-    ("(t * x)(i=1)", Affine, {"j": bint(3), "x": reals()}, reals()),
-    ("(t * x)(i=1, x=y)", Affine, {"j": bint(3), "y": reals()}, reals()),
-    ("(t * x + n)(x=y)", Affine, {"y": reals(), "i": bint(2), "j": bint(3)}, reals()),
-    ("(x + y)(y=z)", Affine, {"x": reals(), "z": reals()}, reals()),
-    ("(-x)(x=y+z)", Affine, {"y": reals(), "z": reals()}, reals()),
-    ("(t * x + t * y)(x=z)", Affine, {"y": reals(), "z": reals(), "i": bint(2), "j": bint(3)}, reals()),
+    ("(t * x)(i=1)", Affine, {"j": bint(3), "x": reals()}),
+    ("(t * x)(i=1, x=y)", Affine, {"j": bint(3), "y": reals()}),
+    ("(t * x + n)(x=y)", Affine, {"y": reals(), "i": bint(2), "j": bint(3)}),
+    ("(x + y)(y=z)", Affine, {"x": reals(), "z": reals()}),
+    ("(-x)(x=y+z)", Affine, {"y": reals(), "z": reals()}),
+    ("(t * x + t * y)(x=z)", Affine, {"y": reals(), "z": reals(), "i": bint(2), "j": bint(3)}),
 ]
 
 
-@pytest.mark.parametrize("expr,expected_type,expected_inputs,expected_output", SUBS_TESTS)
-def test_affine_subs(expr, expected_type, expected_inputs, expected_output):
+@pytest.mark.parametrize("expr,expected_type,expected_inputs", SUBS_TESTS)
+def test_affine_subs(expr, expected_type, expected_inputs):
+
+    expected_output = reals()
 
     t = Tensor(torch.randn(2, 3), OrderedDict([('i', bint(2)), ('j', bint(3))]))
     assert isinstance(t, Tensor)

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -11,12 +11,6 @@ from funsor.terms import Number, Variable
 from funsor.torch import Tensor
 
 
-def id_from_inputs(inputs):
-    if not inputs:
-        return '()'
-    return ','.join(k + ''.join(map(str, d.shape)) for k, d in inputs.items())
-
-
 SMOKE_TESTS = [
     ('t+x', Affine),
     ('x+t', Affine),

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import OrderedDict
+
+import pytest
+import torch
+
+from funsor.affine import Affine
+from funsor.domains import bint, reals
+from funsor.terms import Number, Variable
+from funsor.torch import Tensor
+
+
+def id_from_inputs(inputs):
+    if not inputs:
+        return '()'
+    return ','.join(k + ''.join(map(str, d.shape)) for k, d in inputs.items())
+
+
+SMOKE_TESTS = [
+    ('t+x', Affine),
+    ('x+t', Affine),
+    ('n+x', Affine),
+    ('n*x', Affine),
+    ('t*x', Affine),
+    ('x*t', Affine),
+    ('-x', Affine),
+    ('t-x', Affine),
+]
+
+
+@pytest.mark.parametrize('expr,expected_type', SMOKE_TESTS)
+def test_smoke(expr, expected_type):
+
+    t = Tensor(torch.randn(2, 3), OrderedDict([('i', bint(2)), ('j', bint(3))]))
+    assert isinstance(t, Tensor)
+
+    n = Number(2.)
+    assert isinstance(n, Number)
+
+    x = Variable('x', reals())
+    assert isinstance(x, Variable)
+
+    y = Variable('y', reals())
+    assert isinstance(y, Variable)
+
+    result = eval(expr)
+    assert isinstance(result, expected_type)

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
+from unification import unify
+
 from funsor.domains import reals
 from funsor.interpreter import interpretation, reinterpret
-from funsor.terms import Number, Variable, lazy
-
 from funsor.pattern import match, match_vars, unify_interpreter
-from unification import unify
+from funsor.terms import Number, Variable, lazy
 
 
 def test_unify_binary():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,8 +9,7 @@ import torch
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.interpreter import interpretation
-from funsor.terms import Lambda, Number, Variable, lazy
+from funsor.terms import Lambda, Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import REDUCE_OP_TO_TORCH, Tensor, align_tensors, torch_einsum
 
@@ -163,10 +162,9 @@ def test_advanced_indexing_lazy(output_shape):
     ]))
     u = Variable('u', bint(2))
     v = Variable('v', bint(3))
-    with interpretation(lazy):
-        i = Number(1, 2) - u
-        j = Number(2, 3) - v
-        k = u + v
+    i = Number(1, 2) - u
+    j = Number(2, 3) - v
+    k = u + v
 
     expected_data = torch.empty((2, 3) + output_shape)
     i_data = funsor.torch.materialize(i).data

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,7 +9,8 @@ import torch
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.terms import Lambda, Number, Variable
+from funsor.interpreter import interpretation
+from funsor.terms import Lambda, Number, Variable, lazy
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import REDUCE_OP_TO_TORCH, Tensor, align_tensors, torch_einsum
 
@@ -162,9 +163,10 @@ def test_advanced_indexing_lazy(output_shape):
     ]))
     u = Variable('u', bint(2))
     v = Variable('v', bint(3))
-    i = Number(1, 2) - u
-    j = Number(2, 3) - v
-    k = u + v
+    with interpretation(lazy):
+        i = Number(1, 2) - u
+        j = Number(2, 3) - v
+        k = u + v
 
     expected_data = torch.empty((2, 3) + output_shape)
     i_data = funsor.torch.materialize(i).data


### PR DESCRIPTION
Pair coded with @fritzo.  Addresses #72.

This PR adds an `Affine` term for representing multilinear functions of `Variable`s and includes it in the `eager` interpretation by default.

Tasks:
- [x] Implement `eager_subs`
- [x] Fix tests that were broken by changes to `eager`