### PR TITLE
Make substitution an interpretation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ test: lint FORCE
 	python examples/discrete_hmm.py -n 2
 	python examples/discrete_hmm.py -n 2 -t 50 --lazy
 	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 50 --lazy
-	#FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 500 --lazy
+	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 500 --lazy
 	python examples/kalman_filter.py -n 2
 	python examples/kalman_filter.py -n 2 -t 50 --lazy
 	FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 50 --lazy
-	#FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 500 --lazy
+	FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 500 --lazy
 	python examples/minipyro.py
 	python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test: lint FORCE
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py
+	FUNSOR_USE_TCO=1 pytest -v test/test_numpy.py
 	python examples/discrete_hmm.py -n 2
 	python examples/discrete_hmm.py -n 2 -t 50 --lazy
 	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 50 --lazy

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -129,14 +129,14 @@ eager.register(Binary, AddOp, Reduce, Delta)(
 
 @eager.register(Independent, Delta, str, str)
 def eager_independent(delta, reals_var, bint_var):
-    if delta.name == reals_var:
+    if delta.name == reals_var or delta.name.startswith(reals_var + "__BOUND"):
         i = Variable(bint_var, delta.inputs[bint_var])
         point = Lambda(i, delta.point)
         if bint_var in delta.log_density.inputs:
             log_density = delta.log_density.reduce(ops.add, bint_var)
         else:
             log_density = delta.log_density * delta.inputs[bint_var].dtype
-        return Delta(delta.name, point, log_density)
+        return Delta(reals_var, point, log_density)
 
     return None  # defer to default implementation
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -7,6 +7,7 @@ import re
 import types
 from collections import OrderedDict
 
+import numpy
 import torch
 from contextlib2 import contextmanager
 
@@ -95,8 +96,10 @@ def reinterpret_funsor(x):
 @recursion_reinterpret.register(int)
 @recursion_reinterpret.register(float)
 @recursion_reinterpret.register(type)
+@recursion_reinterpret.register(functools.partial)
 @recursion_reinterpret.register(types.FunctionType)
 @recursion_reinterpret.register(types.BuiltinFunctionType)
+@recursion_reinterpret.register(numpy.ndarray)
 @recursion_reinterpret.register(torch.Tensor)
 @recursion_reinterpret.register(Domain)
 @recursion_reinterpret.register(Op)
@@ -150,8 +153,10 @@ def _children_tuple(x):
 @children.register(int)
 @children.register(float)
 @children.register(type)
+@children.register(functools.partial)
 @children.register(types.FunctionType)
 @children.register(types.BuiltinFunctionType)
+@children.register(numpy.ndarray)
 @children.register(torch.Tensor)
 @children.register(Domain)
 @children.register(Op)
@@ -167,9 +172,11 @@ def is_atom(x):
         str,
         float,
         type,
+        functools.partial,
         types.FunctionType,
         types.BuiltinFunctionType,
         torch.Tensor,
+        numpy.ndarray,
         Domain,
         Op
     ))

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -101,6 +101,7 @@ def reinterpret_funsor(x):
 @recursion_reinterpret.register(types.BuiltinFunctionType)
 @recursion_reinterpret.register(numpy.ndarray)
 @recursion_reinterpret.register(torch.Tensor)
+@recursion_reinterpret.register(torch.nn.Module)
 @recursion_reinterpret.register(Domain)
 @recursion_reinterpret.register(Op)
 def recursion_reinterpret_ground(x):
@@ -158,6 +159,7 @@ def _children_tuple(x):
 @children.register(types.BuiltinFunctionType)
 @children.register(numpy.ndarray)
 @children.register(torch.Tensor)
+@children.register(torch.nn.Module)
 @children.register(Domain)
 @children.register(Op)
 def _children_ground(x):
@@ -176,6 +178,7 @@ def is_atom(x):
         types.FunctionType,
         types.BuiltinFunctionType,
         torch.Tensor,
+        torch.nn.Module,
         numpy.ndarray,
         Domain,
         Op

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -234,7 +234,7 @@ def eager_joint(deltas, discrete, gaussian):
 @eager.register(Independent, Joint, str, str)
 def eager_independent(joint, reals_var, bint_var):
     for i, delta in enumerate(joint.deltas):
-        if delta.name == reals_var:
+        if delta.name == reals_var or delta.name.startswith(reals_var + "__BOUND"):
             delta = Independent(delta, reals_var, bint_var)
             deltas = joint.deltas[:i] + (delta,) + joint.deltas[1+i:]
             discrete = joint.discrete

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -8,7 +8,7 @@ from six import add_metaclass, integer_types
 
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, Subs, eager, to_data, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, substitute, to_data, to_funsor
 
 
 def align_array(new_inputs, x):
@@ -288,4 +288,4 @@ def materialize(x):
         assert not domain.shape
         subs.append((name, arange(name, domain.dtype)))
     subs = tuple(subs)
-    return Subs(x, subs)
+    return substitute(x, subs)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -21,18 +21,16 @@ from funsor.six import getargspec, singledispatch
 
 
 def substitute(expr, subs):
-    if isinstance(subs, dict):
+    if isinstance(subs, (dict, OrderedDict)):
         subs = tuple(subs.items())
     assert isinstance(subs, tuple)
 
-    base_interpretation = interpreter._INTERPRETATION
-
+    @interpreter.interpretation(interpreter._INTERPRETATION)  # use base
     def subs_interpreter(cls, *args):
-        with interpreter.interpretation(base_interpretation):
-            expr = cls(*args)
-            fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
-            if fresh_subs:
-                expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
+        expr = cls(*args)
+        fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
+        if fresh_subs:
+            expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
         return expr
 
     with interpreter.interpretation(subs_interpreter):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -574,23 +574,6 @@ interpreter.recursion_reinterpret.register(Funsor)(interpreter.reinterpret_funso
 interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 
-# @substitute.register(Funsor, tuple)
-@interpreter.debug_logged
-def substitute_funsor(expr, subs):
-    subs = tuple((name, sub) for name, sub in subs if name in expr.inputs)
-
-    generic_subs = tuple((k, v) for k, v in subs if k not in expr.fresh)
-    if generic_subs:
-        expr = type(expr)(
-            *(substitute(v, generic_subs) for v in expr._ast_values))
-
-    fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
-    if fresh_subs:
-        expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
-
-    return expr
-
-
 @dispatch(object)
 def to_funsor(x):
     """

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -5,8 +5,16 @@ import pytest
 
 import funsor
 from funsor import Number, Variable, bint, reals
+from funsor.interpreter import _USE_TCO
 from funsor.numpy import Array
 from funsor.testing import assert_equiv, check_funsor, random_array
+
+
+# FIXME rewrite stack-based interpreter to be compatible with unhashable data
+xfail_with_tco = pytest.mark.xfail(
+    _USE_TCO,
+    reason="fails w/ TCO because numpy arrays can't be hashed"
+)
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
@@ -38,6 +46,7 @@ def test_cons_hash():
     assert Array(x) is Array(x)
 
 
+@xfail_with_tco
 def test_indexing():
     data = np.random.normal(size=(4, 5))
     inputs = OrderedDict([('i', bint(4)),
@@ -61,6 +70,7 @@ def test_indexing():
     check_funsor(x(j=2, k=3), {'i': bint(4)}, reals(), data[:, 2])
 
 
+@xfail_with_tco
 def test_advanced_indexing_shape():
     I, J, M, N = 4, 4, 2, 3
     x = Array(np.random.normal(size=(I, J)), OrderedDict([
@@ -95,6 +105,7 @@ def test_advanced_indexing_shape():
     check_funsor(x(n, m, k=m), {'m': bint(M), 'n': bint(N)}, reals())
 
 
+@xfail_with_tco
 @pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
 def test_advanced_indexing_array(output_shape):
     #      u   v
@@ -148,6 +159,7 @@ def test_advanced_indexing_array(output_shape):
     assert_equiv(expected, x(k=k)(j=j)(i=i))
 
 
+@xfail_with_tco
 @pytest.mark.parametrize('output_shape', [(), (7,), (3, 2)])
 def test_advanced_indexing_lazy(output_shape):
     x = Array(np.random.normal(size=(2, 3, 4) + output_shape), OrderedDict([
@@ -192,6 +204,7 @@ def test_advanced_indexing_lazy(output_shape):
     assert_equiv(expected, x(k=k)(j=j)(i=i))
 
 
+@xfail_with_tco
 def test_align():
     x = Array(np.random.randn(2, 3, 4), OrderedDict([
         ('i', bint(2)),


### PR DESCRIPTION
Resolves #149 

This refactoring PR makes `substitute` into an interpretation, so that it can reuse the tail-call optimization added in #145 and duplicate code can be removed.  The computations actually done by `substitute` should remain unchanged and the cost should be identical.

Tested: exercised by existing tests, and also longer example runs that started failing after #148.

Tasks:
- [x] Make `substitute` into an interpretation
- [x] Update semantics and implementation of `Independent` to be compatible with this version of `substitute`

Triaged:
- Make tail-call optimization compatible with `funsor.numpy` #1 (added conditional xfail for now)