### PR TITLE
Add arg validation logic to funsor.pyro.FunsorDistribution

### DIFF
--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import pyro.distributions as dist
 import torch
+from torch.distributions import constraints
 
 from funsor.delta import Delta
 from funsor.domains import bint
@@ -30,16 +31,25 @@ class FunsorDistribution(dist.TorchDistribution):
     arg_constraints = {}
 
     def __init__(self, funsor_dist, batch_shape=torch.Size(), event_shape=torch.Size(),
-                 dtype="real"):
+                 dtype="real", validate_args=None):
         assert isinstance(funsor_dist, Funsor)
         assert isinstance(batch_shape, tuple)
         assert isinstance(event_shape, tuple)
         assert "value" in funsor_dist.inputs
-        super(FunsorDistribution, self).__init__(batch_shape, event_shape)
+        super(FunsorDistribution, self).__init__(batch_shape, event_shape, validate_args)
         self.funsor_dist = funsor_dist
         self.dtype = dtype
 
+    @constraints.dependent_property
+    def support(self):
+        if self.dtype == "real":
+            return constraints.real
+        else:
+            return constraints.integer_interval(0, self.dtype - 1)
+
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
         value = tensor_to_funsor(value, event_output=self.event_dim, dtype=self.dtype)
         with interpretation(lazy):

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -13,7 +13,7 @@ from funsor.terms import Variable, lazy
 
 
 class DiscreteHMM(FunsorDistribution):
-    def __init__(self, initial_logits, transition_logits, observation_dist):
+    def __init__(self, initial_logits, transition_logits, observation_dist, validate_args=None):
         assert isinstance(initial_logits, torch.Tensor)
         assert isinstance(transition_logits, torch.Tensor)
         assert isinstance(observation_dist, torch.distributions.Distribution)
@@ -47,7 +47,7 @@ class DiscreteHMM(FunsorDistribution):
             self._trans = trans
             self._obs = obs
 
-        super(DiscreteHMM, self).__init__(funsor_dist, batch_shape, event_shape, dtype)
+        super(DiscreteHMM, self).__init__(funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     @torch.distributions.constraints.dependent_property
     def has_rsample(self):
@@ -55,6 +55,8 @@ class DiscreteHMM(FunsorDistribution):
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
         value = tensor_to_funsor(value, ("time",), event_output=self.event_dim - 1,
                                  dtype=self.dtype)
@@ -88,7 +90,7 @@ class DiscreteHMM(FunsorDistribution):
 class GaussianMRF(FunsorDistribution):
     has_rsample = True
 
-    def __init__(self, initial_dist, transition_dist, observation_dist):
+    def __init__(self, initial_dist, transition_dist, observation_dist, validate_args=None):
         assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
         assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
         assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
@@ -120,10 +122,13 @@ class GaussianMRF(FunsorDistribution):
             self._trans = trans
             self._obs = obs
 
-        super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape)
+        dtype = "real"
+        super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - 2)
         value = tensor_to_funsor(value, ("time",), 1)
 

--- a/test/pyro/test_distribution.py
+++ b/test/pyro/test_distribution.py
@@ -10,13 +10,13 @@ SHAPES = [(), (1,), (4,), (2, 3), (1, 2, 1, 3, 1)]
 
 
 class Categorical(FunsorDistribution):
-    def __init__(self, logits):
+    def __init__(self, logits, validate_args=None):
         batch_shape = logits.shape[:-1]
         event_shape = torch.Size()
         funsor_dist = tensor_to_funsor(logits, ("value",))
         dtype = int(logits.size(-1))
         super(Categorical, self).__init__(
-            funsor_dist, batch_shape, event_shape, dtype)
+            funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
 
 @pytest.mark.parametrize("cardinality", [2, 3])


### PR DESCRIPTION
Adding arg validation in `.log_prob()` methods can surface shape errors early, thus sparing users inscrutable error messages from deep in funsor.