### PR TITLE
Add generic Bernoulli wrapper around probs,logits version

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -104,7 +104,7 @@ class Distribution(Funsor):
 # Distribution Wrappers
 ################################################################################
 
-class Bernoulli(Distribution):
+class BernoulliProbs(Distribution):
     dist_class = dist.Bernoulli
 
     @staticmethod
@@ -115,12 +115,12 @@ class Bernoulli(Distribution):
         return probs, value
 
     def __init__(self, probs, value=None):
-        super(Bernoulli, self).__init__(probs, value)
+        super(BernoulliProbs, self).__init__(probs, value)
 
 
-@eager.register(Bernoulli, Tensor, Tensor)
+@eager.register(BernoulliProbs, Tensor, Tensor)
 def eager_bernoulli(probs, value):
-    return Bernoulli.eager_log_prob(probs=probs, value=value)
+    return BernoulliProbs.eager_log_prob(probs=probs, value=value)
 
 
 class BernoulliLogits(Distribution):
@@ -140,6 +140,14 @@ class BernoulliLogits(Distribution):
 @eager.register(BernoulliLogits, Tensor, Tensor)
 def eager_bernoulli_logits(logits, value):
     return BernoulliLogits.eager_log_prob(logits=logits, value=value)
+
+
+def Bernoulli(probs=None, logits=None, value='value'):
+    if probs is not None:
+        return BernoulliProbs(probs, value)
+    if logits is not None:
+        return BernoulliLogits(logits, value)
+    raise ValueError('Either probs or logits must be specified')
 
 
 class Beta(Distribution):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -43,8 +43,8 @@ def test_beta_density(batch_shape, eager):
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-@pytest.mark.parametrize('eager', [False, True])
-def test_bernoulli_density(batch_shape, eager):
+@pytest.mark.parametrize('syntax', ['eager', 'lazy', 'generic'])
+def test_bernoulli_probs_density(batch_shape, syntax):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
@@ -60,15 +60,19 @@ def test_bernoulli_density(batch_shape, eager):
     check_funsor(expected, inputs, reals())
 
     d = Variable('value', reals())
-    actual = dist.Bernoulli(probs, value) if eager else \
-        dist.Bernoulli(probs, d)(value=value)
+    if syntax == 'eager':
+        actual = dist.BernoulliProbs(probs, value)
+    elif syntax == 'lazy':
+        actual = dist.BernoulliProbs(probs, d)(value=value)
+    elif syntax == 'generic':
+        actual = dist.Bernoulli(probs=probs)(value=value)
     check_funsor(actual, inputs, reals())
     assert_close(actual, expected)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-@pytest.mark.parametrize('eager', [False, True])
-def test_bernoulli_logits_density(batch_shape, eager):
+@pytest.mark.parametrize('syntax', ['eager', 'lazy', 'generic'])
+def test_bernoulli_logits_density(batch_shape, syntax):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
@@ -84,8 +88,12 @@ def test_bernoulli_logits_density(batch_shape, eager):
     check_funsor(expected, inputs, reals())
 
     d = Variable('value', reals())
-    actual = dist.BernoulliLogits(logits, value) if eager else \
-        dist.BernoulliLogits(logits, d)(value=value)
+    if syntax == 'eager':
+        actual = dist.BernoulliLogits(logits, value)
+    elif syntax == 'lazy':
+        actual = dist.BernoulliLogits(logits, d)(value=value)
+    elif syntax == 'generic':
+        actual = dist.Bernoulli(logits=logits)(value=value)
     check_funsor(actual, inputs, reals())
     assert_close(actual, expected)
 


### PR DESCRIPTION
Following discussion in #135 , this adds a `Bernoulli` dispatcher between `BernoulliProbs` and `BernoulliLogits`.

I need this syntax to keep a model compatible with both pyro and funsor backends.

## Tested
- added tests cases for both `Bernoulli` -> `BernoulliProbs` and -> `BernoulliLogits`