### PR TITLE
Implement funsor.pyro.GaussianMRF

### DIFF
--- a/funsor/pyro/__init__.py
+++ b/funsor/pyro/__init__.py
@@ -1,7 +1,8 @@
 from funsor.pyro.distribution import FunsorDistribution
-from funsor.pyro.hmm import DiscreteHMM
+from funsor.pyro.hmm import DiscreteHMM, GaussianMRF
 
 __all__ = [
     "DiscreteHMM",
     "FunsorDistribution",
+    "GaussianMRF",
 ]

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -2,11 +2,13 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
+from funsor.domains import reals
+from funsor.gaussian import Gaussian
 from funsor.interpreter import interpretation
 from funsor.pyro.convert import dist_to_funsor, funsor_to_tensor, tensor_to_funsor
 from funsor.pyro.distribution import FunsorDistribution
 from funsor.sum_product import sequential_sum_product
-from funsor.terms import Variable, lazy
+from funsor.terms import Variable, lazy, Stack
 
 
 class DiscreteHMM(FunsorDistribution):
@@ -17,12 +19,11 @@ class DiscreteHMM(FunsorDistribution):
         assert initial_logits.dim() >= 1
         assert transition_logits.dim() >= 2
         assert len(observation_dist.batch_shape) >= 1
-        time_shape = broadcast_shape((1,), transition_logits.shape[-3:-2],
-                                     observation_dist.batch_shape[-2:-1])
+        shape = broadcast_shape(initial_logits.shape[:-1] + (1,),
+                                transition_logits.shape[:-2],
+                                observation_dist.batch_shape[:-1])
+        batch_shape, time_shape = shape[:-1], shape[-1:]
         event_shape = time_shape + observation_dist.event_shape
-        batch_shape = broadcast_shape(initial_logits.shape[:-1],
-                                      transition_logits.shape[:-3],
-                                      observation_dist.batch_shape[:-2])
         self._has_rsample = observation_dist.has_rsample
 
         # Normalize.
@@ -80,4 +81,77 @@ class DiscreteHMM(FunsorDistribution):
         new._trans = self._trans
         new._obs = self._obs
         super(DiscreteHMM, new).__init__(self.funsor_dist, batch_shape, self.event_shape)
+        return new
+
+
+class GaussianMRF(FunsorDistribution):
+    has_rsample = True
+
+    def __init__(self, initial_dist, transition_dist, observation_dist):
+        assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
+        hidden_dim = initial_dist.event_shape[0]
+        assert transition_dist.event_shape[0] == hidden_dim + hidden_dim
+        obs_dim = observation_dist.event_shape[0] - hidden_dim
+        shape = broadcast_shape(initial_dist.batch_shape + (1,),
+                                transition_dist.batch_shape,
+                                observation_dist.batch_shape)
+        batch_shape, time_shape = shape[:-1], shape[-1:]
+        event_shape = time_shape + (obs_dim,)
+
+        # Convert distributions to funsors.
+        init = dist_to_funsor(initial_dist)(value="state")
+        trans_inputs = tensor_to_funsor(transition_dist.loc, ("time",), 1).inputs.copy()
+        trans_inputs["state"] = reals(hidden_dim)
+        trans_inputs["state(time=1)"] = reals(hidden_dim)
+        trans = Gaussian(transition_dist.loc, transition_dist.precision_matrix, trans_inputs)
+        obs_inputs = tensor_to_funsor(observation_dist.loc, ("time",), 1).inputs.copy()
+        obs_inputs["state(time=1)"] = reals(hidden_dim)
+        obs_inputs["value"] = reals(obs_dim)
+        obs = Gaussian(observation_dist.loc, observation_dist.precision_matrix, obs_inputs)
+
+        # Construct the joint funsor.
+        with interpretation(lazy):
+            # TODO perform math here once sequential_sum_product has been
+            #   implemented as a first-class funsor.
+            funsor_dist = Variable("value", obs.inputs["value"])  # a bogus value
+            # Until funsor_dist is defined, we save factors for hand-computation in .log_prob().
+            self._init = init
+            self._trans = trans
+            self._obs = obs
+
+        super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape)
+
+    # TODO remove this once self.funsor_dist is defined.
+    def log_prob(self, value):
+        ndims = max(len(self.batch_shape), value.dim() - 1)
+        value = tensor_to_funsor(value, ("time",), 1)
+
+        # Compare with pyro.distributions.hmm.GaussianMRF.log_prob().
+        logp_oh = self._trans + self._obs(value=value)
+        logp_h = self._trans + self._obs.reduce(ops.logaddexp, "value")
+        logp = Stack((logp_oh, logp_h), "_stack")  # TODO add eager_stack_gaussian
+        logp = sequential_sum_product(ops.logaddexp, ops.add,
+                                      logp, "time", "state", "state(time=1)")
+        logp += self._init
+        logp = logp.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
+        logp_oh, logp_h = logp(_stack=0), logp(_stack=1)
+        result = logp_oh - logp_h
+
+        result = funsor_to_tensor(result, ndims=ndims)
+        return result
+
+    # TODO remove this once self.funsor_dist is defined.
+    def _sample_delta(self, sample_shape):
+        raise NotImplementedError("TODO")
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(DiscreteHMM, _instance)
+        batch_shape = torch.Size(batch_shape)
+        new._has_rsample = self._has_rsample
+        new._init = self._init
+        new._trans = self._trans
+        new._obs = self._obs
+        super(GaussianMRF, new).__init__(self.funsor_dist, batch_shape, self.event_shape)
         return new

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -125,7 +125,7 @@ class GaussianMRF(FunsorDistribution):
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
-        ndims = max(len(self.batch_shape), value.dim() - 1)
+        ndims = max(len(self.batch_shape), value.dim() - 2)
         value = tensor_to_funsor(value, ("time",), 1)
 
         # Compare with pyro.distributions.hmm.GaussianMRF.log_prob().

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -1,14 +1,15 @@
+from collections import OrderedDict
+
 import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
 from funsor.domains import reals
-from funsor.gaussian import Gaussian
 from funsor.interpreter import interpretation
-from funsor.pyro.convert import dist_to_funsor, funsor_to_tensor, tensor_to_funsor
+from funsor.pyro.convert import dist_to_funsor, funsor_to_tensor, mvn_to_funsor, tensor_to_funsor
 from funsor.pyro.distribution import FunsorDistribution
 from funsor.sum_product import sequential_sum_product
-from funsor.terms import Variable, lazy, Stack
+from funsor.terms import Variable, lazy
 
 
 class DiscreteHMM(FunsorDistribution):
@@ -102,14 +103,12 @@ class GaussianMRF(FunsorDistribution):
 
         # Convert distributions to funsors.
         init = dist_to_funsor(initial_dist)(value="state")
-        trans_inputs = tensor_to_funsor(transition_dist.loc, ("time",), 1).inputs.copy()
-        trans_inputs["state"] = reals(hidden_dim)
-        trans_inputs["state(time=1)"] = reals(hidden_dim)
-        trans = Gaussian(transition_dist.loc, transition_dist.precision_matrix, trans_inputs)
-        obs_inputs = tensor_to_funsor(observation_dist.loc, ("time",), 1).inputs.copy()
-        obs_inputs["state(time=1)"] = reals(hidden_dim)
-        obs_inputs["value"] = reals(obs_dim)
-        obs = Gaussian(observation_dist.loc, observation_dist.precision_matrix, obs_inputs)
+        trans = mvn_to_funsor(transition_dist, ("time",),
+                              OrderedDict([("state", reals(hidden_dim)),
+                                           ("state(time=1)", reals(hidden_dim))]))
+        obs = mvn_to_funsor(observation_dist, ("time",),
+                            OrderedDict([("state(time=1)", reals(hidden_dim)),
+                                         ("value", reals(obs_dim))]))
 
         # Construct the joint funsor.
         with interpretation(lazy):
@@ -130,13 +129,15 @@ class GaussianMRF(FunsorDistribution):
 
         # Compare with pyro.distributions.hmm.GaussianMRF.log_prob().
         logp_oh = self._trans + self._obs(value=value)
+        logp_oh = sequential_sum_product(ops.logaddexp, ops.add,
+                                         logp_oh, "time", "state", "state(time=1)")
+        logp_oh += self._init
+        logp_oh = logp_oh.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
         logp_h = self._trans + self._obs.reduce(ops.logaddexp, "value")
-        logp = Stack((logp_oh, logp_h), "_stack")  # TODO add eager_stack_gaussian
-        logp = sequential_sum_product(ops.logaddexp, ops.add,
-                                      logp, "time", "state", "state(time=1)")
-        logp += self._init
-        logp = logp.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
-        logp_oh, logp_h = logp(_stack=0), logp(_stack=1)
+        logp_h = sequential_sum_product(ops.logaddexp, ops.add,
+                                        logp_h, "time", "state", "state(time=1)")
+        logp_h += self._init
+        logp_h = logp_h.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
         result = logp_oh - logp_h
 
         result = funsor_to_tensor(result, ndims=ndims)

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -143,4 +143,4 @@ def test_gaussian_mrf_log_prob(init_shape, trans_shape, obs_shape, hidden_dim, o
     data = obs_dist.expand(batch_shape).sample()[..., hidden_dim:]
     actual_log_prob = actual_dist.log_prob(data)
     expected_log_prob = expected_dist.log_prob(data)
-    assert_close(actual_log_prob, expected_log_prob)
+    assert_close(actual_log_prob, expected_log_prob, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
Addresses #177 

This adds a `GaussianMRF` similar to Pyro's and to `funsor.pyro.hmm.DiscreteHMM`.

I've added a new converter `mvn_to_funsor` to convert Pyro distributions that are to be interpreted as joint distributions over multiple differently-shaped random variables.

## Tested
- unit tests for `mvn_to_funsor()`
- tested `GaussianMRF` against `pyro.distributions.GaussianMRF` implementation