### PR TITLE
Numerically stabilize moment_matching approximation

### DIFF
--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -139,6 +139,11 @@ class Tensor(Funsor, metaclass=TensorMeta):
     def item(self):
         return self.data.item()
 
+    def clamp_finite(self):
+        finfo = torch.finfo(self.data.dtype)
+        data = self.data.clamp(min=finfo.min, max=finfo.max)
+        return Tensor(data, self.inputs, self.dtype)
+
     @property
     def requires_grad(self):
         return self.data.requires_grad

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -312,3 +312,19 @@ def test_reduce_moment_matching_moments():
         actual = Integrate(approx, x * x, frozenset(['x']))
         expected = Integrate(gaussian, x * x, frozenset(['j', 'x']))
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+def test_reduce_moment_matching_finite():
+    delta = Delta('x', random_tensor(OrderedDict([('h', bint(7))])))
+    discrete = random_tensor(OrderedDict(
+        [('i', bint(6)), ('j', bint(5)), ('k', bint(3))]))
+    gaussian = random_gaussian(OrderedDict(
+        [('k', bint(3)), ('l', bint(2)), ('y', reals()), ('z', reals(2))]))
+
+    discrete.data[1:, :] = -float('inf')
+    discrete.data[:, 1:] = -float('inf')
+
+    reduced_vars = frozenset(['j', 'k'])
+    joint = delta + discrete + gaussian
+    with interpretation(moment_matching):
+        joint.reduce(ops.logaddexp, reduced_vars)


### PR DESCRIPTION
This fixes a numerical precision issue when some components of a moment-matched Gaussian are vanishingly improbable. This came up in testing the `SwitchingLinearHMM` in #194 

## Tested

- added a regression test