### PR TITLE
Add an explicit stack-based interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ test: lint FORCE
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	python examples/discrete_hmm.py -n 2
 	python examples/discrete_hmm.py -n 2 -t 50 --lazy
+	python examples/discrete_hmm.py -n 1 -t 500 --lazy
 	python examples/kalman_filter.py -n 2
 	python examples/kalman_filter.py -n 2 -t 50 --lazy
+	python examples/kalman_filter.py -n 1 -t 500 --lazy
 	python examples/minipyro.py
 	python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,14 @@ format: FORCE
 test: lint FORCE
 	pytest -v test
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
+	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
+	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py
 	python examples/discrete_hmm.py -n 2
 	python examples/discrete_hmm.py -n 2 -t 50 --lazy
-	python examples/discrete_hmm.py -n 1 -t 500 --lazy
+	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 500 --lazy
 	python examples/kalman_filter.py -n 2
 	python examples/kalman_filter.py -n 2 -t 50 --lazy
-	python examples/kalman_filter.py -n 1 -t 500 --lazy
+	FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 500 --lazy
 	python examples/minipyro.py
 	python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -93,9 +93,9 @@ def _children_ground(x):
     return ()
 
 
-def is_ground(x):
+def is_atom(x):
     if isinstance(x, (tuple, frozenset)) and not isinstance(x, Domain):
-        return len(x) == 0 or all(is_ground(c) for c in x)
+        return len(x) == 0 or all(is_atom(c) for c in x)
     return isinstance(x, (
         int,
         str,
@@ -153,7 +153,7 @@ def reinterpret(x):
                 leaves.append(parent)
 
         h = node_vars[h_name]
-        if is_ground(h):
+        if is_atom(h):
             env[h_name] = h
         elif isinstance(h, (tuple, frozenset)):
             env[h_name] = type(h)(

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -87,7 +87,7 @@ def recursion_reinterpret(x):
 # We need to register this later in terms.py after declaring Funsor.
 # reinterpret.register(Funsor)
 def reinterpret_funsor(x):
-    return _INTERPRETATION(type(x), *map(reinterpret, x._ast_values))
+    return _INTERPRETATION(type(x), *map(recursion_reinterpret, x._ast_values))
 
 
 @recursion_reinterpret.register(str)
@@ -105,22 +105,22 @@ def recursion_reinterpret_ground(x):
 
 @recursion_reinterpret.register(tuple)
 def recursion_reinterpret_tuple(x):
-    return tuple(map(reinterpret, x))
+    return tuple(map(recursion_reinterpret, x))
 
 
 @recursion_reinterpret.register(frozenset)
 def recursion_reinterpret_frozenset(x):
-    return frozenset(map(reinterpret, x))
+    return frozenset(map(recursion_reinterpret, x))
 
 
 @recursion_reinterpret.register(dict)
 def recursion_reinterpret_dict(x):
-    return {key: reinterpret(value) for key, value in x.items()}
+    return {key: recursion_reinterpret(value) for key, value in x.items()}
 
 
 @recursion_reinterpret.register(OrderedDict)
 def recursion_reinterpret_ordereddict(x):
-    return OrderedDict((key, reinterpret(value)) for key, value in x.items())
+    return OrderedDict((key, recursion_reinterpret(value)) for key, value in x.items())
 
 
 @singledispatch
@@ -176,7 +176,7 @@ def is_atom(x):
 
 def gensym(x=None):
     if x is not None:
-        return hash(x)
+        return id(x)
     return "V" + str(uuid.uuid4().hex)
 
 
@@ -194,7 +194,6 @@ def stack_reinterpret(x):
     :return: A reinterpreted version of the input.
     :raises: ValueError
     """
-
     x_name = gensym(x)
     node_vars = {x_name: x}
     node_names = {x: x_name}

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -8,6 +8,7 @@ import types
 import uuid
 
 import torch
+from collections import OrderedDict
 from contextlib2 import contextmanager
 
 from funsor.domains import Domain
@@ -129,8 +130,8 @@ def reinterpret(x):
     env = {}
     x_name = gensym()
     stack = [(x_name, x)]
-    parent_to_children = {}
-    child_to_parent = {}
+    parent_to_children = OrderedDict()
+    child_to_parent = OrderedDict()
     while stack:
         h_name, h = stack.pop(0)
         node_vars[h_name] = h
@@ -141,10 +142,10 @@ def reinterpret(x):
             parent_to_children[h_name].append(c_name)
             child_to_parent[c_name] = h_name
 
-    children_counts = {k: len(v) for k, v in parent_to_children.items()}
+    children_counts = OrderedDict((k, len(v)) for k, v in parent_to_children.items())
     leaves = [h_name for h_name, count in children_counts.items() if count == 0]
     while leaves:
-        h_name = leaves.pop()
+        h_name = leaves.pop(0)
         if h_name in child_to_parent:
             parent = child_to_parent[h_name]
             children_counts[parent] -= 1

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -209,7 +209,7 @@ def stack_reinterpret(x):
             child_to_parent[c_name] = h_name
 
     children_counts = OrderedDict((k, len(v)) for k, v in parent_to_children.items())
-    leaves = [h_name for h_name, count in children_counts.items() if count == 0]
+    leaves = [name for name, count in children_counts.items() if count == 0]
     while leaves:
         h_name = leaves.pop(0)
         if h_name in child_to_parent:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -517,6 +517,7 @@ class Funsor(object):
         return result
 
 
+interpreter.recursion_reinterpret.register(Funsor)(interpreter.reinterpret_funsor)
 interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -517,7 +517,7 @@ class Funsor(object):
         return result
 
 
-interpreter.reinterpret.register(Funsor)(interpreter.reinterpret_funsor)
+interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 
 @dispatch(object)


### PR DESCRIPTION
Resolves #145 

This PR adds a simple stack-based interpreter as a drop-in replacement for `funsor.interpreter.reinterpret`, so that it's possible to evaluate arbitrarily large deferred expressions that would otherwise exceed the Python interpreter's maximum recursion depth.  

The new interpreter is 2-3x slower than the current recursion-based one since it's using Python data structures, so I've also left the current interpreter in as the default.

The new interpreter is accessible via an environment variable `FUNSOR_USE_TCO=1`:
```
# fails with a RecursionError
python examples/kalman_filter.py -n 2 -t 500 --lazy

# this works
FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 2 -t 500 --lazy
```

Tested: exercised by running existing tests with `FUNSOR_USE_TCO=1`, and by running existing examples with longer time series.