### PR TITLE
Drop python2 support from setup.py and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ cache:
 
 install:
     - pip install -U pip
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-          pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl;
-      else
-          pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl;
-      fi
+    - pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
 
     # Keep track of Pyro dev branch
     - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
@@ -30,7 +26,5 @@ branches:
 
 jobs:
     include:
-        - python: 2.7
-          script: make test
         - python: 3.6
           script: make test

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
Addresses #158 

This the first step in dropping Python 2 support: remove from travis and setup.py
This is high-priority, since tests are now failing.