### PR TITLE
Support constraints in funsor.minipyro

### DIFF
--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -256,9 +256,8 @@ def param(name, init_value=None, constraint=None, event_dim=None):
             value = PARAM_STORE[name]
         else:
             value = PARAM_STORE.setdefault(name, init_value, constraint)
-            value._funsor_cond_indep_stack = cond_indep_stack
-            value._funsor_output = output
-        return tensor_to_funsor(value, value._funsor_cond_indep_stack, value._funsor_output)
+            value.unconstrained()._funsor_metadata = (cond_indep_stack, output)
+        return tensor_to_funsor(value, *value.unconstrained()._funsor_metadata)
 
     # if there are no active Messengers, we just draw a sample and return it as expected:
     if not PYRO_STACK:

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function
 from collections import OrderedDict, namedtuple
 
 import torch
+from pyro.params.param_store import ParamStoreDict
 
 import funsor
 
@@ -60,7 +61,7 @@ class Distribution(object):
 #     See http://docs.pyro.ai/en/0.3.1/parameters.html
 
 PYRO_STACK = []
-PARAM_STORE = {}
+PARAM_STORE = ParamStoreDict()  # A dict-like object that also supports constraints.
 
 
 def get_param_store():
@@ -240,35 +241,35 @@ def sample(name, fn, obs=None):
 
 # param is an effectful version of PARAM_STORE.setdefault
 # When any effect handlers are active, it constructs an initial message and calls apply_stack.
-def param(name, init_value=None, event_dim=None):
+def param(name, init_value=None, constraint=None, event_dim=None):
     cond_indep_stack = {}
     output = None
     if init_value is not None:
         if event_dim is None:
             event_dim = init_value.dim()
         output = funsor.reals(*init_value.shape[init_value.dim() - event_dim:])
+    if constraint is None:
+        constraint = torch.distributions.constraints.real
 
-    def fn(init_value):
-        if name in PARAM_STORE:
+    def fn(init_value, constraint):
+        if init_value is None:
             value = PARAM_STORE[name]
         else:
-            assert isinstance(init_value, torch.Tensor)
-            value = init_value.requires_grad_()
-            PARAM_STORE[name] = value
+            value = PARAM_STORE.setdefault(name, init_value, constraint)
             value._funsor_cond_indep_stack = cond_indep_stack
             value._funsor_output = output
         return tensor_to_funsor(value, value._funsor_cond_indep_stack, value._funsor_output)
 
     # if there are no active Messengers, we just draw a sample and return it as expected:
     if not PYRO_STACK:
-        return fn(init_value)
+        return fn(init_value, constraint)
 
     # Otherwise, we initialize a message...
     initial_msg = {
         "type": "param",
         "name": name,
         "fn": fn,
-        "args": (init_value,),
+        "args": (init_value, constraint),
         "value": None,
         "cond_indep_stack": cond_indep_stack,  # maps dim to CondIndepStackFrame
         "output": output,
@@ -334,7 +335,8 @@ class SVI(object):
         # Differentiate the loss.
         loss.data.backward()
         # Grab all the parameters from the trace.
-        params = [site["value"].data for site in param_capture.values()]
+        params = [site["value"].data.unconstrained()
+                  for site in param_capture.values()]
         # Take a step w.r.t. each parameter in params.
         self.optim(params)
         # Zero out the gradients so that they don't accumulate.

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -21,7 +21,8 @@ def assert_ok(model, guide, elbo, *args, **kwargs):
     pyro.get_param_store().clear()
     adam = optim.Adam({"lr": 1e-6})
     inference = infer.SVI(model, guide, adam, elbo)
-    inference.step(*args, **kwargs)
+    for i in range(2):
+        inference.step(*args, **kwargs)
 
 
 def assert_error(model, guide, elbo, match=None):

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -4,6 +4,7 @@ import warnings
 
 import pytest
 import torch
+from torch.distributions import constraints
 from pyro.generic import distributions as dist
 from pyro.generic import infer, optim, pyro, pyro_backend
 
@@ -119,11 +120,7 @@ def test_plate_ok(backend):
         assert_ok(model, guide, elbo)
 
 
-@pytest.mark.parametrize("backend", [
-    "pyro",
-    "minipyro",
-    xfail_param("funsor", reason="missing patterns"),
-])
+@pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
 def test_nested_plate_plate_ok(backend):
     data = torch.randn(2, 3)
 
@@ -169,6 +166,26 @@ def test_local_param_ok(backend):
         expected = guide()
         actual = pyro.param("p")
         assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("backend", ["pyro", "funsor"])
+def test_constraints(backend):
+    data = torch.tensor(0.5)
+
+    def model():
+        locs = pyro.param("locs", torch.randn(3), constraint=constraints.real)
+        scales = pyro.param("scales", torch.randn(3).exp(), constraint=constraints.positive)
+        p = torch.tensor([0.5, 0.3, 0.2])
+        x = pyro.sample("x", dist.Categorical(p))
+        pyro.sample("obs", dist.Normal(locs[x], scales[x]), obs=data)
+
+    def guide():
+        q = pyro.param("q", torch.randn(3).exp(), constraint=constraints.simplex)
+        pyro.sample("x", dist.Categorical(q))
+
+    with pyro_backend(backend):
+        elbo = infer.Trace_ELBO()
+        assert_ok(model, guide, elbo)
 
 
 @pytest.mark.parametrize("backend", [


### PR DESCRIPTION
This enables constraints in `pyro.param` statements backed by funsor.minipyro.

I've avoided recreating the tricky constraint logic and simply imported Pyro's `ParamStoreDict`. This seems not too bad since the `ParamStoreDict` is independent of the rest of Pyro.

The motivation is to enable learning of constrained parameters e.g. probability distributions of discrete distributions. I had tried to port the Kalman Filter example to funsor.minipyro, but it looked gross to store unconstrained parameters in the param store. After this PR it should be easier to create a KF example to use minipyro.

## Tested
- [x] added a smoke test
- [x] updated minipyro tests to run for 2 iterations so as to test both cases:
    param not found (on step 1); param found (on step 2)