### PR TITLE
Alpha renaming of bound variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ format: FORCE
 
 test: lint FORCE
 	pytest -v test
+	FUNSOR_GENERIC_SUBS=1 pytest -v test  # TODO remove when removing eager_subs
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -58,8 +58,10 @@ def eager_affine(const, coeffs):
     if not coeffs:
         return const
     if any(not isinstance(v, Variable) for v, c in coeffs):
-        return Affine(const + sum(v * c for v, c in coeffs if not isinstance(v, Variable)),
-                      tuple((v, c) for v, c in coeffs if isinstance(v, Variable)))
+        new_const = const + sum(
+            v * c for v, c in coeffs if not isinstance(v, Variable))
+        new_coeffs = tuple((v, c) for v, c in coeffs if isinstance(v, Variable))
+        return Affine(new_const, new_coeffs)
     return None
 
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -57,6 +57,9 @@ class Affine(Funsor):
 def eager_affine(const, coeffs):
     if not coeffs:
         return const
+    if any(not isinstance(v, Variable) for v, c in coeffs):
+        return Affine(const + sum(v * c for v, c in coeffs if not isinstance(v, Variable)),
+                      tuple((v, c) for v, c in coeffs if isinstance(v, Variable)))
     return None
 
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -57,6 +57,12 @@ class Affine(Funsor):
 def eager_affine(const, coeffs):
     if not coeffs:
         return const
+    if not all(isinstance(var, Variable) for var, coeff in coeffs):
+        result = Affine(const, tuple((var, coeff) for var, coeff in coeffs if isinstance(var, Variable)))
+        for var, coeff in coeffs:
+            if not isinstance(var, Variable):
+                result += var * coeff
+        return result
     return None
 
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -57,11 +57,6 @@ class Affine(Funsor):
 def eager_affine(const, coeffs):
     if not coeffs:
         return const
-    if any(not isinstance(v, Variable) for v, c in coeffs):
-        new_const = const + sum(
-            v * c for v, c in coeffs if not isinstance(v, Variable))
-        new_coeffs = tuple((v, c) for v, c in coeffs if isinstance(v, Variable))
-        return Affine(new_const, new_coeffs)
     return None
 
 

--- a/funsor/contract.py
+++ b/funsor/contract.py
@@ -52,7 +52,9 @@ class Contract(Funsor):
         inputs = OrderedDict([(k, d) for t in (lhs, rhs)
                               for k, d in t.inputs.items() if k not in reduced_vars])
         output = rhs.output
-        super(Contract, self).__init__(inputs, output)
+        fresh = frozenset()
+        bound = reduced_vars
+        super(Contract, self).__init__(inputs, output, fresh, bound)
         self.sum_op = sum_op
         self.prod_op = prod_op
         self.lhs = lhs

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -59,7 +59,9 @@ class Delta(Funsor):
         inputs.update(point.inputs)
         inputs.update(log_density.inputs)
         output = reals()
-        super(Delta, self).__init__(inputs, output)
+        fresh = frozenset({name})
+        bound = frozenset()
+        super(Delta, self).__init__(inputs, output, fresh, bound)
         self.name = name
         self.point = point
         self.log_density = log_density

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -24,6 +24,7 @@ from funsor.terms import (
     Unary,
     Variable,
     eager,
+    substitute,
     to_funsor
 )
 
@@ -109,6 +110,11 @@ class Delta(Funsor):
         # TODO Implement ops.add to simulate .to_event().
 
         return None  # defer to default implementation
+
+
+@substitute.register(Delta, dict)
+def subs_gaussian(expr, subs):
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
 
 
 @eager.register(Binary, AddOp, Delta, (Funsor, Align))

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -114,9 +114,9 @@ class Delta(Funsor):
         return None  # defer to default implementation
 
 
-@substitute.register(Delta, dict)
+@substitute.register(Delta, tuple)
 def subs_gaussian(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @eager.register(Binary, AddOp, Delta, (Funsor, Align))

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -530,9 +530,9 @@ class Gaussian(Funsor):
         raise NotImplementedError('TODO implement partial sampling of real variables')
 
 
-@substitute.register(Gaussian, dict)
+@substitute.register(Gaussian, tuple)
 def subs_gaussian(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @eager.register(Binary, AddOp, Gaussian, Gaussian)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -14,7 +14,7 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate, integrator
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, substitute, to_funsor
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 
@@ -526,6 +526,11 @@ class Gaussian(Funsor):
             return reduce(ops.add, results)
 
         raise NotImplementedError('TODO implement partial sampling of real variables')
+
+
+@substitute.register(Gaussian, dict)
+def subs_gaussian(expr, subs):
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
 
 
 @eager.register(Binary, AddOp, Gaussian, Gaussian)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -322,7 +322,9 @@ class Gaussian(Funsor):
             assert _issubshape(precision.shape, batch_shape + (dim, dim))
 
         output = reals()
-        super(Gaussian, self).__init__(inputs, output)
+        fresh = frozenset(inputs.keys())
+        bound = frozenset()
+        super(Gaussian, self).__init__(inputs, output, fresh, bound)
         self.loc = loc
         self.precision = precision
         self.batch_shape = batch_shape

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -21,7 +21,9 @@ class Integrate(Funsor):
                              for (k, d) in term.inputs.items()
                              if k not in reduced_vars)
         output = integrand.output
-        super(Integrate, self).__init__(inputs, output)
+        fresh = frozenset()
+        bound = reduced_vars
+        super(Integrate, self).__init__(inputs, output, fresh, bound)
         self.log_measure = log_measure
         self.integrand = integrand
         self.reduced_vars = reduced_vars

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -5,7 +5,6 @@ import inspect
 import os
 import re
 import types
-import uuid
 from collections import OrderedDict
 
 import torch
@@ -25,6 +24,8 @@ _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 
 # TODO remove this, used temporarily for testing
 _GENERIC_SUBS = int(os.environ.get("FUNSOR_GENERIC_SUBS", 0))
+
+_GENSYM_COUNTER = 0
 
 
 if _DEBUG:
@@ -178,11 +179,14 @@ def is_atom(x):
 
 
 def gensym(x=None):
+    global _GENSYM_COUNTER
+    _GENSYM_COUNTER += 1
+    sym = _GENSYM_COUNTER
     if x is not None:
         if isinstance(x, str):
-            return x + "_" + str(uuid.uuid4().hex)
+            return x + "_" + str(sym)
         return id(x)
-    return "V" + str(uuid.uuid4().hex)
+    return "V" + str(sym)
 
 
 def stack_reinterpret(x):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -176,6 +176,8 @@ def is_atom(x):
 
 def gensym(x=None):
     if x is not None:
+        if isinstance(x, str):
+            return x + "_" + str(uuid.uuid4().hex)
         return id(x)
     return "V" + str(uuid.uuid4().hex)
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -24,7 +24,7 @@ _INTERPRETATION = None  # To be set later in funsor.terms
 _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 
 # TODO remove this, used temporarily for testing
-_GENERIC_SUBS = int(os.environ.get("FUNSOR_GENERIC_SUBS", 1))
+_GENERIC_SUBS = int(os.environ.get("FUNSOR_GENERIC_SUBS", 0))
 
 
 if _DEBUG:

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -23,6 +23,9 @@ _STACK_SIZE = 0
 _INTERPRETATION = None  # To be set later in funsor.terms
 _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 
+# TODO remove this, used temporarily for testing
+_GENERIC_SUBS = int(os.environ.get("FUNSOR_GENERIC_SUBS", 1))
+
 
 if _DEBUG:
     def interpret(cls, *args):

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -245,9 +245,9 @@ def eager_independent(joint, reals_var, bint_var):
     return None  # defer to default implementation
 
 
-@substitute.register(Joint, dict)
+@substitute.register(Joint, tuple)
 def substitute_joint(expr, subs):
-    return expr.eager_subs(tuple(subs.items()))
+    return expr.eager_subs(subs)
 
 
 ################################################################################

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -28,6 +28,7 @@ from funsor.terms import (
     Unary,
     Variable,
     eager,
+    substitute,
     to_funsor
 )
 from funsor.torch import Tensor, arange
@@ -242,6 +243,11 @@ def eager_independent(joint, reals_var, bint_var):
             return Joint(deltas, discrete, gaussian)
 
     return None  # defer to default implementation
+
+
+@substitute.register(Joint, dict)
+def substitute_joint(expr, subs):
+    return expr.eager_subs(tuple(subs.items()))
 
 
 ################################################################################

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -8,7 +8,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, Subs, eager, to_data, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, Subs, eager, substitute, to_data, to_funsor
 
 
 def align_array(new_inputs, x):
@@ -213,6 +213,11 @@ def _to_data_array(x):
         raise ValueError("cannot convert Array to a data due to lazy inputs: {}"
                          .format(set(x.inputs)))
     return x.data
+
+
+@substitute.register(Array, dict)
+def subs_gaussian(expr, subs):
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
 
 
 @eager.register(Binary, object, Array, Number)

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -91,7 +91,9 @@ class Array(Funsor):
         assert all(isinstance(d.dtype, integer_types) for k, d in inputs)
         inputs = OrderedDict(inputs)
         output = Domain(data.shape[len(inputs):], dtype)
-        super(Array, self).__init__(inputs, output)
+        fresh = frozenset(inputs.keys())
+        bound = frozenset()
+        super(Array, self).__init__(inputs, output, fresh, bound)
         self.data = data
 
     def __repr__(self):

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -215,9 +215,9 @@ def _to_data_array(x):
     return x.data
 
 
-@substitute.register(Array, dict)
+@substitute.register(Array, tuple)
 def subs_gaussian(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @eager.register(Binary, object, Array, Number)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1190,7 +1190,7 @@ class Lambda(Funsor):
 @eager.register(Binary, GetitemOp, Lambda, (Funsor, Align))
 def eager_getitem_lambda(op, lhs, rhs):
     if op.offset == 0:
-        return lhs.expr.eager_subs(((lhs.var.name, rhs),))
+        return Subs(lhs.expr, ((lhs.var.name, rhs),))
     if lhs.var.name in rhs.inputs:
         raise NotImplementedError('TODO alpha-convert to avoid conflict')
     expr = GetitemOp(op.offset - 1)(lhs.expr, rhs)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -601,6 +601,7 @@ def substitute_funsor(expr, subs):
     subs = {name: sub for name, sub in subs.items() if name in expr.inputs}
     if not subs:
         return expr
+    assert not expr.fresh & frozenset(subs), "cannot generically substitute into a fresh variable"
     return type(expr)(
         *(substitute(v, subs) for v in expr._ast_values))
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -90,7 +90,7 @@ def reflect(cls, *args):
 
     # alpha-convert eagerly upon binding any variable
     # TODO verify that this doesn't break cons-hashing
-    if result.bound:
+    if interpreter._GENERIC_SUBS:
         result = alpha_convert(result)
 
     cls._cons_cache[cache_key] = result

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -51,11 +51,11 @@ def substitute_ordereddict(expr, subs):
 
 
 def alpha_convert(expr):
-    if not expr.bound or all("BOUND" in name for name in expr.bound):
+    if not expr.bound or all("__BOUND" in name for name in expr.bound):
         return expr
 
-    alpha_subs = {name: interpreter.gensym(name + "_BOUND")
-                  for name in expr.bound if "BOUND" not in name}
+    alpha_subs = {name: interpreter.gensym(name + "__BOUND")
+                  for name in expr.bound if "__BOUND" not in name}
 
     new_values = []
     for v in expr._ast_values:
@@ -85,6 +85,7 @@ def reflect(cls, *args):
     cache_key = tuple(id(arg) if not isinstance(arg, Hashable) else arg for arg in args)
     if cache_key in cls._cons_cache:
         return cls._cons_cache[cache_key]
+
     result = super(FunsorMeta, cls).__call__(*args)
     result._ast_values = args
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1146,6 +1146,13 @@ class Stack(Funsor):
         return Stack(components, self.name)
 
 
+@substitute.register(Stack, dict)
+def substitute_stack(expr, subs):
+    if not any(fresh_var in subs for fresh_var in expr.fresh):
+        return substitute_funsor(expr, subs)
+    return expr.eager_subs(tuple(subs.items()))
+
+
 class Lambda(Funsor):
     """
     Lazy inverse to ``ops.getitem``.

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -902,7 +902,7 @@ def eager_distribute_reduce_other(op, red, other):
         # Use distributive law.
         if not red.reduced_vars.isdisjoint(other.inputs):
             raise NotImplementedError('TODO alpha-convert')
-        arg = red.arg + other
+        arg = op(red.arg, other)
         return arg.reduce(red.op, red.reduced_vars)
 
     return None  # defer to default implementation
@@ -914,7 +914,7 @@ def eager_distribute_other_reduce(op, other, red):
         # Use distributive law.
         if not red.reduced_vars.isdisjoint(other.inputs):
             raise NotImplementedError('TODO alpha-convert')
-        arg = other + red.arg
+        arg = op(other, red.arg)
         return arg.reduce(red.op, red.reduced_vars)
 
     return None  # defer to default implementation

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -214,12 +214,6 @@ class Funsor(object):
         self.fresh = fresh
         self.bound = bound
 
-    def alpha_convert(self):
-        if self.bound:
-            raise NotImplementedError(
-                "{} has bound variables {} but does not implement alpha-conversion".format(self, self.bound))
-        raise ValueError("{} does not have bound variables, should not be here".format(self))
-
     @property
     def dtype(self):
         return self.output.dtype

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -317,9 +317,9 @@ def to_funsor(x):
     return Tensor(x)
 
 
-@substitute.register(Tensor, dict)
+@substitute.register(Tensor, tuple)
 def subs_tensor(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @dispatch(torch.Tensor, Domain)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -17,7 +17,8 @@ from funsor.delta import Delta
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.six import getargspec
-from funsor.terms import Binary, Funsor, FunsorMeta, Lambda, Number, Subs, Variable, eager, to_data, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Lambda, Number, Subs, Variable, \
+    eager, substitute, to_data, to_funsor
 
 
 @contextmanager
@@ -110,7 +111,9 @@ class Tensor(Funsor):
                 assert d.dtype == size
         inputs = OrderedDict(inputs)
         output = Domain(data.shape[len(inputs):], dtype)
-        super(Tensor, self).__init__(inputs, output)
+        fresh = frozenset(inputs.keys())
+        bound = frozenset()
+        super(Tensor, self).__init__(inputs, output, fresh, bound)
         self.data = data
 
     def __repr__(self):
@@ -314,6 +317,12 @@ def to_funsor(x):
     return Tensor(x)
 
 
+@substitute.register(Tensor, dict)
+def subs_tensor(expr, subs):
+    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
+    # return expr.eager_subs(tuple(subs.items()))
+
+
 @dispatch(torch.Tensor, Domain)
 def to_funsor(x, output):
     result = Tensor(x, dtype=output.dtype)
@@ -489,7 +498,8 @@ def materialize(x):
         if isinstance(domain.dtype, integer_types):
             subs.append((name, arange(name, domain.dtype)))
     subs = tuple(subs)
-    return Subs(x, subs)
+    # return Subs(x, subs)
+    return substitute(x, subs)
 
 
 class LazyTuple(tuple):

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -320,7 +320,6 @@ def to_funsor(x):
 @substitute.register(Tensor, dict)
 def subs_tensor(expr, subs):
     return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs.items()))
-    # return expr.eager_subs(tuple(subs.items()))
 
 
 @dispatch(torch.Tensor, Domain)

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -10,9 +10,14 @@ import funsor
 from funsor.adjoint import adjoint
 from funsor.domains import bint
 from funsor.einsum import einsum, naive_einsum, naive_plated_einsum
-from funsor.interpreter import interpretation
+from funsor.interpreter import interpretation, _GENERIC_SUBS
 from funsor.terms import Variable, reflect
 from funsor.testing import make_einsum_example, make_plated_hmm_einsum
+
+
+# TODO remove this when removing eager_subs methods
+xfail_if_new_subs = pytest.mark.xfail(_GENERIC_SUBS, reason="fails w/ new subs")
+
 
 EINSUM_EXAMPLES = [
     "a->",
@@ -32,7 +37,7 @@ EINSUM_EXAMPLES = [
 ]
 
 
-@pytest.mark.xfail(reason="affected by alpha renaming")
+@xfail_if_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -60,7 +65,7 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
 
-@pytest.mark.xfail(reason="affected by alpha renaming")
+@xfail_if_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -95,7 +100,7 @@ PLATED_EINSUM_EXAMPLES = [
 ]
 
 
-@pytest.mark.xfail(reason="affected by alpha renaming")
+@xfail_if_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_plated_einsum, einsum])
 @pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -131,7 +136,7 @@ OPTIMIZED_PLATED_EINSUM_EXAMPLES = [
 ]
 
 
-@pytest.mark.xfail(reason="affected by alpha renaming")
+@xfail_if_new_subs
 @pytest.mark.parametrize('equation,plates', OPTIMIZED_PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_optimized_plated_einsum_adjoint(equation, plates, backend):

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -32,6 +32,7 @@ EINSUM_EXAMPLES = [
 ]
 
 
+@pytest.mark.xfail(reason="affected by alpha renaming")
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -59,6 +60,7 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
 
+@pytest.mark.xfail(reason="affected by alpha renaming")
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -93,6 +95,7 @@ PLATED_EINSUM_EXAMPLES = [
 ]
 
 
+@pytest.mark.xfail(reason="affected by alpha renaming")
 @pytest.mark.parametrize('einsum_impl', [naive_plated_einsum, einsum])
 @pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -128,6 +131,7 @@ OPTIMIZED_PLATED_EINSUM_EXAMPLES = [
 ]
 
 
+@pytest.mark.xfail(reason="affected by alpha renaming")
 @pytest.mark.parametrize('equation,plates', OPTIMIZED_PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_optimized_plated_einsum_adjoint(equation, plates, backend):

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -58,17 +58,19 @@ def test_subs_lambda():
     ix = random_tensor(OrderedDict([('i', bint(5))]), reals())
     actual = Lambda(i, z)(z=ix)
     expected = Lambda(i(i='j'), z(z=ix))
+    check_funsor(actual, expected.inputs, expected.output)
     assert_close(actual, expected)
 
 
-@pytest.mark.xfail(reason="GetItem handling not finished")
-def test_getitem_lambda():
+def test_slice_lambda():
     z = Variable('z', reals())
     i = Variable('i', bint(5))
-    ix = random_tensor(OrderedDict([('i', bint(5))]), reals())
-    actual = Lambda(i, z)[:, ix]
-    expected = Lambda(i(i='j'), z(z=ix))
-    assert_close(actual, expected)
+    j = Variable('j', bint(7))
+    zi = Lambda(i, z)
+    zj = Lambda(j, z)
+    zij = Lambda(j, zi)
+    zj2 = zij[:, i]
+    check_funsor(zj2, zj.inputs, zj.output)
 
 
 @pytest.mark.xfail(reason="Independent has both fresh and bound vars")

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -6,11 +6,16 @@ import pytest
 
 import funsor.ops as ops
 from funsor.domains import bint, reals
-from funsor.interpreter import gensym, interpretation
+from funsor.interpreter import gensym, interpretation, _GENERIC_SUBS
 from funsor.terms import Independent, Lambda, Variable, reflect
 from funsor.testing import assert_close, check_funsor, random_tensor
 
 
+# TODO remove this when removing eager_subs methods
+xfail_if_old_subs = pytest.mark.xfail(not _GENERIC_SUBS, reason="fails w/ old subs")
+
+
+@xfail_if_old_subs
 def test_sample_subs_smoke():
     x = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
     with interpretation(reflect):
@@ -19,6 +24,7 @@ def test_sample_subs_smoke():
     check_funsor(actual, {"j": bint(2), "i": bint(4)}, reals())
 
 
+@xfail_if_old_subs
 def test_subs_reduce():
     x = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
     ix = random_tensor(OrderedDict([('i', bint(3))]), bint(2))
@@ -30,6 +36,7 @@ def test_subs_reduce():
     assert_close(actual, expected)
 
 
+@xfail_if_old_subs
 @pytest.mark.parametrize('lhs_vars', [(), ('i',), ('j',), ('i', 'j')])
 @pytest.mark.parametrize('rhs_vars', [(), ('i',), ('j',), ('i', 'j')])
 def test_distribute_reduce(lhs_vars, rhs_vars):
@@ -52,6 +59,7 @@ def test_distribute_reduce(lhs_vars, rhs_vars):
     assert_close(actual, expected)
 
 
+@xfail_if_old_subs
 def test_subs_lambda():
     z = Variable('z', reals())
     i = Variable('i', bint(5))
@@ -62,6 +70,7 @@ def test_subs_lambda():
     assert_close(actual, expected)
 
 
+@xfail_if_old_subs
 def test_slice_lambda():
     z = Variable('z', reals())
     i = Variable('i', bint(5))
@@ -73,6 +82,7 @@ def test_slice_lambda():
     check_funsor(zj2, zj.inputs, zj.output)
 
 
+@xfail_if_old_subs
 def test_subs_independent():
     f = Variable('x', reals(4, 5)) + random_tensor(OrderedDict(i=bint(3)))
 
@@ -90,6 +100,7 @@ def test_subs_independent():
     assert_close(actual(y=data), expected(y=data))
 
 
+# @xfail_if_old_subs
 @pytest.mark.xfail(reason="Independent not quite compatible with sample")
 def test_sample_independent():
     f = Variable('x', reals(4, 5)) + random_tensor(OrderedDict(i=bint(3)))

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -1,19 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-import itertools
 from collections import OrderedDict
 
-import numpy as np
 import pytest
-from six.moves import reduce
 
-import funsor
 import funsor.ops as ops
-from funsor.domains import Domain, bint, reals
-from funsor.interpreter import gensym, interpretation, reinterpret
-from funsor.terms import Binary, Independent, Lambda, Number, Stack, Variable, reflect, sequential, to_data, to_funsor
+from funsor.domains import bint, reals
+from funsor.interpreter import gensym, interpretation
+from funsor.terms import Independent, Lambda, Variable, reflect
 from funsor.testing import assert_close, check_funsor, random_tensor
-from funsor.torch import REDUCE_OP_TO_TORCH
 
 
 def test_sample_subs_smoke():
@@ -26,7 +21,7 @@ def test_sample_subs_smoke():
 
 def test_subs_reduce():
     x = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
-    ix = random_tensor(OrderedDict([('i', bint(3)),]), bint(2))
+    ix = random_tensor(OrderedDict([('i', bint(3))]), bint(2))
     ix2 = ix(i='i2')
     with interpretation(reflect):
         actual = x.reduce(ops.add, frozenset({"i"}))
@@ -46,7 +41,7 @@ def test_distribute_reduce(lhs_vars, rhs_vars):
     with interpretation(reflect):
         actual_lhs = lhs.reduce(ops.add, lhs_vars) if lhs_vars else lhs
         actual_rhs = rhs.reduce(ops.add, rhs_vars) if rhs_vars else rhs
-    
+
     actual = actual_lhs * actual_rhs
 
     lhs_subs = {v: gensym(v) for v in lhs_vars}
@@ -60,7 +55,7 @@ def test_distribute_reduce(lhs_vars, rhs_vars):
 def test_subs_lambda():
     z = Variable('z', reals())
     i = Variable('i', bint(5))
-    ix = random_tensor(OrderedDict([('i', bint(5)),]), reals())
+    ix = random_tensor(OrderedDict([('i', bint(5))]), reals())
     actual = Lambda(i, z)(z=ix)
     expected = Lambda(i(i='j'), z(z=ix))
     assert_close(actual, expected)
@@ -70,7 +65,7 @@ def test_subs_lambda():
 def test_getitem_lambda():
     z = Variable('z', reals())
     i = Variable('i', bint(5))
-    ix = random_tensor(OrderedDict([('i', bint(5)),]), reals())
+    ix = random_tensor(OrderedDict([('i', bint(5))]), reals())
     actual = Lambda(i, z)[:, ix]
     expected = Lambda(i(i='j'), z(z=ix))
     assert_close(actual, expected)

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -73,15 +73,21 @@ def test_slice_lambda():
     check_funsor(zj2, zj.inputs, zj.output)
 
 
-@pytest.mark.xfail(reason="Independent has both fresh and bound vars")
 def test_subs_independent():
     f = Variable('x', reals(4, 5)) + random_tensor(OrderedDict(i=bint(3)))
-    actual = Independent(f, 'x', 'i')(x=Variable('y', reals(4, 5)) + random_tensor(OrderedDict(i=bint(3))))
+
+    actual = Independent(f, 'x', 'i')
+    assert 'i' not in actual.inputs
 
     y = Variable('y', reals(3, 4, 5))
-    expected = f(y=y['i']).reduce(ops.add, 'i')
+    fsub = y + (0. * random_tensor(OrderedDict(i=bint(7))))
+    actual = actual(x=fsub)
+    assert actual.inputs['i'] == bint(7)
 
-    assert_close(actual, expected)
+    expected = f(x=y['i']).reduce(ops.add, 'i')
+
+    data = random_tensor(OrderedDict(i=bint(7)), y.output)
+    assert_close(actual(y=data), expected(y=data))
 
 
 @pytest.mark.xfail(reason="Independent not quite working")

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -90,7 +90,7 @@ def test_subs_independent():
     assert_close(actual(y=data), expected(y=data))
 
 
-@pytest.mark.xfail(reason="Independent not quite working")
+@pytest.mark.xfail(reason="Independent not quite compatible with sample")
 def test_sample_independent():
     f = Variable('x', reals(4, 5)) + random_tensor(OrderedDict(i=bint(3)))
     actual = Independent(f, 'x', 'i')

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import, division, print_function
+
+import itertools
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+from six.moves import reduce
+
+import funsor
+import funsor.ops as ops
+from funsor.domains import Domain, bint, reals
+from funsor.interpreter import interpretation, reinterpret
+from funsor.terms import Binary, Independent, Lambda, Number, Stack, Variable, reflect, sequential, to_data, to_funsor
+from funsor.testing import assert_close, check_funsor, random_tensor
+from funsor.torch import REDUCE_OP_TO_TORCH
+
+
+def test_sample_subs():
+    pass
+
+
+def test_subs_reduce():
+    x = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
+    ix = random_tensor(OrderedDict([('i', bint(3)),]), bint(2))
+    ix2 = ix(i='i2')
+    with interpretation(reflect):
+        actual = x.reduce(ops.add, frozenset({"i"}))
+    actual = actual(j=ix)
+    expected = x(j=ix2).reduce(ops.add, frozenset({"i"}))(i2='i')
+    assert_close(actual, expected)
+
+
+@pytest.mark.xfail(reason="vars wrong")
+@pytest.mark.parametrize('lhs_vars', [(), ('i',), ('j',), ('i', 'j')])
+@pytest.mark.parametrize('rhs_vars', [(), ('i',), ('j',), ('i', 'j')])
+def test_distribute_reduce(lhs_vars, rhs_vars):
+
+    lhs_vars, rhs_vars = frozenset(lhs_vars), frozenset(rhs_vars)
+    lhs = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
+    rhs = random_tensor(OrderedDict([('i', bint(3)), ('j', bint(2))]), reals())
+
+    with interpretation(reflect):
+        actual = lhs.reduce(ops.add, lhs_vars) * rhs.reduce(ops.add, rhs_vars)
+
+    actual = reinterpret(actual)
+    expected = (lhs * rhs).reduce(ops.add, lhs_vars | rhs_vars)
+    assert_close(actual, expected)
+
+
+def test_subs_lambda():
+    pass
+
+
+def test_getitem_lambda():
+    pass
+
+
+def test_subs_independent():
+    pass
+
+
+def test_sample_independent():
+    pass
+
+
+def test_subs_gaussian():
+    pass
+
+
+def test_subs_contract():
+    pass
+
+
+def test_subs_integrate():
+    pass

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -230,8 +230,9 @@ def test_lambda(base_shape):
     zij = Lambda(j, zi)
     assert zij.output.shape == (7, 5) + base_shape
     assert zij[j] is zi
-    assert zij[:, i] is zj
     assert zij[j, i] is z
+    # assert zij[:, i] is zj  # XXX this was disabled by alpha-renaming
+    check_funsor(zij[:, i], zj.inputs, zj.output)
 
 
 def test_independent():


### PR DESCRIPTION
Resolves #96.  Blocking #130.

This PR makes the following changes to substitution and interpretation:
1. Adds eager alpha-renaming whenever a variable is newly bound
2. Adds `.fresh` and `.bound` attributes to each term (empty by default) which are `frozenset`s of names of fresh variables introduced by a term and variables newly bound by a term respectively.  These must be manually populated in the `__init__` method of each new term if they are not empty for that term.
3. Changes the semantics of the `Subs` term slightly: there is now a `substitute` function that calls itself recursively, as opposed to `Subs` calling `eager_subs` methods which in turn recursively call `Subs`.  A `Subs` term now represents a lazy call to `substitute`.  I did this instead of manually changing every call to `Subs` inside an `eager_subs` method into recursive `eager_subs` calls.
4. Makes substitution more generic, removing the need for `.eager_subs` implementations in terms that don't introduce fresh variables and simplifying the implementation of new terms.  Hopefully most `eager_subs` methods of terms that don't introduce fresh variables can be removed in a followup PR.

Tasks:
- [x] Add `.fresh` and `.bound` to any remaining terms missing them and add some tests checking
- [x] Fix various minor regressions (`Affine`, `Joint`, `Stack`, `Lambda`, `Independent`, etc)
- [x] Add new tests exercising alpha-renaming (which would currently trigger `NotImplementedError`s)

Triaged:
- Make `funsor.adjoint` compatible with alpha-renaming
