### PR TITLE
Use @singledispatch in dist_to_funsor; add more distributions

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1130,7 +1130,8 @@ class Independent(Funsor):
         return Independent(fn, self.reals_var, self.bint_var)
 
     def eager_subs(self, subs):
-        subs = tuple((self.reals_var_bound, v[self.bint_var])
+        subs = tuple((self.reals_var_bound,
+                      to_funsor(v, self.inputs[k])[self.bint_var])
                      if k == self.reals_var
                      else (k, v)
                      for k, v in subs)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -418,7 +418,7 @@ def eager_getitem_tensor_tensor(op, lhs, rhs):
         rhs_data = rhs_data.reshape(rhs_data.shape + (1,) * (len(lhs.output.shape) - 1))
 
     # Perform advanced indexing.
-    target_dim = len(lhs.inputs) + op.offset
+    target_dim = lhs_data.dim() - len(lhs.output.shape) + op.offset
     index = [None] * lhs_data.dim()
     for i in range(target_dim):
         index[i] = torch.arange(lhs_data.size(i)).reshape((-1,) + (1,) * (lhs_data.dim() - i - 2))


### PR DESCRIPTION
This improves `funsor.pyro.dist_to_funsor()` in a few ways:
- Supports `dist.Independent()` using `funsor.Independent` as suggested by @eb8680 
- Supports `dist.Bernoulli`
- Fixes two funsor bugs blocking `dist.Independent` (one in `Tensor`, one in `Indepenedent`)

This should be sufficient support for our first release.

## Tested
- added unit tests in test/pyro/test_convert.py