### PR TITLE
Remove dependency on pyro ParamStoreDict

### DIFF
--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -48,7 +48,8 @@ def main(args):
         # Report the final values of the variational parameters
         # in the guide after training.
         if args.verbose:
-            for name, value in pyro.get_param_store().items():
+            for name in pyro.get_param_store():
+                value = pyro.param(name).data
                 print("{} = {}".format(name, value.detach().cpu().numpy()))
 
         # For this simple (conjugate) model we know the exact posterior. In

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -169,7 +169,7 @@ def test_local_param_ok(backend):
         assert_close(actual, expected)
 
 
-@pytest.mark.parametrize("backend", ["pyro", "funsor"])
+@pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
 def test_constraints(backend):
     data = torch.tensor(0.5)
 


### PR DESCRIPTION
Replaces #128 by making funsor.minipyro closer to pyro.contrib.minipyro https://github.com/pyro-ppl/pyro/pull/1820 , as suggested by @eb8680 .

## Tested

- [x] updated examples/minipyro.py
- [x] added a test case to test/test_minipyro.py