### PR TITLE
Separate generic and fresh variables in substitute

### DIFF
--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -8,7 +8,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, Subs, eager, substitute, to_data, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, Subs, eager, to_data, to_funsor
 
 
 def align_array(new_inputs, x):
@@ -213,11 +213,6 @@ def _to_data_array(x):
         raise ValueError("cannot convert Array to a data due to lazy inputs: {}"
                          .format(set(x.inputs)))
     return x.data
-
-
-@substitute.register(Array, tuple)
-def subs_gaussian(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @eager.register(Binary, object, Array, Number)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -588,6 +588,7 @@ interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 
 @substitute.register(Funsor, tuple)
+@interpreter.debug_logged
 def substitute_funsor(expr, subs):
     subs = tuple((name, sub) for name, sub in subs if name in expr.inputs)
 
@@ -738,7 +739,7 @@ def eager_subs(arg, subs):
     assert isinstance(subs, tuple)
     if not any(k in arg.inputs for k, v in subs):
         return arg
-    return substitute(arg, subs)  # TODO make this compatible with FUNSOR_DEBUG=1
+    return substitute(arg, subs)
 
 
 _PREFIX = {

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -599,7 +599,7 @@ def substitute_funsor(expr, subs):
 
     fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
     if fresh_subs:
-        expr = expr.eager_subs(fresh_subs)
+        expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
 
     return expr
 


### PR DESCRIPTION
Part of #149.

This refactoring PR simplifies `eager_subs` methods of terms with fresh variables by moving substitution into non-fresh variables into the generic `substitute_funsor` function.  It also reenables debug logging for substitution, which was temporarily disabled in #148.