### PR TITLE
Implement log-time sequential sum product function

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -50,6 +50,11 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     def num_elements(self):
         return reduce(operator.mul, self.shape, 1)
 
+    @property
+    def size(self):
+        assert isinstance(self.dtype, int)
+        return self.dtype
+
 
 def reals(*shape):
     """


### PR DESCRIPTION
This ports Pyro's algorithm from https://github.com/pyro-ppl/pyro/pull/1958 to funsor.
Pair coded with @eb8680 

## Tested
- added tests with `Tensor` contraction.

## Triaged
- make a `Slice` funsor
- implement `Cat` for `Gaussian`s and `Joint`s.