### PR TITLE
Support wrapping PyTorch builtin functions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -587,6 +587,15 @@ def test_function_nested_lazy():
     assert_close(actual_argmax, expected_argmax)
 
 
+def test_function_of_torch_tensor():
+    x = torch.randn(4, 3)
+    y = torch.randn(3, 2)
+    f = funsor.torch.function(reals(4, 3), reals(3, 2), reals(4, 2))(torch.matmul)
+    actual = f(x, y)
+    expected = f(Tensor(x), Tensor(y))
+    assert_close(actual, expected)
+
+
 def test_align():
     x = Tensor(torch.randn(2, 3, 4), OrderedDict([
         ('i', bint(2)),


### PR DESCRIPTION
Addresses #83 

This adds support for PyTorch builtin functions to `funsor.torch.function`. Before this PR `function(reals(2,3), reals(3,4), reals(2,4))(torch.matmul)` would fail due to [cpython limitations](https://docs.python.org/3.7/library/inspect.html#inspect.signature). However PyTorch functions contain name metadata in the standardized `.__doc__` attribute. This PR falls back to attempting to extract arg names from the docstring.

## Tested
- added a unit test