### PR TITLE
Refactor pyro converters

### DIFF
--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -5,77 +5,90 @@ from collections import OrderedDict
 import pyro.distributions as dist
 import torch
 
+from funsor.distributions import MultivariateNormal, Normal
 from funsor.domains import bint
 from funsor.torch import Tensor
 
-# Conversion functions use fixed names for Pyro batch dims.
+# Conversion functions use fixed names for Pyro batch dims, but
+# accept an event_inputs tuple for custom event dim names.
 DIM_TO_NAME = tuple(map("_pyro_dim_{}".format, range(-100, 0)))
 NAME_TO_DIM = dict(zip(DIM_TO_NAME, range(-100, 0)))
 
 
-def tensor_to_funsor(tensor, event_dim=0, dtype="real"):
+def tensor_to_funsor(tensor, event_inputs=(), event_output=0, dtype="real"):
     """
     Convert a :class:`torch.Tensor` to a :class:`funsor.torch.Tensor` .
     """
     assert isinstance(tensor, torch.Tensor)
-    batch_shape = tensor.shape[:tensor.dim() - event_dim]
-    event_shape = tensor.shape[tensor.dim() - event_dim:]
+    assert isinstance(event_inputs, tuple)
+    assert isinstance(event_output, int) and event_output >= 0
+    inputs_shape = tensor.shape[:tensor.dim() - event_output]
+    output_shape = tensor.shape[tensor.dim() - event_output:]
+    dim_to_name = DIM_TO_NAME + event_inputs if event_inputs else DIM_TO_NAME
 
-    # Squeeze batch_shape.
+    # Squeeze shape of inputs.
     inputs = OrderedDict()
-    squeezed_batch_shape = []
-    for dim, size in enumerate(batch_shape):
+    squeezed_shape = []
+    for dim, size in enumerate(inputs_shape):
         if size > 1:
-            name = DIM_TO_NAME[dim - len(batch_shape)]
+            name = dim_to_name[dim - len(inputs_shape)]
             inputs[name] = bint(size)
-            squeezed_batch_shape.append(size)
-    squeezed_batch_shape = torch.Size(squeezed_batch_shape)
-    if squeezed_batch_shape != batch_shape:
-        batch_shape = squeezed_batch_shape
-        tensor = tensor.reshape(batch_shape + event_shape)
+            squeezed_shape.append(size)
+    squeezed_shape = torch.Size(squeezed_shape)
+    if squeezed_shape != inputs_shape:
+        tensor = tensor.reshape(squeezed_shape + output_shape)
 
     return Tensor(tensor, inputs, dtype)
 
 
-def funsor_to_tensor(funsor_, ndims):
+def funsor_to_tensor(funsor_, ndims, event_inputs=()):
     """
     Convert a :class:`funsor.torch.Tensor` to a :class:`torch.Tensor` .
     """
     assert isinstance(funsor_, Tensor)
-    assert all(k.startswith("_pyro_dim_") for k in funsor_.inputs)
-    names = tuple(sorted(funsor_.inputs, key=NAME_TO_DIM.__getitem__))
+    assert all(k.startswith("_pyro_dim_") or k in event_inputs for k in funsor_.inputs)
+    name_to_dim = NAME_TO_DIM
+    if event_inputs:
+        dim_to_name = DIM_TO_NAME + event_inputs
+        name_to_dim = dict(zip(dim_to_name, range(-len(dim_to_name), 0)))
+    names = tuple(sorted(funsor_.inputs, key=name_to_dim.__getitem__))
     tensor = funsor_.align(names).data
     if names:
-        # Unsqueeze batch_shape.
-        dims = list(map(NAME_TO_DIM.__getitem__, names))
-        batch_shape = [1] * (-dims[0])
+        # Unsqueeze shape of inputs.
+        dims = list(map(name_to_dim.__getitem__, names))
+        inputs_shape = [1] * (-dims[0])
         for dim, size in zip(dims, tensor.shape):
-            batch_shape[dim] = size
-        batch_shape = torch.Size(batch_shape)
-        tensor = tensor.reshape(batch_shape + funsor_.output.shape)
+            inputs_shape[dim] = size
+        inputs_shape = torch.Size(inputs_shape)
+        tensor = tensor.reshape(inputs_shape + funsor_.output.shape)
     if ndims != tensor.dim():
         tensor = tensor.reshape((1,) * (ndims - tensor.dim()) + tensor.shape)
     assert tensor.dim() == ndims
     return tensor
 
 
-def dist_to_funsor(pyro_dist, reinterpreted_batch_ndims=0):
+def dist_to_funsor(pyro_dist, event_inputs=()):
     """
     Convert a :class:`torch.distributions.Distribution` to a
     :class:`~funsor.terms.Funsor` .
     """
     assert isinstance(pyro_dist, torch.distributions.Distribution)
+
     while isinstance(pyro_dist, dist.Independent):
-        reinterpreted_batch_ndims += pyro_dist.reinterpreted_batch_ndims
         pyro_dist = pyro_dist.base_dist
-    event_dim = pyro_dist.event_dim + reinterpreted_batch_ndims
 
     if isinstance(pyro_dist, dist.Categorical):
-        return tensor_to_funsor(pyro_dist.logits, event_dim=event_dim + 1)
+        return tensor_to_funsor(pyro_dist.logits, event_inputs + ("value",))
+
     if isinstance(pyro_dist, dist.Normal):
-        raise NotImplementedError("TODO")
+        loc = tensor_to_funsor(pyro_dist.loc, event_inputs)
+        scale = tensor_to_funsor(pyro_dist.scale, event_inputs)
+        return Normal(loc, scale)
+
     if isinstance(pyro_dist, dist.MultivariateNormal):
-        raise NotImplementedError("TODO")
+        loc = tensor_to_funsor(pyro_dist.loc, event_inputs, 1)
+        scale_tril = tensor_to_funsor(pyro_dist.scale_tril, event_inputs, 2)
+        return MultivariateNormal(loc, scale_tril)
 
     raise ValueError("Cannot convert {} distribution to a Funsor"
                      .format(type(pyro_dist).__name__))

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -43,7 +43,7 @@ class FunsorDistribution(dist.TorchDistribution):
 
     def log_prob(self, value):
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
-        value = tensor_to_funsor(value, event_dim=self.event_dim, dtype=self.dtype)
+        value = tensor_to_funsor(value, event_output=self.event_dim, dtype=self.dtype)
         with interpretation(lazy):
             log_prob = apply_optimizer(self.funsor_dist(value=value))
         log_prob = reinterpret(log_prob)

--- a/test/pyro/test_convert.py
+++ b/test/pyro/test_convert.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from funsor.pyro.convert import dist_to_funsor, funsor_to_tensor, tensor_to_funsor
+from funsor.terms import Funsor
 from funsor.testing import assert_close
 from funsor.torch import Tensor
 
@@ -12,13 +13,17 @@ EVENT_SHAPES = [(), (1,), (5,), (4, 3)]
 BATCH_SHAPES = [(), (1,), (4,), (2, 3), (1, 2, 1, 3, 1)]
 
 
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+@pytest.mark.parametrize("event_shape,event_output", [
+    (shape, size)
+    for shape in EVENT_SHAPES
+    for size in range(len(shape))
+], ids=str)
 @pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-def test_tensor_funsor_tensor(batch_shape, event_shape):
-    event_dim = len(event_shape)
+def test_tensor_funsor_tensor(batch_shape, event_shape, event_output):
+    event_inputs = ("foo", "bar", "baz")[:len(event_shape) - event_output]
     t = torch.randn(batch_shape + event_shape)
-    f = tensor_to_funsor(t, event_dim=event_dim)
-    t2 = funsor_to_tensor(f, ndims=t.dim())
+    f = tensor_to_funsor(t, event_inputs, event_output)
+    t2 = funsor_to_tensor(f, t.dim(), event_inputs)
     assert_close(t2, t)
 
 
@@ -30,5 +35,36 @@ def test_dist_to_funsor_categorical(batch_shape, cardinality):
     d = dist.Categorical(logits=logits)
     f = dist_to_funsor(d)
     assert isinstance(f, Tensor)
-    expected = tensor_to_funsor(logits, event_dim=1)
+    expected = tensor_to_funsor(logits, ("value",))
     assert_close(f, expected)
+
+
+@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
+def test_dist_to_funsor_normal(batch_shape):
+    loc = torch.randn(batch_shape)
+    scale = torch.randn(batch_shape).exp()
+    d = dist.Normal(loc, scale)
+    f = dist_to_funsor(d)
+    assert isinstance(f, Funsor)
+
+    value = d.sample()
+    actual_log_prob = f(value=tensor_to_funsor(value))
+    expected_log_prob = tensor_to_funsor(d.log_prob(value))
+    assert_close(actual_log_prob, expected_log_prob)
+
+
+@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
+@pytest.mark.parametrize("event_size", [2, 3, 5])
+def test_dist_to_funsor_mvn(batch_shape, event_size):
+    loc = torch.randn(batch_shape + (event_size,))
+    cov = torch.randn(batch_shape + (event_size, 2 * event_size))
+    cov = cov.matmul(cov.transpose(-1, -2))
+    scale_tril = torch.cholesky(cov)
+    d = dist.MultivariateNormal(loc, scale_tril=scale_tril)
+    f = dist_to_funsor(d)
+    assert isinstance(f, Funsor)
+
+    value = d.sample()
+    actual_log_prob = f(value=tensor_to_funsor(value, event_output=1))
+    expected_log_prob = tensor_to_funsor(d.log_prob(value))
+    assert_close(actual_log_prob, expected_log_prob)

--- a/test/pyro/test_distribution.py
+++ b/test/pyro/test_distribution.py
@@ -15,7 +15,7 @@ class Categorical(FunsorDistribution):
     def __init__(self, logits):
         batch_shape = logits.shape[:-1]
         event_shape = torch.Size()
-        funsor_dist = tensor_to_funsor(logits, event_dim=1)["value"]
+        funsor_dist = tensor_to_funsor(logits, ("value",))
         dtype = int(logits.size(-1))
         super(Categorical, self).__init__(
             funsor_dist, batch_shape, event_shape, dtype)


### PR DESCRIPTION
This refactors funsor.pyro.convert to:
- more uniformly convert distributions to funsors
- more easily convert tensors to funsors

(apologies for the churn; I'm trying to keep #171 easy to review, and it requires this PR)