### PR TITLE
Support Gaussian funsors in sequential_sum_product

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -78,6 +78,15 @@ class Joint(Funsor, metaclass=JointMeta):
         self.discrete = discrete
         self.gaussian = gaussian
 
+    def align(self, names):
+        if not self.deltas:
+            discrete = self.discrete.align(tuple(k for k in names if k in self.discrete.inputs))
+            gaussian = self.gaussian.align(tuple(k for k in names if k in self.gaussian.inputs))
+            result = discrete + gaussian
+            if tuple(result.inputs) == names:
+                return result
+        return super(Joint, self).align(names)
+
     def eager_reduce(self, op, reduced_vars):
         if op is ops.logaddexp:
             # Keep mixture parameters lazy.

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -136,8 +136,6 @@ def Cat(parts, name):
             inputs[name] = part.inputs[name]  # typically a smaller bint
             int_inputs[name] = inputs[name]
             shape = tuple(d.size for d in int_inputs.values())
-            loc_shape = shape + (-1,)
-            precision_shape = shape + (-1, -1)
             if isinstance(part, Gaussian):
                 discrete = None
                 gaussian = part
@@ -148,8 +146,8 @@ def Cat(parts, name):
                 gaussian = part.gaussian
             discretes.append(discrete)
             loc, precision = align_gaussian(inputs, gaussian)
-            locs.append(loc.expand(loc_shape))
-            precisions.append(precision.expand(precision_shape))
+            locs.append(loc.expand(shape + (-1,)))
+            precisions.append(precision.expand(shape + (-1, -1)))
 
         dim = tuple(inputs).index(name)
         loc = torch.cat(locs, dim=dim)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -4,7 +4,9 @@ from functools import reduce
 import torch
 
 from funsor.domains import bint
-from funsor.ops import UNITS, Op
+from funsor.gaussian import Gaussian, align_gaussian
+from funsor.joint import Joint
+from funsor.ops import UNITS, AssociativeOp
 from funsor.terms import Funsor, Number
 from funsor.torch import Tensor, align_tensor
 
@@ -106,22 +108,64 @@ def Cat(parts, name):
         return parts[0]
     if len(set(part.output for part in parts)) > 1:
         raise NotImplementedError("TODO")
-    if not all(isinstance(part, Tensor) for part in parts):
-        raise NotImplementedError("TODO")
-
     inputs = OrderedDict()
     for x in parts:
         inputs.update(x.inputs)
-    tensors = []
-    for part in parts:
-        inputs[name] = part.inputs[name]
-        shape = tuple(d.size for d in inputs.values())
-        tensors.append(align_tensor(inputs, part).expand(shape))
 
-    dim = tuple(inputs).index(name)
-    tensor = torch.cat(tensors, dim=dim)
-    inputs[name] = bint(tensor.size(dim))
-    return Tensor(tensor, inputs, dtype=parts[0].dtype)
+    if all(isinstance(part, Tensor) for part in parts):
+        tensors = []
+        for part in parts:
+            inputs[name] = part.inputs[name]  # typically a smaller bint
+            shape = tuple(d.size for d in inputs.values())
+            tensors.append(align_tensor(inputs, part).expand(shape))
+
+        dim = tuple(inputs).index(name)
+        tensor = torch.cat(tensors, dim=dim)
+        inputs[name] = bint(tensor.size(dim))
+        return Tensor(tensor, inputs, dtype=parts[0].dtype)
+
+    if all(isinstance(part, (Gaussian, Joint)) for part in parts):
+        int_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype != "real")
+        real_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype == "real")
+        inputs = int_inputs.copy()
+        inputs.update(real_inputs)
+        discretes = []
+        locs = []
+        precisions = []
+        for part in parts:
+            inputs[name] = part.inputs[name]  # typically a smaller bint
+            int_inputs[name] = inputs[name]
+            shape = tuple(d.size for d in int_inputs.values())
+            loc_shape = shape + (-1,)
+            precision_shape = shape + (-1, -1)
+            if isinstance(part, Gaussian):
+                discrete = None
+                gaussian = part
+            elif isinstance(part, Joint):
+                if part.deltas:
+                    raise NotImplementedError("TODO")
+                discrete = align_tensor(int_inputs, part.discrete).expand(shape)
+                gaussian = part.gaussian
+            discretes.append(discrete)
+            loc, precision = align_gaussian(inputs, gaussian)
+            locs.append(loc.expand(loc_shape))
+            precisions.append(precision.expand(precision_shape))
+
+        dim = tuple(inputs).index(name)
+        loc = torch.cat(locs, dim=dim)
+        precision = torch.cat(precisions, dim=dim)
+        inputs[name] = bint(loc.size(dim))
+        int_inputs[name] = inputs[name]
+        result = Gaussian(loc, precision, inputs)
+        if any(d is not None for d in discretes):
+            for i, d in enumerate(discretes):
+                if d is None:
+                    discretes[i] = locs[i].new_zeros(locs[i].shape[:-1])
+            discrete = torch.cat(discretes, dim=dim)
+            result += Tensor(discrete, int_inputs)
+        return result
+
+    raise NotImplementedError("TODO")
 
 
 # TODO Promote this to a first class funsor, enabling zero-copy slicing.
@@ -165,23 +209,23 @@ def sequential_sum_product(sum_op, prod_op, trans, time, prev, curr):
 
     but does so efficiently in parallel in O(log(time)).
     """
-    assert isinstance(sum_op, Op)
-    assert isinstance(prod_op, Op)
+    assert isinstance(sum_op, AssociativeOp)
+    assert isinstance(prod_op, AssociativeOp)
     assert isinstance(trans, Funsor)
     assert isinstance(time, str)
     assert isinstance(prev, str)
     assert isinstance(curr, str)
 
-    while trans.inputs["time"].size > 1:
-        duration = trans.inputs["time"].size
+    while trans.inputs[time].size > 1:
+        duration = trans.inputs[time].size
         even_duration = duration // 2 * 2
         # TODO support syntax
         # x = trans(time=slice(0, even_duration, 2), ...)
-        x = trans(time=Slice("time", 0, even_duration, 2, duration), curr="_drop")
-        y = trans(time=Slice("time", 1, even_duration, 2, duration), prev="_drop")
+        x = trans(**{time: Slice("time", 0, even_duration, 2, duration), curr: "_drop"})
+        y = trans(**{time: Slice("time", 1, even_duration, 2, duration), prev: "_drop"})
         contracted = prod_op(x, y).reduce(sum_op, "_drop")
         if duration > even_duration:
-            extra = trans(time=Slice("time", duration - 1, duration))
-            contracted = Cat((contracted, extra), "time")
+            extra = trans(**{time: Slice(time, duration - 1, duration)})
+            contracted = Cat((contracted, extra), time)
         trans = contracted
     return trans(time=0)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -4,7 +4,7 @@ from functools import reduce
 import pytest
 
 import funsor.ops as ops
-from funsor.domains import bint
+from funsor.domains import bint, reals
 from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer
 from funsor.sum_product import _partition, partial_sum_product, sequential_sum_product, sum_product
@@ -83,16 +83,13 @@ def test_partial_sum_product(sum_op, prod_op, inputs, plates, vars1, vars2):
 
 
 @pytest.mark.parametrize('num_steps', list(range(1, 13)))
-@pytest.mark.parametrize('sum_op,prod_op', [
-    (ops.add, ops.mul),
-    (ops.logaddexp, ops.add),
-], ids=str)
-@pytest.mark.parametrize('state_domain', [
-    bint(2),
-    bint(3),
-    # TODO test with Gaussians.
-    # reals(),
-    # reals(2),
+@pytest.mark.parametrize('sum_op,prod_op,state_domain', [
+    (ops.add, ops.mul, bint(2)),
+    (ops.add, ops.mul, bint(3)),
+    (ops.logaddexp, ops.add, bint(2)),
+    (ops.logaddexp, ops.add, bint(3)),
+    (ops.logaddexp, ops.add, reals()),
+    (ops.logaddexp, ops.add, reals(2)),
 ], ids=str)
 @pytest.mark.parametrize('batch_inputs', [
     {},


### PR DESCRIPTION
Addresses #177 

This adds `Gaussian` support to `sequential_sum_product()`. This required:
- supporting `Gaussian` and `Joint` in our ad-hoc `Cat` funsor
- adding a `Joint.align()` method
- fixing typos in `sequential_sum_product()` (as @eb8680 and I noticed offline)

Note this means we can now implement asymptotically fast Kalman filter learning with funsor. (Provisos include: (1) only for full-rank observation distributions, (2) fast asymptotically, but with a big constant factor due to our broadcast-multiply-reduce implementation of gaussian_gemm).

## Tested
- added a grid of normal and multivariate normal tests to test_sum_product.py