### PR TITLE
Add BernoulliLogits distribution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -119,8 +119,27 @@ class Bernoulli(Distribution):
 
 
 @eager.register(Bernoulli, Tensor, Tensor)
-def eager_categorical(probs, value):
+def eager_bernoulli(probs, value):
     return Bernoulli.eager_log_prob(probs=probs, value=value)
+
+
+class BernoulliLogits(Distribution):
+    dist_class = dist.Bernoulli
+
+    @staticmethod
+    def _fill_defaults(logits, value='value'):
+        logits = to_funsor(logits)
+        assert logits.dtype == "real"
+        value = to_funsor(value, reals())
+        return logits, value
+
+    def __init__(self, logits, value=None):
+        super(BernoulliLogits, self).__init__(logits, value)
+
+
+@eager.register(BernoulliLogits, Tensor, Tensor)
+def eager_bernoulli_logits(logits, value):
+    return BernoulliLogits.eager_log_prob(logits=logits, value=value)
 
 
 class Beta(Distribution):
@@ -444,6 +463,7 @@ def eager_mvn(loc, scale_tril, value):
 
 __all__ = [
     'Bernoulli',
+    'BernoulliLogits',
     'Beta',
     'Binomial',
     'Categorical',

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -44,6 +44,54 @@ def test_beta_density(batch_shape, eager):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('eager', [False, True])
+def test_bernoulli_density(batch_shape, eager):
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    @funsor.torch.function(reals(), reals(), reals())
+    def bernoulli(probs, value):
+        return torch.distributions.Bernoulli(probs).log_prob(value)
+
+    check_funsor(bernoulli, {'probs': reals(), 'value': reals()}, reals())
+
+    probs = Tensor(torch.rand(batch_shape), inputs)
+    value = Tensor(torch.rand(batch_shape).round(), inputs)
+    expected = bernoulli(probs, value)
+    check_funsor(expected, inputs, reals())
+
+    d = Variable('value', reals())
+    actual = dist.Bernoulli(probs, value) if eager else \
+        dist.Bernoulli(probs, d)(value=value)
+    check_funsor(actual, inputs, reals())
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+@pytest.mark.parametrize('eager', [False, True])
+def test_bernoulli_logits_density(batch_shape, eager):
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    @funsor.torch.function(reals(), reals(), reals())
+    def bernoulli(logits, value):
+        return torch.distributions.Bernoulli(logits=logits).log_prob(value)
+
+    check_funsor(bernoulli, {'logits': reals(), 'value': reals()}, reals())
+
+    logits = Tensor(torch.rand(batch_shape), inputs)
+    value = Tensor(torch.rand(batch_shape).round(), inputs)
+    expected = bernoulli(logits, value)
+    check_funsor(expected, inputs, reals())
+
+    d = Variable('value', reals())
+    actual = dist.BernoulliLogits(logits, value) if eager else \
+        dist.BernoulliLogits(logits, d)(value=value)
+    check_funsor(actual, inputs, reals())
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+@pytest.mark.parametrize('eager', [False, True])
 def test_binomial_density(batch_shape, eager):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))


### PR DESCRIPTION
This adds a `BernoulliLogits(logits)` distribution. In the future we may merge this with the Bernoulli distribution, but currently we don't have enough kwargs machinery to handle optional params in distributions.

The motivating use case is a linear-gaussian HMM with a probit likelihood model.

## Tested
- added a unit test for likelihood
- added a unit test for `Bernoulli` as well