### PR TITLE
Implement log-time Markov sum product algorithm

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import re
 from collections import OrderedDict, defaultdict
 
 import torch
@@ -174,16 +175,89 @@ def sequential_sum_product(sum_op, prod_op, trans, time, prev, curr):
     assert isinstance(prev, str)
     assert isinstance(curr, str)
 
-    while trans.inputs["time"].size > 1:
-        duration = trans.inputs["time"].size
+    while trans.inputs[time].size > 1:
+        duration = trans.inputs[time].size
         even_duration = duration // 2 * 2
         # TODO support syntax
         # x = trans(time=slice(0, even_duration, 2), ...)
-        x = trans(time=Slice("time", 0, even_duration, 2, duration), curr="_drop")
-        y = trans(time=Slice("time", 1, even_duration, 2, duration), prev="_drop")
+        x = trans(**{time: Slice(time, 0, even_duration, 2, duration), curr: "_drop"})
+        y = trans(**{time: Slice(time, 1, even_duration, 2, duration), prev: "_drop"})
         contracted = prod_op(x, y).reduce(sum_op, "_drop")
         if duration > even_duration:
-            extra = trans(time=Slice("time", duration - 1, duration))
-            contracted = Cat((contracted, extra), "time")
+            extra = trans(**{time: Slice(time, duration - 1, duration)})
+            contracted = Cat((contracted, extra), time)
         trans = contracted
-    return trans(time=0)
+    return trans(**{time: 0})
+
+
+def parse_lags(name):
+    lags = defaultdict(0)
+    while True:
+        match = re.match(r"(.*)\(([^=]+)=([0-9]+)\)", name)
+        if match:
+            name, time, lag = match.groups()
+            lags[time] = int(lag)
+    return name, lags
+
+
+def format_lags(name, lags):
+    parts = ["name"]
+    for time, lag in sorted(lags.items()):
+        if lag:
+            parts.extend("({}={:d})".format(time, lag))
+    return "".join(parts)
+
+
+def increment_lags(dependent_vars, time):
+    step = {}
+    for name in dependent_vars:
+        name, lags = parse_lags(name)
+        lags[time] += 1
+        step[name] = format_lags(name, lags)
+    # TODO fix sum_vars
+    sum_vars = frozenset(step).intersection(step.values())
+    x_subs = {curr: prev for prev, curr in step.values()
+              if "TODO"}
+    y_subs = {prev: curr for prev, curr in step.values()
+              if "TODO"}
+    return x_subs, y_subs, sum_vars
+
+
+def markov_sum_product(sum_op, prod_op, arg, dependent_vars, prod_vars):
+    """
+    This encodes time dependency as a special convention in ``arg.inputs``; see
+    :func:`print_lags` and :func:`format_lags` for details.
+    """
+    assert dependent_vars.issubset(arg.inputs)
+    assert prod_vars.issubset(arg.inputs)
+    assert dependent_vars.isdisjoint(prod_vars)
+    lags = defaultdict(dict)
+    for name in dependent_vars:
+        for basename, name_lags in parse_lags(name):
+            for prod_var in prod_vars:
+                lags[prod_var][basename] = name_lags[prod_var]
+
+    # Eliminate time dimensions one at a time.
+    # TODO decide optimal order.
+    for time in prod_vars:
+        window = max(lags[time].values()) - min(lags[time].values())
+        if window == 0:
+            arg = arg.reduce(prod_op, time)
+            continue
+
+        # TODO does dependent_vars depend on time?
+        x_subs, y_subs, sum_vars = increment_lags(dependent_vars, time)
+        while arg.inputs[time].size > 1:
+            duration = arg.inputs[time].size - window + 1  # XXX Correct?
+            even_duration = duration // (1 + window) * (1 + window)
+            x_subs[time] = Slice(time, 0, even_duration, 1 + window, duration)
+            y_subs[time] = Slice(time, 1, even_duration, 1 + window, duration)
+            x = arg(**x_subs)
+            y = arg(**y_subs)
+            contracted = prod_op(x, y).reduce(sum_op, sum_vars)
+            if duration > even_duration:
+                extra = arg(**{time: Slice(time, even_duration, duration)})
+                contracted = Cat((contracted, extra), time)
+            arg = contracted
+        arg = arg(**{time: 0})
+    return arg

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -865,32 +865,6 @@ def moment_matching_reduce(op, arg, reduced_vars):
     return interpreter.debug_logged(arg.moment_matching_reduce)(op, reduced_vars)
 
 
-class Convolve(Funsor):
-    """
-    Lazy convolution over multiple variables.
-
-    Note that time lag information must be in the input names in arg.
-    TODO describe arg naming convention.
-    """
-    def __init__(self, sum_op, prod_op, arg, sum_vars, prod_vars):
-        assert isinstance(sum_op, AssociativeOp)
-        assert isinstance(prod_op, AssociativeOp)
-        assert isinstance(arg, Funsor)
-        assert isinstance(sum_vars, frozenset)
-        assert isinstance(prod_vars, frozenset)
-        reduced_vars = sum_vars | prod_vars
-        inputs = OrderedDict((k, v) for k, v in arg.inputs.items() if k not in reduced_vars)
-        output = arg.output
-        fresh = frozenset()
-        bound = reduced_vars
-        super(Convolve, self).__init__(inputs, output, fresh, bound)
-        self.sum_op = sum_op
-        self.prod_op = prod_op
-        self.arg = arg
-        self.sum_vars = sum_vars
-        self.prod_vars = prod_vars
-
-
 class NumberMeta(FunsorMeta):
     """
     Wrapper to fill in default ``dtype``.

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -799,7 +799,7 @@ class Reduce(Funsor):
     Lazy reduction over multiple variables.
     """
     def __init__(self, op, arg, reduced_vars):
-        assert callable(op)
+        assert isinstance(op, AssociativeOp)
         assert isinstance(arg, Funsor)
         assert isinstance(reduced_vars, frozenset)
         inputs = OrderedDict((k, v) for k, v in arg.inputs.items() if k not in reduced_vars)
@@ -863,6 +863,32 @@ def sequential_reduce(op, arg, reduced_vars):
 @moment_matching.register(Reduce, AssociativeOp, Funsor, frozenset)
 def moment_matching_reduce(op, arg, reduced_vars):
     return interpreter.debug_logged(arg.moment_matching_reduce)(op, reduced_vars)
+
+
+class Convolve(Funsor):
+    """
+    Lazy convolution over multiple variables.
+
+    Note that time lag information must be in the input names in arg.
+    TODO describe arg naming convention.
+    """
+    def __init__(self, sum_op, prod_op, arg, sum_vars, prod_vars):
+        assert isinstance(sum_op, AssociativeOp)
+        assert isinstance(prod_op, AssociativeOp)
+        assert isinstance(arg, Funsor)
+        assert isinstance(sum_vars, frozenset)
+        assert isinstance(prod_vars, frozenset)
+        reduced_vars = sum_vars | prod_vars
+        inputs = OrderedDict((k, v) for k, v in arg.inputs.items() if k not in reduced_vars)
+        output = arg.output
+        fresh = frozenset()
+        bound = reduced_vars
+        super(Convolve, self).__init__(inputs, output, fresh, bound)
+        self.sum_op = sum_op
+        self.prod_op = prod_op
+        self.arg = arg
+        self.sum_vars = sum_vars
+        self.prod_vars = prod_vars
 
 
 class NumberMeta(FunsorMeta):


### PR DESCRIPTION
Addresses #70 #177
Pair coded with @eb8680 

This aims to generalize `sequential_sum_product()` from simple contractions to arbitrary contractions with different window size. This aims to be maximally general and should be able to be integrated into the TVE algorithm `partial_sum_product()` (as in the [convolve-method branch](https://github.com/pyro-ppl/funsor/compare/convolve-method?expand=1)).

## Design Questions
- [ ] What problem class should we address? E.g. should this assume that the components have already been decomposed by a connected components algorithm? I've started to enumerate test cases, and I think we should spend a many hours whiteboarding examples to understand the problem class (as we did with TVE).
- [ ] How can we pass around the metadata of time lags? This PR attempts to do so via name mangling of `.inputs.keys()`, but that approach won't currently work because alpha binding mangles names in a different way. Indeed the alpha mangling appears to thwart other nearby designs such as passing in a side-information dict indicating which names correspond to which lags. One possible solution is to make alpha renaming less intrusive. @eb8680 can you think about possible solutions?