### PR TITLE
Promote Einsum to a funsor for pattern matching

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -4,7 +4,7 @@ from funsor.domains import Domain, bint, find_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.terms import Funsor, Independent, Lambda, Number, Variable, of_shape, to_data, to_funsor
-from funsor.torch import Tensor, arange, torch_einsum
+from funsor.torch import Tensor, arange
 
 from . import (
     adjoint,
@@ -63,5 +63,4 @@ __all__ = [
     'to_data',
     'to_funsor',
     'torch',
-    'torch_einsum',
 ]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11,7 +11,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.terms import Lambda, Number, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
-from funsor.torch import REDUCE_OP_TO_TORCH, Tensor, align_tensors, torch_einsum, torch_tensordot, torch_stack
+from funsor.torch import REDUCE_OP_TO_TORCH, Einsum, Tensor, align_tensors, torch_stack, torch_tensordot
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
@@ -633,8 +633,8 @@ def test_einsum(equation):
     tensors = [torch.randn(tuple(sizes[d] for d in dims)) for dims in inputs]
     funsors = [Tensor(x) for x in tensors]
     expected = Tensor(torch.einsum(equation, *tensors))
-    actual = torch_einsum(equation, *funsors)
-    assert_close(actual, expected)
+    actual = Einsum(equation, tuple(funsors))
+    assert_close(actual, expected, atol=1e-5, rtol=None)
 
 
 @pytest.mark.parametrize('y_shape', [(), (4,), (4, 5)], ids=str)
@@ -646,7 +646,7 @@ def test_tensordot(x_shape, xy_shape, y_shape):
     dim = len(xy_shape)
     actual = torch_tensordot(Tensor(x), Tensor(y), dim)
     expected = Tensor(torch.tensordot(x, y, dim))
-    assert_close(actual, expected)
+    assert_close(actual, expected, atol=1e-5, rtol=None)
 
 
 @pytest.mark.parametrize('n', [1, 2, 5])


### PR DESCRIPTION
Addresses #72

This promotes the `torch_einsum()` function to an `Einsum` funsor so we can add patterns that match against it. This also refactors the `torch_tensordot()` function to use `Einsum`.

Note I've added einsum string validation to the `Einsum` class, so that we can detect errors before patterns are matched; previously errors would only be detected at function evaluation time.

## Tested
- refactoring is exercised by existing tests