### PR TITLE
Implement funsor.pyro.GaussianHMM

### DIFF
--- a/funsor/pyro/__init__.py
+++ b/funsor/pyro/__init__.py
@@ -1,8 +1,9 @@
 from funsor.pyro.distribution import FunsorDistribution
-from funsor.pyro.hmm import DiscreteHMM, GaussianMRF
+from funsor.pyro.hmm import DiscreteHMM, GaussianHMM, GaussianMRF
 
 __all__ = [
     "DiscreteHMM",
     "FunsorDistribution",
+    "GaussianHMM",
     "GaussianMRF",
 ]

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -2,8 +2,8 @@ import math
 from collections import OrderedDict
 from functools import singledispatch
 
-import pyro.distributions as dist
 import torch
+import torch.distributions as dist
 from pyro.distributions.torch_distribution import MaskedDistribution
 from pyro.distributions.util import broadcast_shape
 

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -5,10 +5,11 @@ from functools import singledispatch
 import pyro.distributions as dist
 import torch
 from pyro.distributions.torch_distribution import MaskedDistribution
+from pyro.distributions.util import broadcast_shape
 
 from funsor.distributions import BernoulliLogits, MultivariateNormal, Normal
-from funsor.domains import bint
-from funsor.gaussian import Gaussian
+from funsor.domains import bint, reals
+from funsor.gaussian import Gaussian, cholesky_solve
 from funsor.terms import Independent
 from funsor.torch import Tensor
 
@@ -91,6 +92,45 @@ def mvn_to_funsor(pyro_dist, event_dims=(), real_inputs=OrderedDict()):
     inputs = loc.inputs.copy()
     inputs.update(real_inputs)
     return Tensor(log_prob, loc.inputs) + Gaussian(info_vec, precision.data, inputs)
+
+
+def matrix_and_mvn_to_funsor(matrix, mvn, event_dims=(), x_name="value_x", y_name="value_y"):
+    """
+    Convert a noisy affine function to a Gaussian. The noisy affine function is defined as::
+
+        y = x @ matrix + mvn.sample()
+
+    :param ~torch.Tensor matrix: A matrix with rightmost shape ``(x_size, y_size)``.
+    :param ~torch.distributions.MultivariateNormal mvn: A multivariate normal
+        distribution with ``event_shape == (y_size,)``.
+    """
+    assert isinstance(mvn, torch.distributions.MultivariateNormal)
+    assert isinstance(matrix, torch.Tensor)
+    x_size, y_size = matrix.shape[-2:]
+    assert mvn.event_shape == (y_size,)
+    info_vec = cholesky_solve(mvn.loc.unsqueeze(-1), mvn.scale_tril).squeeze(-1)
+    log_prob = (-0.5 * y_size * math.log(2 * math.pi)
+                - mvn.scale_tril.diagonal(dim1=-1, dim2=-2).log().sum(-1)
+                - 0.5 * (info_vec * mvn.loc).sum(-1))
+
+    batch_shape = broadcast_shape(matrix.shape[:-2], mvn.batch_shape)
+    P_yy = mvn.precision_matrix.expand(batch_shape + (y_size, y_size))
+    neg_P_xy = matrix.matmul(P_yy)
+    P_xy = -neg_P_xy
+    P_yx = P_xy.transpose(-1, -2)
+    P_xx = neg_P_xy.matmul(matrix.transpose(-1, -2))
+    precision = torch.cat([torch.cat([P_xx, P_xy], -1),
+                           torch.cat([P_yx, P_yy], -1)], -2)
+    info_y = info_vec.expand(batch_shape + (y_size,))
+    info_x = -matrix.matmul(info_y.unsqueeze(-1)).squeeze(-1)
+    info_vec = torch.cat([info_x, info_y], -1)
+
+    info_vec = tensor_to_funsor(info_vec, event_dims, 1)
+    precision = tensor_to_funsor(precision, event_dims, 2)
+    inputs = info_vec.inputs.copy()
+    inputs[x_name] = reals(x_size)
+    inputs[y_name] = reals(y_size)
+    return tensor_to_funsor(log_prob, event_dims) + Gaussian(info_vec.data, precision.data, inputs)
 
 
 @singledispatch

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -195,6 +195,17 @@ def random_gaussian(inputs):
     return Gaussian(info_vec, precision, inputs)
 
 
+def random_mvn(batch_shape, dim):
+    """
+    Generate a random :class:`torch.distributions.MultivariateNormal` with given shape.
+    """
+    rank = dim + dim
+    loc = torch.randn(batch_shape + (dim,))
+    cov = torch.randn(batch_shape + (dim, rank))
+    cov = cov.matmul(cov.transpose(-1, -2))
+    return torch.distributions.MultivariateNormal(loc, cov)
+
+
 def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
 
     assert num_obs_plates >= num_hidden_plates

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -1,17 +1,12 @@
+import warnings
+
 import pyro.distributions as dist
 import pytest
 import torch
 from pyro.distributions.util import broadcast_shape
 
-from funsor.pyro.hmm import DiscreteHMM, GaussianMRF
-from funsor.testing import assert_close, xfail_param
-
-
-def random_mvn(batch_shape, dim):
-    loc = torch.randn(batch_shape + (dim,))
-    cov = torch.randn(batch_shape + (dim, 2 * dim))
-    cov = cov.matmul(cov.transpose(-1, -2))
-    return dist.MultivariateNormal(loc, cov)
+from funsor.pyro.hmm import DiscreteHMM, GaussianHMM, GaussianMRF
+from funsor.testing import assert_close, xfail_param, random_mvn
 
 
 DISCRETE_HMM_SHAPES = [
@@ -124,6 +119,52 @@ def test_discrete_diag_normal_log_prob(init_shape, trans_shape, obs_shape, state
     actual_log_prob = actual_dist.log_prob(data)
     expected_log_prob = expected_dist.log_prob(data)
     assert_close(actual_log_prob, expected_log_prob, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("obs_dim", [1, 2, 3])
+@pytest.mark.parametrize("hidden_dim", [1, 2, 3])
+@pytest.mark.parametrize("init_shape,trans_mat_shape,trans_mvn_shape,obs_mat_shape,obs_mvn_shape", [
+    ((), (6,), (), (), ()),
+    ((), (), (6,), (), ()),
+    ((), (), (), (6,), ()),
+    ((), (), (), (), (6,)),
+    ((), (6,), (6,), (6,), (6,)),
+    ((5,), (6,), (), (), ()),
+    ((), (5, 1), (6,), (), ()),
+    ((), (), (5, 1), (6,), ()),
+    ((), (), (), (5, 1), (6,)),
+    ((), (6,), (5, 1), (), ()),
+    ((), (), (6,), (5, 1), ()),
+    ((), (), (), (6,), (5, 1)),
+    ((5,), (), (), (), (6,)),
+    ((5,), (5, 6), (5, 6), (5, 6), (5, 6)),
+], ids=str)
+def test_gaussian_hmm_log_prob(init_shape, trans_mat_shape, trans_mvn_shape,
+                               obs_mat_shape, obs_mvn_shape, hidden_dim, obs_dim):
+    init_dist = random_mvn(init_shape, hidden_dim)
+    trans_mat = torch.randn(trans_mat_shape + (hidden_dim, hidden_dim))
+    trans_dist = random_mvn(trans_mvn_shape, hidden_dim)
+    obs_mat = torch.randn(obs_mat_shape + (hidden_dim, obs_dim))
+    obs_dist = random_mvn(obs_mvn_shape, obs_dim)
+
+    actual_dist = GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    expected_dist = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    assert actual_dist.batch_shape == expected_dist.batch_shape
+    assert actual_dist.event_shape == expected_dist.event_shape
+
+    shape = broadcast_shape(init_shape + (1,),
+                            trans_mat_shape, trans_mvn_shape,
+                            obs_mat_shape, obs_mvn_shape)
+    data = obs_dist.expand(shape).sample()
+    assert data.shape == actual_dist.shape()
+
+    # https://github.com/pyro-ppl/funsor/issues/184
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+    actual_log_prob = actual_dist.log_prob(data)
+
+    expected_log_prob = expected_dist.log_prob(data)
+    assert_close(actual_log_prob, expected_log_prob, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.parametrize("obs_dim", [1, 2, 3])


### PR DESCRIPTION
Addresses #177 
~~Blocked by #186~~

This implements a `GaussianHMM` distribution using a parallel scan algorithm. This is nearly identical to https://github.com/pyro-ppl/pyro/pull/1984, including the helper `matrix_and_mvn_to_funsor()`.

## Tested
- tested against `pyro.distributions.GaussianHMM`
- unit test for `matrix_and_mvn_to_funsor()`