### PR TITLE
Remove eager_subs method from Joint

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -14,7 +14,7 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate, integrator
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, substitute, to_funsor
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, reflect, to_funsor
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 
@@ -361,7 +361,7 @@ class Gaussian(Funsor):
         real_subs = tuple((k, v) for k, v in subs if isinstance(v, (Number, Tensor))
                           if v.dtype == 'real')
         if not (var_subs or int_subs or real_subs):
-            return None  # entirely lazy
+            return reflect(Subs, self, lazy_subs)
 
         # First perform any variable substitutions.
         if var_subs:
@@ -524,11 +524,6 @@ class Gaussian(Funsor):
             return reduce(ops.add, results)
 
         raise NotImplementedError('TODO implement partial sampling of real variables')
-
-
-@substitute.register(Gaussian, tuple)
-def subs_gaussian(expr, subs):
-    return expr.eager_subs(tuple((k, to_funsor(v, expr.inputs[k]) if k in expr.inputs else v) for k, v in subs))
 
 
 @eager.register(Binary, AddOp, Gaussian, Gaussian)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -14,7 +14,7 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate, integrator
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, reflect, to_funsor
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, reflect
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -14,7 +14,7 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate, integrator
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, reflect
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Subs, Unary, Variable, eager, reflect, to_funsor
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 
@@ -347,7 +347,8 @@ class Gaussian(Funsor):
 
     def eager_subs(self, subs):
         assert isinstance(subs, tuple)
-        subs = tuple((k, materialize(v)) for k, v in subs if k in self.inputs)
+        subs = tuple((k, materialize(to_funsor(v, self.inputs[k])))
+                     for k, v in subs if k in self.inputs)
         if not subs:
             return self
 

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -200,6 +200,9 @@ class Joint(Funsor):
 @eager.register(Joint, tuple, Funsor, Funsor)
 def eager_joint(deltas, discrete, gaussian):
 
+    if not isinstance(gaussian, (Number, Tensor, Gaussian)):
+        return Joint(deltas, discrete) + gaussian
+
     if any(not isinstance(d, Delta) for d in deltas):
         new_deltas = []
         for d in deltas:

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -28,7 +28,6 @@ from funsor.terms import (
     Unary,
     Variable,
     eager,
-    substitute,
     to_funsor
 )
 from funsor.torch import Tensor, arange
@@ -83,21 +82,6 @@ class Joint(Funsor):
         self.deltas = deltas
         self.discrete = discrete
         self.gaussian = gaussian
-
-    def eager_subs(self, subs):
-        discrete = Subs(self.discrete, subs)
-        gaussian = Subs(self.gaussian, subs)
-        deltas = []
-        for x in self.deltas:
-            x = Subs(x, subs)
-            if isinstance(x, Delta):
-                deltas.append(x)
-            elif isinstance(x, (Number, Tensor)):
-                discrete += x
-            else:
-                raise ValueError('Cannot substitute {}'.format(x))
-        deltas = tuple(deltas)
-        return Joint(deltas, discrete) + gaussian
 
     def eager_reduce(self, op, reduced_vars):
         if op is ops.logaddexp:
@@ -215,6 +199,22 @@ class Joint(Funsor):
 
 @eager.register(Joint, tuple, Funsor, Funsor)
 def eager_joint(deltas, discrete, gaussian):
+
+    if any(not isinstance(d, Delta) for d in deltas):
+        new_deltas = []
+        for d in deltas:
+            if isinstance(d, Delta):
+                new_deltas.append(d)
+            elif isinstance(d, (Number, Tensor)):
+                discrete += d
+            else:
+                raise ValueError("Invalid component for Joint: {}".format(d))
+        return Joint(tuple(new_deltas), discrete) + gaussian
+
+    if isinstance(gaussian, (Number, Tensor)) and gaussian is not Number(0):
+        discrete += gaussian
+        return Joint(deltas, discrete, Number(0))
+
     # Demote a Joint to a simpler elementary funsor.
     if not deltas:
         if gaussian is Number(0):
@@ -243,11 +243,6 @@ def eager_independent(joint, reals_var, bint_var):
             return Joint(deltas, discrete, gaussian)
 
     return None  # defer to default implementation
-
-
-@substitute.register(Joint, tuple)
-def substitute_joint(expr, subs):
-    return expr.eager_subs(subs)
 
 
 ################################################################################


### PR DESCRIPTION
Part of #149 

As discussed in #148, since `Joint` has no fresh variables, it does not need an `eager_subs` method.  This refactoring PR moves the re-normalization logic into `eager_joint` and reuses the generic substitution machinery for `Joint`.