### PR TITLE
Fix sequential_sum_product, add naive_sequential_sum_product

### DIFF
--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -71,7 +71,7 @@ class DiscreteHMM(FunsorDistribution):
         obs = self._obs(value=value)
         result = self._trans + obs
         result = sequential_sum_product(ops.logaddexp, ops.add,
-                                        result, "time", "state", "state(time=1)")
+                                        result, "time", {"state": "state(time=1)"})
         result = self._init + result.reduce(ops.logaddexp, "state(time=1)")
         result = result.reduce(ops.logaddexp, "state")
 
@@ -206,7 +206,7 @@ class GaussianHMM(FunsorDistribution):
         obs = self._obs(value=value)
         result = self._trans + obs
         result = sequential_sum_product(ops.logaddexp, ops.add,
-                                        result, "time", "state", "state(time=1)")
+                                        result, "time", {"state": "state(time=1)"})
         result = self._init + result.reduce(ops.logaddexp, "state(time=1)")
         result = result.reduce(ops.logaddexp, "state")
 
@@ -275,12 +275,12 @@ class GaussianMRF(FunsorDistribution):
         # Compare with pyro.distributions.hmm.GaussianMRF.log_prob().
         logp_oh = self._trans + self._obs(value=value)
         logp_oh = sequential_sum_product(ops.logaddexp, ops.add,
-                                         logp_oh, "time", "state", "state(time=1)")
+                                         logp_oh, "time", {"state": "state(time=1)"})
         logp_oh += self._init
         logp_oh = logp_oh.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
         logp_h = self._trans + self._obs.reduce(ops.logaddexp, "value")
         logp_h = sequential_sum_product(ops.logaddexp, ops.add,
-                                        logp_h, "time", "state", "state(time=1)")
+                                        logp_h, "time", {"state": "state(time=1)"})
         logp_h += self._init
         logp_h = logp_h.reduce(ops.logaddexp, frozenset({"state", "state(time=1)"}))
         result = logp_oh - logp_h

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -102,7 +102,7 @@ class GaussianHMM(FunsorDistribution):
 
         z = initial_distribution.sample()
         x = []
-        for t in range(num_events):
+        for t in range(num_steps):
             z = z @ transition_matrix + transition_dist.sample()
             x.append(z @ observation_matrix + observation_dist.sample())
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -193,15 +193,41 @@ def Slice(name, *args):
     return Tensor(data, inputs, dtype=bound)
 
 
-def sequential_sum_product(sum_op, prod_op, trans, time, prev, curr):
+def naive_sequential_sum_product(sum_op, prod_op, trans, time, step):
+    assert isinstance(sum_op, AssociativeOp)
+    assert isinstance(prod_op, AssociativeOp)
+    assert isinstance(trans, Funsor)
+    assert isinstance(time, str)
+    assert isinstance(step, dict)
+    assert all(isinstance(k, str) for k in step.keys())
+    assert all(isinstance(v, str) for v in step.values())
+    if time not in trans.inputs:
+        return trans  # edge case of a single time step
+
+    step = OrderedDict(sorted(step.items()))
+    drop = tuple("_drop_{}".format(i) for i in range(len(step)))
+    prev_to_drop = dict(zip(step.keys(), drop))
+    curr_to_drop = dict(zip(step.values(), drop))
+    drop = frozenset(drop)
+
+    factors = [trans(**{time: t}) for t in range(trans.inputs[time].size)]
+    while len(factors) > 1:
+        y = factors.pop()(**prev_to_drop)
+        x = factors.pop()(**curr_to_drop)
+        xy = prod_op(x, y).reduce(sum_op, drop)
+        factors.append(xy)
+    return factors[0]
+
+
+def sequential_sum_product(sum_op, prod_op, trans, time, step):
     """
-    For a funsor ``trans`` with dimensions ``time``, ``prev`` and ``curr``,
-    computes a recursion equivalent to::
+    For a funsor ``trans`` with dimensions ``time``, ``step.keys()``,
+    and ``step.values()``, computes a recursion equivalent to::
 
         tail_time = 1 + arange("time", trans.inputs["time"].size - 1)
         tail = sequential_sum_product(sum_op, prod_op,
                                       trans(time=tail_time),
-                                      "time", "prev", "curr")
+                                      "time", step)
         return prod_op(trans(time=0)(curr="drop"), tail(prev="drop")) \
            .reduce(sum_op, "drop")
 
@@ -211,27 +237,22 @@ def sequential_sum_product(sum_op, prod_op, trans, time, prev, curr):
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.
     :param ~funsor.terms.Funsor trans: A transition funsor.
     :param str time: The name of the time input dimension.
-    :param prev: The name or tuple of names of previous state inputs.
-    :type prev: str or tuple
-    :param curr: The name or tuple of names of current state inputs.
-    :type curr: str or tuple
+    :param dict step: A dict mapping previous variable to current variable.
     """
     assert isinstance(sum_op, AssociativeOp)
     assert isinstance(prod_op, AssociativeOp)
     assert isinstance(trans, Funsor)
     assert isinstance(time, str)
-    if isinstance(prev, str):
-        prev = (prev,)
-        curr = (curr,)
-    assert isinstance(prev, tuple) and all(isinstance(n, str) for n in prev)
-    assert isinstance(curr, tuple) and all(isinstance(n, str) for n in curr)
-    assert len(prev) == len(curr)
+    assert isinstance(step, dict)
+    assert all(isinstance(k, str) for k in step.keys())
+    assert all(isinstance(v, str) for v in step.values())
     if time not in trans.inputs:
         return trans  # edge case of a single time step
 
-    drop = tuple("_drop_{}".format(i) for i in range(len(prev)))
-    prev_to_drop = dict(zip(prev, drop))
-    curr_to_drop = dict(zip(curr, drop))
+    step = OrderedDict(sorted(step.items()))
+    drop = tuple("_drop_{}".format(i) for i in range(len(step)))
+    prev_to_drop = dict(zip(step.keys(), drop))
+    curr_to_drop = dict(zip(step.values(), drop))
     drop = frozenset(drop)
 
     while trans.inputs[time].size > 1:

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -221,13 +221,13 @@ def naive_sequential_sum_product(sum_op, prod_op, trans, time, step):
 
 def sequential_sum_product(sum_op, prod_op, trans, time, step):
     """
-    For a funsor ``trans`` with dimensions ``time``, ``step.keys()``,
-    and ``step.values()``, computes a recursion equivalent to::
+    For a funsor ``trans`` with dimensions ``time``, ``prev`` and ``curr``,
+    computes a recursion equivalent to::
 
         tail_time = 1 + arange("time", trans.inputs["time"].size - 1)
         tail = sequential_sum_product(sum_op, prod_op,
                                       trans(time=tail_time),
-                                      "time", step)
+                                      "time", {"prev": "curr"})
         return prod_op(trans(time=0)(curr="drop"), tail(prev="drop")) \
            .reduce(sum_op, "drop")
 
@@ -237,7 +237,8 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.
     :param ~funsor.terms.Funsor trans: A transition funsor.
     :param str time: The name of the time input dimension.
-    :param dict step: A dict mapping previous variable to current variable.
+    :param dict step: A dict mapping previous variables to current variables.
+        This can contain multiple pairs of prev->curr variable names.
     """
     assert isinstance(sum_op, AssociativeOp)
     assert isinstance(prod_op, AssociativeOp)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -226,6 +226,8 @@ def sequential_sum_product(sum_op, prod_op, trans, time, prev, curr):
     assert isinstance(prev, tuple) and all(isinstance(n, str) for n in prev)
     assert isinstance(curr, tuple) and all(isinstance(n, str) for n in curr)
     assert len(prev) == len(curr)
+    if time not in trans.inputs:
+        return trans  # edge case of a single time step
 
     drop = tuple("_drop_{}".format(i) for i in range(len(prev)))
     prev_to_drop = dict(zip(prev, drop))

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -6,13 +6,13 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 from funsor.pyro.hmm import DiscreteHMM, GaussianHMM, GaussianMRF
-from funsor.testing import assert_close, xfail_param, random_mvn
+from funsor.testing import assert_close, random_mvn
 
 
 DISCRETE_HMM_SHAPES = [
     # init_shape, trans_shape, obs_shape
-    xfail_param((), (1,), (), reason="time series of length 1 are not yet supported"),
-    xfail_param((), (), (1,), reason="time series of length 1 are not yet supported"),
+    ((), (1,), ()),
+    ((), (), (1,)),
     ((), (2,), ()),
     ((), (7,), ()),
     ((), (), (7,)),
@@ -124,6 +124,7 @@ def test_discrete_diag_normal_log_prob(init_shape, trans_shape, obs_shape, state
 @pytest.mark.parametrize("obs_dim", [1, 2, 3])
 @pytest.mark.parametrize("hidden_dim", [1, 2, 3])
 @pytest.mark.parametrize("init_shape,trans_mat_shape,trans_mvn_shape,obs_mat_shape,obs_mvn_shape", [
+    ((), (), (), (), ()),
     ((), (6,), (), (), ()),
     ((), (), (6,), (), ()),
     ((), (), (), (6,), ()),

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -7,7 +7,13 @@ import funsor.ops as ops
 from funsor.domains import bint, reals
 from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer
-from funsor.sum_product import _partition, partial_sum_product, sequential_sum_product, sum_product
+from funsor.sum_product import (
+    _partition,
+    naive_sequential_sum_product,
+    partial_sum_product,
+    sequential_sum_product,
+    sum_product
+)
 from funsor.terms import moment_matching, reflect
 from funsor.testing import assert_close, random_gaussian, random_tensor
 
@@ -82,7 +88,7 @@ def test_partial_sum_product(sum_op, prod_op, inputs, plates, vars1, vars2):
     assert_close(actual, expected)
 
 
-@pytest.mark.parametrize('num_steps', list(range(1, 13)))
+@pytest.mark.parametrize('num_steps', [None] + list(range(1, 13)))
 @pytest.mark.parametrize('sum_op,prod_op,state_domain', [
     (ops.add, ops.mul, bint(2)),
     (ops.add, ops.mul, bint(3)),
@@ -96,15 +102,20 @@ def test_partial_sum_product(sum_op, prod_op, inputs, plates, vars1, vars2):
     {"foo": bint(5)},
     {"foo": bint(2), "bar": bint(4)},
 ], ids=lambda d: ",".join(d.keys()))
-def test_sequential_sum_product(sum_op, prod_op, batch_inputs, state_domain, num_steps):
+@pytest.mark.parametrize('impl', [sequential_sum_product, naive_sequential_sum_product])
+def test_sequential_sum_product(impl, sum_op, prod_op, batch_inputs, state_domain, num_steps):
     inputs = OrderedDict(batch_inputs)
-    inputs.update(time=bint(num_steps), prev=state_domain, curr=state_domain)
+    inputs.update(prev=state_domain, curr=state_domain)
+    if num_steps is None:
+        num_steps = 1
+    else:
+        inputs["time"] = bint(num_steps)
     if state_domain.dtype == "real":
         trans = random_gaussian(inputs)
     else:
         trans = random_tensor(inputs)
 
-    actual = sequential_sum_product(sum_op, prod_op, trans, "time", "prev", "curr")
+    actual = impl(sum_op, prod_op, trans, "time", {"prev": "curr"})
     expected_inputs = batch_inputs.copy()
     expected_inputs.update(prev=state_domain, curr=state_domain)
     assert dict(actual.inputs) == expected_inputs
@@ -121,7 +132,7 @@ def test_sequential_sum_product(sum_op, prod_op, batch_inputs, state_domain, num
     assert_close(actual, expected, rtol=1e-4 * num_steps)
 
 
-@pytest.mark.parametrize('num_steps', list(range(1, 6)))
+@pytest.mark.parametrize('num_steps', [None] + list(range(1, 6)))
 @pytest.mark.parametrize('batch_inputs', [
     {},
     {"foo": bint(5)},
@@ -132,22 +143,25 @@ def test_sequential_sum_product(sum_op, prod_op, batch_inputs, state_domain, num
     (reals(), reals(2, 2)),
     (bint(2), reals(2)),
 ], ids=str)
-def test_sequential_sum_product_multi(x_domain, y_domain, batch_inputs, num_steps):
+@pytest.mark.parametrize('impl', [sequential_sum_product, naive_sequential_sum_product])
+def test_sequential_sum_product_multi(impl, x_domain, y_domain, batch_inputs, num_steps):
     sum_op = ops.logaddexp
     prod_op = ops.add
     inputs = OrderedDict(batch_inputs)
-    inputs.update(time=bint(num_steps),
-                  x_prev=x_domain, x_curr=x_domain,
+    inputs.update(x_prev=x_domain, x_curr=x_domain,
                   y_prev=y_domain, y_curr=y_domain)
+    if num_steps is None:
+        num_steps = 1
+    else:
+        inputs["time"] = bint(num_steps)
     if any(v.dtype == "real" for v in inputs.values()):
         trans = random_gaussian(inputs)
     else:
         trans = random_tensor(inputs)
-    prev = ("x_prev", "y_prev")
-    curr = ("x_curr", "y_curr")
+    step = {"x_prev": "x_curr", "y_prev": "y_curr"}
 
     with interpretation(moment_matching):
-        actual = sequential_sum_product(sum_op, prod_op, trans, "time", prev, curr)
+        actual = impl(sum_op, prod_op, trans, "time", step)
         expected_inputs = batch_inputs.copy()
         expected_inputs.update(x_prev=x_domain, x_curr=x_domain,
                                y_prev=y_domain, y_curr=y_domain)


### PR DESCRIPTION
Addresses #177 
Blocking #187 

This PR:
1. Fixes an edge case bug in `sequential_sum_product` that happens with length-1 time series.
2. Simplifies the interface of `sequential_sum_product` to input a dict rather than two tuples
3. Adds a reference implementation `naive_sequential_sum_product()` for use in testing. This version does not rely on `Cat` and `Stack`, and can be used to test e.g. an exact version of `SwitchingLinearHMM` #187 that avoids a moment matching approximation.

## Tested
- added new test cases for `num_steps=1`
- enabled previously xfailing hmm test cases with `num_steps=1`
- added new test cases for `naive_sequential_sum_product()`