### PR TITLE
Add JitTrace_ELBO class to minipyro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: lint FORCE
 	python examples/kalman_filter.py -n 2
 	python examples/kalman_filter.py -n 2 -t 50 --lazy
 	python examples/minipyro.py
-	@#python examples/minipyro.py --jit
+	python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50
 	python examples/pcfg.py --size 3
 	python examples/vae.py --smoke-test

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: lint FORCE
 	python examples/kalman_filter.py -n 2
 	python examples/kalman_filter.py -n 2 -t 50 --lazy
 	python examples/minipyro.py
+	@#python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50
 	python examples/pcfg.py --size 3
 	python examples/vae.py --smoke-test

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ autodoc_default_options = {
     'show-inheritance': True,
     'special-members': True,
     'undoc-members': True,
-    'exclude-members': '__dict__',
+    'exclude-members': '__dict__,__module__,__weakref__',
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,14 @@ extensions = [
 
 autodoc_inherit_docstrings = False
 
+autodoc_default_options = {
+    'member-order': 'bysource',
+    'show-inheritance': True,
+    'special-members': True,
+    'undoc-members': True,
+    'exclude-members': '__dict__',
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -5,6 +5,7 @@ import argparse
 import torch
 from pyro.generic import distributions as dist
 from pyro.generic import infer, optim, pyro, pyro_backend
+from torch.distributions import constraints
 
 from funsor.interpreter import interpretation
 from funsor.montecarlo import monte_carlo
@@ -22,7 +23,8 @@ def main(args):
     # distribution over the latent random variable `loc`.
     def guide(data):
         guide_loc = pyro.param("guide_loc", torch.tensor(0.))
-        guide_scale = pyro.param("guide_scale_log", torch.tensor(0.)).exp()
+        guide_scale = pyro.param("guide_scale", torch.tensor(1.),
+                                 constraint=constraints.positive)
         pyro.sample("loc", dist.Normal(guide_loc, guide_scale))
 
     # Generate some data.
@@ -34,7 +36,8 @@ def main(args):
     with pyro_backend(args.backend), interpretation(monte_carlo):
         # Construct an SVI object so we can do variational inference on our
         # model/guide pair.
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if args.jit else infer.Trace_ELBO
+        elbo = Elbo()
         adam = optim.Adam({"lr": args.learning_rate})
         svi = infer.SVI(model, guide, adam, elbo)
 
@@ -63,6 +66,7 @@ if __name__ == "__main__":
     parser.add_argument("-b", "--backend", default="funsor")
     parser.add_argument("-n", "--num-steps", default=1001, type=int)
     parser.add_argument("-lr", "--learning-rate", default=0.02, type=float)
+    parser.add_argument("--jit", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
     main(args)

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -8,8 +8,6 @@ import torch
 from pyro.distributions.util import broadcast_shape
 from six import add_metaclass
 
-from pyro.distributions.util import broadcast_shape
-
 import funsor.delta
 import funsor.ops as ops
 from funsor.affine import Affine
@@ -17,7 +15,7 @@ from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import interpretation
 from funsor.terms import Funsor, FunsorMeta, Number, Subs, Variable, eager, lazy, to_funsor
-from funsor.torch import Tensor, align_tensors, materialize, torch_stack
+from funsor.torch import Tensor, align_tensors, ignore_jit_warnings, materialize, torch_stack
 
 
 def numbers_to_tensors(*args):
@@ -31,8 +29,9 @@ def numbers_to_tensors(*args):
             if isinstance(x, Tensor):
                 new_tensor = x.data.new_tensor
                 break
-        args = tuple(Tensor(new_tensor(x.data), dtype=x.dtype) if isinstance(x, Number) else x
-                     for x in args)
+        with ignore_jit_warnings():
+            args = tuple(Tensor(new_tensor(x.data), dtype=x.dtype) if isinstance(x, Number) else x
+                         for x in args)
     return args
 
 

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -9,6 +9,7 @@ from six.moves import reduce
 
 import funsor.ops as ops
 from funsor.util import lazy_property
+import torch
 
 
 class Domain(namedtuple('Domain', ['shape', 'dtype'])):
@@ -18,7 +19,9 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     """
     def __new__(cls, shape, dtype):
         assert isinstance(shape, tuple)
-        assert all(isinstance(size, integer_types) for size in shape)
+        if torch._C._get_tracing_state():
+            shape = tuple(map(int, shape))
+        assert all(isinstance(size, integer_types) for size in shape), shape
         if isinstance(dtype, integer_types):
             assert not shape
         elif isinstance(dtype, str):
@@ -59,6 +62,8 @@ def bint(size):
     """
     Construct a bounded integer domain of scalar shape.
     """
+    if torch._C._get_tracing_state():
+        size = int(size)
     assert isinstance(size, integer_types) and size >= 0
     return Domain((), size)
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -152,7 +152,7 @@ def _parse_slices(index, value):
 class BlockVector(object):
     """
     Jit-compatible helper to build blockwise vectors.
-    Syntax is similar to :func:`torch.zeros`::
+    Syntax is similar to :func:`torch.zeros` ::
 
         x = BlockVector((100, 20))
         x[..., 0:4] = x1
@@ -185,9 +185,9 @@ class BlockVector(object):
 class BlockMatrix(object):
     """
     Jit-compatible helper to build blockwise matrices.
-    Syntax is similar to :func:`torch.zeros`::
+    Syntax is similar to :func:`torch.zeros` ::
 
-        x = BlockVector((100, 20, 20))
+        x = BlockMatrix((100, 20, 20))
         x[..., 0:4, 0:4] = x11
         x[..., 0:4, 6:10] = x12
         x[..., 6:10, 0:4] = x12.transpose(-1, -2)

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -13,7 +13,6 @@ found at examples/minipyro.py.
 """
 from __future__ import absolute_import, division, print_function
 
-import functools
 import warnings
 import weakref
 from collections import OrderedDict, namedtuple

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -13,10 +13,13 @@ found at examples/minipyro.py.
 """
 from __future__ import absolute_import, division, print_function
 
+import functools
+import warnings
 import weakref
 from collections import OrderedDict, namedtuple
 
 import torch
+from pyro.distributions import validation_enabled
 
 import funsor
 
@@ -46,9 +49,9 @@ class Distribution(object):
     # Similar to torch.distributions.Distribution.expand().
     def expand_inputs(self, name, size):
         if name in self.funsor_dist.inputs:
-            assert self.funsor_dist.inputs[name] == funsor.bint(size)
+            assert self.funsor_dist.inputs[name] == funsor.bint(int(size))
             return self
-        inputs = OrderedDict([(name, funsor.bint(size))])
+        inputs = OrderedDict([(name, funsor.bint(int(size)))])
         funsor_dist = self.funsor_dist + funsor.torch.Tensor(torch.zeros(size), inputs)
         return Distribution(funsor_dist)
 
@@ -105,12 +108,28 @@ class trace(Messenger):
     # trace illustrates why we need postprocess_message in addition to process_message:
     # We only want to record a value after all other effects have been applied
     def postprocess_message(self, msg):
-        assert msg["name"] not in self.trace, "all sites must have unique names"
+        assert msg["type"] != "sample" or msg["name"] not in self.trace, \
+            "sample sites must have unique names"
         self.trace[msg["name"]] = msg.copy()
 
     def get_trace(self, *args, **kwargs):
         self(*args, **kwargs)
         return self.trace
+
+
+# A second example of an effect handler for setting the value at a sample site.
+# This illustrates why effect handlers are a useful PPL implementation technique:
+# We can compose trace and replay to replace values but preserve distributions,
+# allowing us to compute the joint probability density of samples under a model.
+# See the definition of elbo(...) below for an example of this pattern.
+class replay(Messenger):
+    def __init__(self, fn, guide_trace):
+        self.guide_trace = guide_trace
+        super(replay, self).__init__(fn)
+
+    def process_message(self, msg):
+        if msg["name"] in self.guide_trace:
+            msg["value"] = self.guide_trace[msg["name"]]["value"]
 
 
 # block allows the selective application of effect handlers to different parts of a model.
@@ -153,6 +172,9 @@ def tensor_to_funsor(value, cond_indep_stack, output):
     assert isinstance(value, torch.Tensor)
     event_shape = output.shape
     batch_shape = value.shape[:value.dim() - len(event_shape)]
+    if torch._C._get_tracing_state():
+        with funsor.torch.ignore_jit_warnings():
+            batch_shape = tuple(map(int, batch_shape))
     inputs = OrderedDict()
     data = value
     for dim, size in enumerate(batch_shape):
@@ -161,7 +183,7 @@ def tensor_to_funsor(value, cond_indep_stack, output):
         else:
             frame = cond_indep_stack[dim - len(batch_shape)]
             assert size == frame.size, (size, frame)
-            inputs[frame.name] = funsor.bint(size)
+            inputs[frame.name] = funsor.bint(int(size))
     value = funsor.torch.Tensor(data, inputs, output.dtype)
     assert value.output == output
     return value
@@ -408,10 +430,68 @@ def elbo(model, guide, *args, **kwargs):
 
 
 # This is a wrapper for compatibility with full Pyro.
-def Trace_ELBO(*args, **kwargs):
+def Trace_ELBO(**kwargs):
     return elbo
 
 
-def TraceMeanField_ELBO(*args, **kwargs):
+def TraceMeanField_ELBO(**kwargs):
     # TODO Use exact KLs where possible.
     return elbo
+
+
+# This is a PyTorch jit wrapper that (1) delays tracing until the first
+# invocation, and (2) registers pyro.param() statements with torch.jit.trace.
+# This version does not support variable number of args or non-tensor kwargs.
+class Jit(object):
+    def __init__(self, fn, **kwargs):
+        self.fn = fn
+        self.ignore_jit_warnings = kwargs.pop("ignore_jit_warnings", False)
+        self._compiled = None
+        self._param_trace = None
+
+    def __call__(self, *args):
+        # On first call, initialize params and save their names.
+        if self._param_trace is None:
+            with block(), trace() as tr, block(hide_fn=lambda m: m["type"] != "param"):
+                self.fn(*args)
+            self._param_trace = tr
+
+        # Augment args with reads from the global param store.
+        unconstrained_params = tuple(param(name).data.unconstrained()
+                                     for name in self._param_trace)
+        params_and_args = unconstrained_params + args
+
+        # On first call, create a compiled elbo.
+        if self._compiled is None:
+
+            def compiled(*params_and_args):
+                unconstrained_params = params_and_args[:len(self._param_trace)]
+                args = params_and_args[len(self._param_trace):]
+                for name, unconstrained_param in zip(self._param_trace, unconstrained_params):
+                    constrained_param = param(name)  # assume param has been initialized
+                    assert constrained_param.data.unconstrained() is unconstrained_param
+                    self._param_trace[name]["value"] = constrained_param
+                result = replay(self.fn, guide_trace=self._param_trace)(*args)
+                assert not result.inputs
+                assert result.output == funsor.reals()
+                return result.data
+
+            with validation_enabled(False), warnings.catch_warnings():
+                if self.ignore_jit_warnings:
+                    warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
+                self._compiled = torch.jit.trace(compiled, params_and_args, check_trace=False)
+
+        data = self._compiled(*params_and_args)
+        return funsor.torch.Tensor(data)
+
+
+class JitTrace_ELBO(object):
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+        self._compiled = {}  # maps (model,guide) -> Jit instances
+
+    def __call__(self, model, guide, *args):
+        if (model, guide) not in self._compiled:
+            fn = functools.partial(elbo, model, guide)
+            self._compiled[model, guide] = Jit(fn, **self._kwargs)
+        return self._compiled[model, guide](*args)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             'flake8',
             'isort',
             'pytest>=4.1',
-            'sphinx',
+            'sphinx>=2.0',
             'sphinx_rtd_theme',
             'torchvision==0.2.1',
         ],

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -9,7 +9,7 @@ from six.moves import reduce
 
 import funsor.ops as ops
 from funsor.domains import bint, reals
-from funsor.gaussian import Gaussian
+from funsor.gaussian import BlockMatrix, BlockVector, Gaussian
 from funsor.integrate import Integrate
 from funsor.interpreter import interpretation
 from funsor.joint import Joint
@@ -17,6 +17,76 @@ from funsor.montecarlo import monte_carlo, monte_carlo_interpretation
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor, xfail_if_not_implemented
 from funsor.torch import Tensor
+
+
+def test_block_vector():
+    shape = (10,)
+    expected = torch.zeros(shape)
+    actual = BlockVector(shape)
+
+    expected[1] = torch.randn(())
+    actual[1] = expected[1]
+
+    expected[3:5] = torch.randn(2)
+    actual[3:5] = expected[3:5]
+
+    assert_close(actual.as_tensor(), expected)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)])
+def test_block_vector_batched(batch_shape):
+    shape = batch_shape + (10,)
+    expected = torch.zeros(shape)
+    actual = BlockVector(shape)
+
+    expected[..., 1] = torch.randn(batch_shape)
+    actual[..., 1] = expected[..., 1]
+
+    expected[..., 3:5] = torch.randn(batch_shape + (2,))
+    actual[..., 3:5] = expected[..., 3:5]
+
+    assert_close(actual.as_tensor(), expected)
+
+
+def test_block_matrix():
+    shape = (10, 10)
+    expected = torch.zeros(shape)
+    actual = BlockMatrix(shape)
+
+    expected[1, 1] = torch.randn(())
+    actual[1, 1] = expected[1, 1]
+
+    expected[1, 3:5] = torch.randn(2)
+    actual[1, 3:5] = expected[1, 3:5]
+
+    expected[3:5, 1] = torch.randn(2)
+    actual[3:5, 1] = expected[3:5, 1]
+
+    expected[3:5, 3:5] = torch.randn(2, 2)
+    actual[3:5, 3:5] = expected[3:5, 3:5]
+
+    assert_close(actual.as_tensor(), expected)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)])
+def test_block_matrix_batched(batch_shape):
+    shape = batch_shape + (10, 10)
+    expected = torch.zeros(shape)
+    actual = BlockMatrix(shape)
+
+    expected[..., 1, 1] = torch.randn(batch_shape)
+    actual[..., 1, 1] = expected[..., 1, 1]
+
+    expected[..., 1, 3:5] = torch.randn(batch_shape + (2,))
+    actual[..., 1, 3:5] = expected[..., 1, 3:5]
+
+    expected[..., 3:5, 1] = torch.randn(batch_shape + (2,))
+    actual[..., 3:5, 1] = expected[..., 3:5, 1]
+
+    expected[..., 3:5, 3:5] = torch.randn(batch_shape + (2, 2))
+    actual[..., 3:5, 3:5] = expected[..., 3:5, 3:5]
+
+    assert_close(actual.as_tensor(), expected)
 
 
 @pytest.mark.parametrize('expr,expected_type', [

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -84,8 +84,9 @@ def test_generate_data_plate(backend):
         assert 1.9 <= mean <= 2.1
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
-def test_nonempty_model_empty_guide_ok(backend):
+def test_nonempty_model_empty_guide_ok(backend, jit):
 
     def model(data):
         loc = pyro.param("loc", torch.tensor(0.0))
@@ -96,12 +97,14 @@ def test_nonempty_model_empty_guide_ok(backend):
 
     data = torch.tensor(2.)
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo, data)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
-def test_plate_ok(backend):
+def test_plate_ok(backend, jit):
     data = torch.randn(10)
 
     def model():
@@ -117,12 +120,14 @@ def test_plate_ok(backend):
             pyro.sample("x", dist.Categorical(p))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
-def test_nested_plate_plate_ok(backend):
+def test_nested_plate_plate_ok(backend, jit):
     data = torch.randn(2, 3)
 
     def model():
@@ -139,12 +144,14 @@ def test_nested_plate_plate_ok(backend):
             pyro.sample("x", dist.Normal(loc, scale))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "funsor"])
-def test_local_param_ok(backend):
+def test_local_param_ok(backend, jit):
     data = torch.randn(10)
 
     def model():
@@ -160,7 +167,8 @@ def test_local_param_ok(backend):
         return p
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
         # Check that pyro.param() can be called without init_value.
@@ -169,8 +177,9 @@ def test_local_param_ok(backend):
         assert_close(actual, expected)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro", "funsor"])
-def test_constraints(backend):
+def test_constraints(backend, jit):
     data = torch.tensor(0.5)
 
     def model():
@@ -185,7 +194,8 @@ def test_constraints(backend):
         pyro.sample("x", dist.Categorical(q))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
 


### PR DESCRIPTION
This adds a `JitTrace_ELBO` class to minipyro, following https://github.com/pyro-ppl/pyro/pull/1838

```
time    command line
------------------------------------------------------------
5.91s   python examples/minipyro.py
1.89s   python examples/minipyro.py --jit
1.35s   python examples/minipyro.py --backend=pyro
1.10s   python examples/minipyro.py --backend=pyro --jit
1.02s   python examples/minipyro.py --backend=minipyro
0.99s   python examples/minipyro.py --backend=minipyro --jit
```

Most of the work was in refactoring Gaussian math to be jit compatible. This was achieved with two new helpers `BlockVector` and `BlockMatrix` that wrap `torch.cat()` in syntax that looks like `torch.zeros` followed by in-place ops.

## Tasks
- [x] Add `JitTrace_ELBO` class
- [x] Update examples/minipyro.py
- [x] Fix type errors in `Domain`s
- [x] Work around in-place ops in `Normal`
- [x] Work around in-place ops in `Gaussian`

## Tested
- [x] unit tests in test_minipyro.py
- [x] updated examples/minipyro.py and added to `make test`
- [x] unit tests for `BlockVector` and `BlockMatrix`