### PR TITLE
Implement funsor.pyro.GaussianDiscreteMRF

### DIFF
--- a/funsor/pyro/__init__.py
+++ b/funsor/pyro/__init__.py
@@ -1,8 +1,9 @@
 from funsor.pyro.distribution import FunsorDistribution
-from funsor.pyro.hmm import DiscreteHMM, GaussianMRF
+from funsor.pyro.hmm import DiscreteHMM, GaussianDiscreteMRF, GaussianMRF
 
 __all__ = [
     "DiscreteHMM",
     "FunsorDistribution",
+    "GaussianDiscreteMRF",
     "GaussianMRF",
 ]

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -31,12 +31,12 @@ class FunsorDistribution(dist.TorchDistribution):
     arg_constraints = {}
 
     def __init__(self, funsor_dist, batch_shape=torch.Size(), event_shape=torch.Size(),
-                 dtype="real"):
+                 dtype="real", validate_args=None):
         assert isinstance(funsor_dist, Funsor)
         assert isinstance(batch_shape, tuple)
         assert isinstance(event_shape, tuple)
         assert "value" in funsor_dist.inputs
-        super(FunsorDistribution, self).__init__(batch_shape, event_shape)
+        super(FunsorDistribution, self).__init__(batch_shape, event_shape, validate_args)
         self.funsor_dist = funsor_dist
         self.dtype = dtype
 

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 import torch
 from pyro.distributions.util import broadcast_shape
-from torch.distributions import constraints
 
 import funsor.ops as ops
 from funsor.domains import reals
@@ -62,6 +61,8 @@ class DiscreteHMM(FunsorDistribution):
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
         value = tensor_to_funsor(value, ("time",), event_output=self.event_dim - 1,
                                  dtype=self.dtype)
@@ -131,6 +132,8 @@ class GaussianMRF(FunsorDistribution):
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - 2)
         value = tensor_to_funsor(value, ("time",), 1)
 
@@ -236,10 +239,6 @@ class GaussianDiscreteMRF(FunsorDistribution):
             self._obs = obs
 
         super(GaussianDiscreteMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype)
-
-    @constraints.dependent_property
-    def support(self):
-        return constraints.integer_interval(0, self.dtype - 1)
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -6,10 +6,16 @@ from pyro.distributions.util import broadcast_shape
 import funsor.ops as ops
 from funsor.domains import reals
 from funsor.interpreter import interpretation
-from funsor.pyro.convert import dist_to_funsor, funsor_to_tensor, mvn_to_funsor, tensor_to_funsor
+from funsor.pyro.convert import (
+    dist_to_funsor,
+    funsor_to_tensor,
+    matrix_and_mvn_to_funsor,
+    mvn_to_funsor,
+    tensor_to_funsor
+)
 from funsor.pyro.distribution import FunsorDistribution
 from funsor.sum_product import sequential_sum_product
-from funsor.terms import Variable, lazy
+from funsor.terms import Variable, lazy, moment_matching
 
 
 class DiscreteHMM(FunsorDistribution):
@@ -155,4 +161,111 @@ class GaussianMRF(FunsorDistribution):
         new._trans = self._trans
         new._obs = self._obs
         super(GaussianMRF, new).__init__(self.funsor_dist, batch_shape, self.event_shape)
+        return new
+
+
+class GaussianDiscreteMRF(FunsorDistribution):
+    """
+    Temporal Markov Random Field with Gaussian latent state and discrete
+    observations, where observation factors are mixtures-of-gaussians.
+
+    This distribution uses the :func:`~funsor.terms.moment_matching`
+    approximation to perform inference in the following Pyro model, where
+    ``state`` be the latent multivariate normal state, ``prediction`` is the
+    predicted future state, and ``obs`` is the discrete observation::
+
+        def model(data):
+            state = pyro.sample("state_0", initial_dist)
+            for t in range(len(data)):
+                noise = pyro.sample("noise_{}".format(t), transition_dist)
+                state = state @ transition_matrix[t] + noise
+                obs = pyro.sample("x_{}".format(t),
+                                  dist.Categorical(observation_logits),
+                                  obs=data[t])
+                pyro.sample("state_{}".format(t), observation_dist[t, data[t]],
+                            obs=state)
+
+    :param ~torch.distributions.MultivariateNormal initial_dist: Represents
+        ``p(state[0])``.
+    :param ~torch.Tensor transition_matrix: Transforms ``state[t]`` to
+        ``prediction[t+1]``.
+    :param ~torch.distributions.MultivariateNormal transition_dist: Represents
+        ``p(state[t+1] | prediction[t+1])``.
+    :param ~torch.Tensor observation_logits: Represents ``p(obs[t+1])``.
+    :param ~torch.distributions.MultivariateNormal observation_dist: Represents
+        ``p(state[t+1] | obs[t+1])``.
+    """
+    def __init__(self, initial_dist, transition_matrix, transition_dist,
+                 observation_logits, observation_dist):
+        assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(transition_matrix, torch.Tensor)
+        assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(observation_logits, torch.Tensor)
+        assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
+        hidden_dim = initial_dist.event_shape[0]
+        obs_dim = observation_logits.size(-1)
+        assert transition_matrix.shape[-2:] == (hidden_dim, hidden_dim)
+        assert transition_dist.event_shape[0] == hidden_dim
+        assert observation_dist.shape()[-2:] == (obs_dim, hidden_dim)
+        shape = broadcast_shape(initial_dist.batch_shape + (1,),
+                                transition_matrix.shape[:-2],
+                                transition_dist.batch_shape,
+                                observation_logits.shape[:-1],
+                                observation_dist.batch_shape[:-1])
+        batch_shape, event_shape = shape[:-1], shape[-1:]
+
+        # Convert distributions to funsors.
+        init = dist_to_funsor(initial_dist)(value="state")
+        trans = matrix_and_mvn_to_funsor(transition_matrix, transition_dist,
+                                         ("time",), "state", "state(time=1)")
+        obs_mvn = dist_to_funsor(observation_dist, ("time", "_value"))
+        obs = (obs_mvn(value="state(time=1)")(_value="value") +
+               tensor_to_funsor(observation_logits, ("time", "value")))
+        dtype = obs.inputs["value"].dtype
+
+        # Construct the joint funsor.
+        with interpretation(lazy):
+            # TODO perform math here once sequential_sum_product has been
+            #   implemented as a first-class funsor.
+            funsor_dist = Variable("value", obs.inputs["value"])  # a bogus value
+            # Until funsor_dist is defined, we save factors for hand-computation in .log_prob().
+            self._init = init
+            self._trans = trans
+            self._obs = obs
+
+        super(GaussianDiscreteMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype)
+
+    # TODO remove this once self.funsor_dist is defined.
+    def log_prob(self, value):
+        ndims = max(len(self.batch_shape), value.dim() - 1)
+        value = tensor_to_funsor(value, ("time",), dtype=self.dtype)
+
+        with interpretation(moment_matching):
+            logp_oh = self._trans + self._obs(value=value)
+            logp_oh = sequential_sum_product(ops.logaddexp, ops.add,
+                                             logp_oh, "time", "state", "state(time=1)")
+            logp_oh += self._init
+            logp_oh = logp_oh.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
+            logp_h = self._trans + self._obs.reduce(ops.logaddexp, "value")
+            logp_h = sequential_sum_product(ops.logaddexp, ops.add,
+                                            logp_h, "time", "state", "state(time=1)")
+            logp_h += self._init
+            logp_h = logp_h.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
+            result = logp_oh - logp_h
+
+        result = funsor_to_tensor(result, ndims=ndims)
+        return result
+
+    # TODO remove this once self.funsor_dist is defined.
+    def _sample_delta(self, sample_shape):
+        raise NotImplementedError("TODO")
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(DiscreteHMM, _instance)
+        batch_shape = torch.Size(batch_shape)
+        new._has_rsample = self._has_rsample
+        new._init = self._init
+        new._trans = self._trans
+        new._obs = self._obs
+        super(GaussianDiscreteMRF, new).__init__(self.funsor_dist, batch_shape, self.event_shape)
         return new

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -19,7 +19,7 @@ from funsor.terms import Variable, lazy, moment_matching
 
 
 class DiscreteHMM(FunsorDistribution):
-    def __init__(self, initial_logits, transition_logits, observation_dist):
+    def __init__(self, initial_logits, transition_logits, observation_dist, validate_args=None):
         assert isinstance(initial_logits, torch.Tensor)
         assert isinstance(transition_logits, torch.Tensor)
         assert isinstance(observation_dist, torch.distributions.Distribution)
@@ -53,7 +53,7 @@ class DiscreteHMM(FunsorDistribution):
             self._trans = trans
             self._obs = obs
 
-        super(DiscreteHMM, self).__init__(funsor_dist, batch_shape, event_shape, dtype)
+        super(DiscreteHMM, self).__init__(funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     @torch.distributions.constraints.dependent_property
     def has_rsample(self):
@@ -96,7 +96,7 @@ class DiscreteHMM(FunsorDistribution):
 class GaussianMRF(FunsorDistribution):
     has_rsample = True
 
-    def __init__(self, initial_dist, transition_dist, observation_dist):
+    def __init__(self, initial_dist, transition_dist, observation_dist, validate_args=None):
         assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
         assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
         assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
@@ -128,7 +128,8 @@ class GaussianMRF(FunsorDistribution):
             self._trans = trans
             self._obs = obs
 
-        super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape)
+        dtype = "real"
+        super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):
@@ -201,7 +202,7 @@ class GaussianDiscreteMRF(FunsorDistribution):
         ``p(state[t+1] | obs[t+1])``.
     """
     def __init__(self, initial_dist, transition_matrix, transition_dist,
-                 observation_logits, observation_dist):
+                 observation_logits, observation_dist, validate_args=None):
         assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
         assert isinstance(transition_matrix, torch.Tensor)
         assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
@@ -238,7 +239,8 @@ class GaussianDiscreteMRF(FunsorDistribution):
             self._trans = trans
             self._obs = obs
 
-        super(GaussianDiscreteMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype)
+        super(GaussianDiscreteMRF, self).__init__(
+            funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     # TODO remove this once self.funsor_dist is defined.
     def log_prob(self, value):

--- a/test/pyro/test_distribution.py
+++ b/test/pyro/test_distribution.py
@@ -1,6 +1,7 @@
 import pyro.distributions as dist
 import pytest
 import torch
+from torch.distributions import constraints
 
 from funsor.pyro.convert import tensor_to_funsor
 from funsor.pyro.distribution import FunsorDistribution
@@ -17,6 +18,10 @@ class Categorical(FunsorDistribution):
         dtype = int(logits.size(-1))
         super(Categorical, self).__init__(
             funsor_dist, batch_shape, event_shape, dtype)
+
+    @constraints.dependent_property
+    def support(self):
+        return constraints.integer_interval(0, self.dtype - 1)
 
 
 @pytest.mark.parametrize("cardinality", [2, 3])

--- a/test/pyro/test_distribution.py
+++ b/test/pyro/test_distribution.py
@@ -11,13 +11,13 @@ SHAPES = [(), (1,), (4,), (2, 3), (1, 2, 1, 3, 1)]
 
 
 class Categorical(FunsorDistribution):
-    def __init__(self, logits):
+    def __init__(self, logits, validate_args=None):
         batch_shape = logits.shape[:-1]
         event_shape = torch.Size()
         funsor_dist = tensor_to_funsor(logits, ("value",))
         dtype = int(logits.size(-1))
         super(Categorical, self).__init__(
-            funsor_dist, batch_shape, event_shape, dtype)
+            funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
     @constraints.dependent_property
     def support(self):


### PR DESCRIPTION
Based on #181 

This adds a FunsorDistribution with latent Gaussian state and discrete observations. It uses the moment matching approximation to compute an approximate log normalizer. This also adds a `matrix_and_mvn_to_funsor()` helper similar to `pyro.ops.gaussian.matrix_and_mvn_to_gaussian()` in https://github.com/pyro-ppl/pyro/pull/1984.

## Questions for reviewers

1. Any ideas why the log normalizer is so far off? I would have expected moment matching to be more accurate, but test threshold is 4.0 (in log space)
2. Any ideas for how to test `.log_prob()` for this model? I guess I could use SVI...

## Tested
- [x] unit tests for `matrix_and_mvn_to_funsor()`
- [x] shape tests for `GaussianDiscreteMRF`
- [x] normalization tests for `GaussianDiscreteMRF` (these are very inaccurate)
- [ ] test for `GaussianDiscreteMRF.log_prob()`