### PR TITLE
Fix normalization bug in moment_matching interpretation

### DIFF
--- a/examples/slds.py
+++ b/examples/slds.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Switching linear dynamical system")
     parser.add_argument("-t", "--time-steps", default=10, type=int)
     parser.add_argument("-n", "--train-steps", default=101, type=int)
-    parser.add_argument("-lr", "--learning-rate", default=0.05, type=float)
+    parser.add_argument("-lr", "--learning-rate", default=0.01, type=float)
     parser.add_argument("--filter", action='store_true')
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -1,5 +1,4 @@
 import math
-import warnings
 from collections import OrderedDict, defaultdict
 from functools import reduce
 
@@ -57,41 +56,6 @@ def cholesky_inverse(u):
     if u.dim() == 2:
         return u.cholesky_inverse()
     return cholesky_solve(torch.eye(u.size(-1)).expand(u.size()), u)
-
-
-def _pinverse(mat):
-    """
-    Like torch.pinverse() but supports batching.
-    """
-    shape = mat.shape
-    mat = mat.reshape((-1,) + mat.shape[-2:])
-    if mat.size(0) == 1:
-        flat = mat[0].pinverse()
-    else:
-        flat = torch.stack([m.pinverse() for m in mat])
-    return flat.reshape(shape)
-
-
-def sym_inverse(mat):
-    r"""
-    Computes ``inverse(mat)`` assuming mat is symmetric and usually positive
-    definite, but falling back to general pseudoinverse if positive
-    definiteness fails.
-    """
-    try:
-        # Attempt to use stable positive definite math.
-        return cholesky_inverse(mat.cholesky())
-    except RuntimeError as e:
-        warnings.warn(e, RuntimeWarning)
-
-    # Try masked reciprocal.
-    if mat.size(-1) == 1:
-        result = mat.reciprocal()
-        result[(mat != 0) == 0] = 0
-        return result
-
-    # Fall back to pseudoinverse.
-    return _pinverse(mat)
 
 
 def _compute_offsets(inputs):

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -1,5 +1,4 @@
 import functools
-import math
 from collections import OrderedDict
 from functools import reduce
 
@@ -8,7 +7,7 @@ import funsor.ops as ops
 import funsor.terms
 from funsor.delta import Delta
 from funsor.domains import reals
-from funsor.gaussian import Gaussian, cholesky_solve, sym_inverse
+from funsor.gaussian import Gaussian, cholesky_solve, cholesky_inverse
 from funsor.integrate import Integrate, integrator
 from funsor.montecarlo import monte_carlo
 from funsor.ops import AddOp, NegOp, SubOp
@@ -155,31 +154,28 @@ class Joint(Funsor, metaclass=JointMeta):
 
             # Moment-matching approximation.
             assert approx_vars and not exact_vars
-            discrete = self.discrete
-
-            new_discrete = discrete.reduce(ops.logaddexp, approx_vars.intersection(discrete.inputs))
-            num_elements = reduce(ops.mul, [
-                self.inputs[k].num_elements for k in approx_vars.difference(discrete.inputs)], 1)
-            if num_elements != 1:
-                new_discrete -= math.log(num_elements)
-
             gaussian = self.gaussian
+            discrete = self.discrete + gaussian.log_normalizer
+            new_discrete = discrete.reduce(ops.logaddexp, approx_vars.intersection(discrete.inputs))
+
             int_inputs = OrderedDict((k, d) for k, d in gaussian.inputs.items() if d.dtype != 'real')
             probs = (discrete - new_discrete).exp()
             old_loc = Tensor(cholesky_solve(gaussian.info_vec.unsqueeze(-1),
                                             gaussian._precision_chol).squeeze(-1),
                              int_inputs)
             new_loc = (probs * old_loc).reduce(ops.add, approx_vars)
-            old_cov = Tensor(sym_inverse(gaussian.precision), int_inputs)
+            old_cov = Tensor(cholesky_inverse(gaussian._precision_chol), int_inputs)
             diff = old_loc - new_loc
             outers = Tensor(diff.data.unsqueeze(-1) * diff.data.unsqueeze(-2), diff.inputs)
             new_cov = ((probs * old_cov).reduce(ops.add, approx_vars) +
                        (probs * outers).reduce(ops.add, approx_vars))
-            new_precision = Tensor(sym_inverse(new_cov.data), new_cov.inputs)
+            new_precision = Tensor(cholesky_inverse(new_cov.data.cholesky()), new_cov.inputs)
             new_info_vec = new_precision.data.matmul(new_loc.data.unsqueeze(-1)).squeeze(-1)
             new_inputs = new_loc.inputs.copy()
             new_inputs.update((k, d) for k, d in self.gaussian.inputs.items() if d.dtype == 'real')
             new_gaussian = Gaussian(new_info_vec, new_precision.data, new_inputs)
+            new_discrete -= new_gaussian.log_normalizer
+
             result = Joint(self.deltas, new_discrete, new_gaussian)
             return result.reduce(ops.logaddexp, lazy_vars)
 

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -8,9 +8,11 @@ import funsor.ops as ops
 from funsor.delta import Delta
 from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
+from funsor.integrate import Integrate
 from funsor.interpreter import interpretation
 from funsor.joint import Joint
-from funsor.terms import Number, Reduce, eager, moment_matching
+from funsor.montecarlo import monte_carlo_interpretation
+from funsor.terms import Number, Reduce, Variable, eager, moment_matching
 from funsor.testing import assert_close, random_gaussian, random_tensor, xfail_if_not_implemented
 from funsor.torch import Tensor
 
@@ -225,9 +227,11 @@ def test_reduce_moment_matching_univariate():
     info_vec = precision.matmul(loc.unsqueeze(-1)).squeeze(-1)
     discrete = Tensor(torch.tensor([1 - p, p]).log() + t, int_inputs)
     gaussian = Gaussian(info_vec, precision, inputs)
+    gaussian -= gaussian.log_normalizer
     joint = discrete + gaussian
     with interpretation(moment_matching):
         actual = joint.reduce(ops.logaddexp, 'i')
+    assert_close(actual.reduce(ops.logaddexp), joint.reduce(ops.logaddexp))
 
     expected_loc = torch.tensor([(2 * p - 1) * s1])
     expected_variance = (4 * p * (1 - p) * s1 ** 2
@@ -236,6 +240,7 @@ def test_reduce_moment_matching_univariate():
     expected_precision = torch.tensor([[1 / expected_variance]])
     expected_info_vec = expected_precision.matmul(expected_loc.unsqueeze(-1)).squeeze(-1)
     expected_gaussian = Gaussian(expected_info_vec, expected_precision, real_inputs)
+    expected_gaussian -= expected_gaussian.log_normalizer
     expected_discrete = Tensor(torch.tensor(t))
     expected = expected_discrete + expected_gaussian
     assert_close(actual, expected, atol=1e-5, rtol=None)
@@ -255,14 +260,17 @@ def test_reduce_moment_matching_multivariate():
     precision = torch.zeros(4, 1, 1) + torch.eye(2, 2)
     discrete = Tensor(torch.zeros(4), int_inputs)
     gaussian = Gaussian(loc, precision, inputs)
+    gaussian -= gaussian.log_normalizer
     joint = discrete + gaussian
     with interpretation(moment_matching):
         actual = joint.reduce(ops.logaddexp, 'i')
+    assert_close(actual.reduce(ops.logaddexp), joint.reduce(ops.logaddexp))
 
     expected_loc = torch.zeros(2)
     expected_covariance = torch.tensor([[101., 0.], [0., 2.]])
     expected_precision = expected_covariance.inverse()
     expected_gaussian = Gaussian(expected_loc, expected_precision, real_inputs)
+    expected_gaussian -= expected_gaussian.log_normalizer
     expected_discrete = Tensor(torch.tensor(4.).log())
     expected = expected_discrete + expected_gaussian
     assert_close(actual, expected, atol=1e-5, rtol=None)
@@ -277,7 +285,30 @@ def test_reduce_moment_matching_shape(interp):
     gaussian = random_gaussian(OrderedDict(
         [('k', bint(4)), ('l', bint(3)), ('m', bint(2)), ('y', reals()), ('z', reals(2))]))
     reduced_vars = frozenset(['i', 'k', 'l'])
+    real_vars = frozenset(k for k, d in gaussian.inputs.items() if d.dtype == "real")
     joint = delta + discrete + gaussian
     with interpretation(interp):
         actual = joint.reduce(ops.logaddexp, reduced_vars)
     assert set(actual.inputs) == set(joint.inputs) - reduced_vars
+    assert_close(actual.reduce(ops.logaddexp, real_vars),
+                 joint.reduce(ops.logaddexp, real_vars | reduced_vars))
+
+
+def test_reduce_moment_matching_moments():
+    x = Variable('x', reals(2))
+    gaussian = random_gaussian(OrderedDict(
+        [('i', bint(2)), ('j', bint(3)), ('x', reals(2))]))
+    with interpretation(moment_matching):
+        approx = gaussian.reduce(ops.logaddexp, 'j')
+    with monte_carlo_interpretation(s=bint(100000)):
+        actual = Integrate(approx, Number(1.), frozenset(['x']))
+        expected = Integrate(gaussian, Number(1.), frozenset(['j', 'x']))
+        assert_close(actual, expected, atol=1e-3, rtol=1e-3)
+
+        actual = Integrate(approx, x, frozenset(['x']))
+        expected = Integrate(gaussian, x, frozenset(['j', 'x']))
+        assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+        actual = Integrate(approx, x * x, frozenset(['x']))
+        expected = Integrate(gaussian, x * x, frozenset(['j', 'x']))
+        assert_close(actual, expected, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
Blocking #187 

This fixes a normalization bug in our `moment_matching` interpretation.

Our original tests only checked mean and covariance, but since funsor distributions are non-normalized, we should also check total. This PR adds such tests and fixes the error.

I've also switched from `sym_inverse()` to Cholesky-based inverse in `Joint.moment_matching_reduce()` as suggested by @fehiepsi in #185 .

## Tested
- added total checks to existing tests
- added a monte carlo test for zeroth, first, and second moments