### PR TITLE
Implement SwitchingLinearHMM.filter() method for forecasting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 install:
     - pip install -U pip
-    - pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
+    - pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
     # Keep track of Pyro dev branch
     - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -125,10 +125,10 @@ def funsor_to_cat_and_mvn(funsor_, ndims, event_inputs):
     Converts a labeled gaussian mixture model to a pair of distributions.
 
     :return: A pair ``(cat, mvn)``, where ``cat`` is a
-    :class:`~pyro.distributions.Categorical` distribution over mixture
+        :class:`~pyro.distributions.Categorical` distribution over mixture
         components and ``mvn`` is a
-        :class:`~pyro.distributions.MultivariateNormal` with rightmost
-        batch dimension ranging over mixture components.
+        :class:`~pyro.distributions.MultivariateNormal` with rightmost batch
+        dimension ranging over mixture components.
     """
     assert isinstance(funsor_, Joint), funsor_
     assert sum(1 for d in funsor_.inputs.values() if d.dtype == "real") == 1

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -2,6 +2,7 @@ import math
 from collections import OrderedDict
 from functools import singledispatch
 
+import pyro.distributions
 import torch
 import torch.distributions as dist
 from pyro.distributions.torch_distribution import MaskedDistribution
@@ -10,6 +11,7 @@ from pyro.distributions.util import broadcast_shape
 from funsor.distributions import BernoulliLogits, MultivariateNormal, Normal
 from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian, cholesky_solve
+from funsor.joint import Joint
 from funsor.terms import Independent
 from funsor.torch import Tensor
 
@@ -131,6 +133,30 @@ def matrix_and_mvn_to_funsor(matrix, mvn, event_dims=(), x_name="value_x", y_nam
     inputs[x_name] = reals(x_size)
     inputs[y_name] = reals(y_size)
     return tensor_to_funsor(log_prob, event_dims) + Gaussian(info_vec.data, precision.data, inputs)
+
+
+def funsor_to_cat_and_mvn(funsor_, int_name, real_name):
+    """
+    Converts a labeled gaussian mixture model to a pair of distributions.
+
+    :param Funsor funsor_:
+    :param str int_name: Name of the int input for components.
+    :param str real_name: Name of the real input.
+    :return: A pair ``(cat, mvn)``, where ``cat`` is a
+    :class:`~pyro.distributions.Categorical` distribution over mixture
+        components and ``mvn`` is a
+        :class:`~pyro.distributions.MultivariateNormal` with rightmost
+        batch dimension ranging over mixture components.
+    """
+    assert isinstance(funsor_, Joint)
+    assert isinstance(funsor_.inputs[int_name].dtype, int)
+    assert funsor_.inputs[real_name].dtype == "real"
+
+    raise NotImplementedError("TODO")
+
+    cat = pyro.distributions.Categorical(logits="TODO")
+    mvn = pyro.distributions.MultivariateNormal(loc="TODO", precision_matrix="TODO")
+    return cat, mvn
 
 
 @singledispatch

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -437,6 +437,19 @@ class SwitchingLinearHMM(FunsorDistribution):
         return new
 
     def filter(self, value):
+        """
+        Compute posterior over final state given a sequence of observations.
+
+        :param ~torch.Tensor value: A sequence of observations.
+        :return: A posterior distribution over latent states at the final time
+            step, represented as a pair ``(cat, mvn)``, where
+            :class:`~pyro.distributions.Categorical` distribution over mixture
+            components and ``mvn`` is a
+            :class:`~pyro.distributions.MultivariateNormal` with rightmost
+            batch dimension ranging over mixture components. This can then be
+            used to initialize a sequential Pyro model for prediction.
+        :rtype: tuple
+        """
         ndims = max(len(self.batch_shape), value.dim() - 2)
         value = tensor_to_funsor(value, ("time",), 1)
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -72,7 +72,7 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
     elif isinstance(actual, torch.Tensor):
         assert actual.dtype == expected.dtype, msg
         assert actual.shape == expected.shape, msg
-        if actual.dtype in (torch.long, torch.uint8):
+        if actual.dtype in (torch.long, torch.uint8, torch.bool):
             assert (actual == expected).all(), msg
         else:
             eq = (actual == expected)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -746,7 +746,7 @@ def _exp(x):
 
 @ops.log.register(torch.Tensor)
 def _log(x):
-    if x.dtype in (torch.uint8, torch.long):
+    if x.dtype in (torch.bool, torch.uint8, torch.long):
         x = x.float()
     return x.log()
 

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -263,6 +263,12 @@ def test_switching_linear_hmm_shape(init_cat_shape, init_mvn_shape,
     assert actual_log_prob.shape == expected_batch_shape
     check_expand(actual_dist, data)
 
+    final_cat, final_mvn = actual_dist.filter(data)
+    assert isinstance(final_cat, dist.Categorical)
+    assert isinstance(final_mvn, dist.MultivariateNormal)
+    assert final_cat.batch_shape == actual_dist.batch_shape
+    assert final_mvn.batch_shape == actual_dist.batch_shape + final_cat.logits.shape[-1:]
+
 
 @pytest.mark.parametrize("num_components", [2, 3])
 @pytest.mark.parametrize("obs_dim,hidden_dim",

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13,7 +13,7 @@ from funsor.torch import REDUCE_OP_TO_TORCH, Einsum, Tensor, align_tensors, torc
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
-@pytest.mark.parametrize('dtype', [torch.float, torch.long, torch.uint8])
+@pytest.mark.parametrize('dtype', [torch.float, torch.long, torch.uint8, torch.bool])
 def test_to_funsor(shape, dtype):
     t = torch.randn(shape).type(dtype)
     f = funsor.to_funsor(t)


### PR DESCRIPTION
Addresses #177 
Based on #192 (required for tests to pass)

See https://github.com/pyro-ppl/pyro/pull/2010 for details.

## Tested
- unit tests for `funsor_to_mvn`
- unit tests for `funsor_to_cat_and_mvn`
- shape tests for `SwitchingLinearHMM.filter()` (math is nearly identical to `.log_prob()`)