### PR TITLE
Add model and guide auxiliary variable elimination to minipyro.elbo

### DIFF
--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -212,17 +212,6 @@ class log_joint(Messenger):
             self.plates.update(f.name for f in msg["cond_indep_stack"].values())
 
 
-class EnumerateMessenger(Messenger):
-
-    def process_message(self, msg):
-        if msg["type"] == "sample" and msg["value"] is None:
-            if (msg["infer"].get("exact", None) or
-                    msg["infer"].get("enumerate", None) == "parallel"):
-                msg["value"] = funsor.Variable(msg["name"], msg["fn"].output)
-            else:
-                msg["value"] = msg["fn"](*msg["args"])  # default to eager
-
-
 # apply_stack is called by pyro.sample and pyro.param.
 # It is responsible for applying each Messenger to each effectful operation.
 def apply_stack(msg):
@@ -493,10 +482,8 @@ class TraceMeanField_ELBO(ELBO):
 
 
 class TraceEnum_ELBO(ELBO):
-    def __call__(self, model, guide, *args, **kwargs):
-        model = EnumerateMessenger(model)
-        guide = EnumerateMessenger(guide)
-        return elbo(model, guide, *args, **kwargs)
+    # TODO allow mixing of sampling and exact integration
+    pass
 
 
 # This is a PyTorch jit wrapper that (1) delays tracing until the first

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -216,12 +216,11 @@ class EnumerateMessenger(Messenger):
 
     def process_message(self, msg):
         if msg["type"] == "sample" and msg["value"] is None:
-            if msg["infer"].get("enumerate", None) == "parallel":
+            if (msg["infer"].get("exact", None) or
+                    msg["infer"].get("enumerate", None) == "parallel"):
                 msg["value"] = funsor.Variable(msg["name"], msg["fn"].output)
-            elif msg["infer"].get("enumerate", None) is None:
-                msg["value"] = msg["fn"](*msg["args"])  # default to eager
             else:
-                raise ValueError("{} not a supported enumeration type".format(msg["infer"]["enumerate"]))
+                msg["value"] = msg["fn"](*msg["args"])  # default to eager
 
 
 # apply_stack is called by pyro.sample and pyro.param.
@@ -495,6 +494,8 @@ class TraceMeanField_ELBO(ELBO):
 
 class TraceEnum_ELBO(ELBO):
     def __call__(self, model, guide, *args, **kwargs):
+        model = EnumerateMessenger(model)
+        guide = EnumerateMessenger(guide)
         return elbo(model, guide, *args, **kwargs)
 
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -81,9 +81,6 @@ def partial_sum_product(sum_op, prod_op, factors, eliminate=frozenset(), plates=
                     *(var_to_ordinal[v] for v in remaining_sum_vars))
                 if new_plates == leaf:
                     raise ValueError("intractable!")
-                if not (leaf - new_plates).issubset(eliminate):
-                    raise ValueError("cannot reduce {} before {}".format(
-                        remaining_sum_vars, (leaf - new_plates) - eliminate))
                 f = f.reduce(prod_op, leaf - new_plates)
                 ordinal_to_factors[new_plates].append(f)
 

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -477,7 +477,10 @@ def test_elbo_enumerate_plate_7(backend):
 
 @pytest.mark.xfail(reason="missing patterns")
 @pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
-@pytest.mark.parametrize("exact", [False, True], ids=["exact", "monte-carlo"])
+@pytest.mark.parametrize("exact", [
+    True,
+    xfail_param(False, reason="mixed sampling and exact not implemented yet")
+], ids=["exact", "monte-carlo"])
 def test_gaussian_probit_hmm_smoke(exact, jit):
 
     def model(data):

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -477,7 +477,8 @@ def test_elbo_enumerate_plate_7(backend):
 
 @pytest.mark.xfail(reason="missing patterns")
 @pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
-def test_gaussian_probit_hmm_smoke(jit):
+@pytest.mark.parametrize("exact", [False, True], ids=["exact", "monte-carlo"])
+def test_gaussian_probit_hmm_smoke(exact, jit):
 
     def model(data):
         T, N, D = data.shape  # time steps, individuals, features
@@ -506,7 +507,7 @@ def test_gaussian_probit_hmm_smoke(jit):
                     scale_tril = noise
                 state = pyro.sample("state_{}".format(t),
                                     dist.MultivariateNormal(loc, scale_tril),
-                                    infer={"enumerate": "parallel"})
+                                    infer={"exact": exact})
 
                 # Factorial probit likelihood model.
                 with obs_plate:
@@ -517,7 +518,7 @@ def test_gaussian_probit_hmm_smoke(jit):
     def guide(data):
         pass
 
-    data = torch.distributions.Bernoulli(0.5).sample((10, 8, 4))
+    data = torch.distributions.Bernoulli(0.5).sample((3, 4, 2))
 
     with pyro_backend("funsor"):
         Elbo = infer.JitTraceEnum_ELBO if jit else infer.TraceEnum_ELBO

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -385,10 +385,7 @@ def test_elbo_enumerate_plates_1(backend):
         _check_loss_and_grads(hand_loss, auto_loss)
 
 
-@pytest.mark.parametrize('backend', [
-    "pyro",
-    xfail_param("funsor", reason="sum-product is failing somehow???"),
-])
+@pytest.mark.parametrize('backend', ["pyro", "funsor"])
 def test_elbo_enumerate_plate_7(backend):
     #  Guide    Model
     #    a -----> b
@@ -478,7 +475,7 @@ def test_elbo_enumerate_plate_7(backend):
         _check_loss_and_grads(hand_loss, auto_loss)
 
 
-@pytest.mark.xfail(reason="sum-product error: reduce sum_var before plate_var")
+@pytest.mark.xfail(reason="missing patterns")
 @pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 def test_gaussian_probit_hmm_smoke(jit):
 


### PR DESCRIPTION
This exploratory PR adds a few lines of code to `minipyro.elbo` that integrate out auxiliary variables in the model and guide, as in `pyro.infer.TraceEnum_ELBO`.

## Tasks
- [x] Add an example or two
- [x] Add tests

## Triaged
- Troubleshoot performance issues
- Switch to using Expectation term #132 
- Mixed sampling and exact integration in `elbo`