### PR TITLE
Update adjoint to support different forward and backward interpretations

### DIFF
--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -2,49 +2,83 @@ from collections import defaultdict
 
 import torch
 
+import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.contract import Contract
-from funsor.interpreter import interpretation, reinterpret
+from funsor.interpreter import interpretation
 from funsor.ops import AssociativeOp
 from funsor.registry import KeyedRegistry
-from funsor.terms import Binary, Funsor, Number, Reduce, Variable, eager
+from funsor.terms import Binary, Funsor, Reduce, Variable, alpha_substitute, lazy, to_funsor
 from funsor.torch import Tensor
+
+
+def _alpha_deconvert(expr):
+    alpha_subs = {name: name.split("__BOUND")[0]
+                  for name in expr.bound if "__BOUND" in name}
+    if not alpha_subs:
+        return tuple(expr._ast_values)
+
+    return alpha_substitute(expr, alpha_subs)
 
 
 class AdjointTape(object):
 
     def __init__(self):
         self.tape = []
+        self._old_interpretation = None
 
     def __call__(self, cls, *args):
-        result = eager(cls, *args)
-        if cls in (Reduce, Contract, Binary, Tensor):
+        result = cls(*args) if self._old_interpretation is None \
+            else self._old_interpretation(cls, *args)
+        if cls in (Reduce, Contract, Binary, Tensor):  # TODO make generic
             self.tape.append((result, cls, args))
         return result
 
+    def __enter__(self):
+        self.tape = []
+        self._old_interpretation = interpreter._INTERPRETATION
+        interpreter.set_interpretation(self)
+        return self
 
-def adjoint(expr, targets, start=Number(0.)):
+    def __exit__(self, *args):
+        interpreter.set_interpretation(self._old_interpretation)
+        self._old_interpretation = None
 
-    adjoint_values = defaultdict(lambda: Number(0.))  # 1 in logspace
-    multiplicities = defaultdict(lambda: 0)
+    def adjoint(self, red_op, root, targets):
 
-    tape_recorder = AdjointTape()
-    with interpretation(tape_recorder):
-        adjoint_values[reinterpret(expr)] = start
+        bin_op = [b for a, b in ops.DISTRIBUTIVE_OPS if a is red_op][0]
+        bin_unit = to_funsor(ops.UNITS[bin_op])
 
-    while tape_recorder.tape:
-        output, fn, inputs = tape_recorder.tape.pop()
-        in_adjs = adjoint_ops(fn, adjoint_values[output], output, *inputs)
-        for v, adjv in in_adjs.items():
-            multiplicities[v] += 1
-            adjoint_values[v] = adjoint_values[v] + adjv  # product in logspace
+        adjoint_values = defaultdict(lambda: bin_unit)
+        multiplicities = defaultdict(lambda: 0)
 
-    target_adjs = {}
-    for v in targets:
-        target_adjs[v] = adjoint_values[v] / multiplicities[v]
-        if not isinstance(v, Variable):
-            target_adjs[v] = target_adjs[v] + v
-    return target_adjs
+        reached_root = False
+        while self.tape:
+            output, fn, inputs = self.tape.pop()
+            if not reached_root:
+                if output is root:
+                    reached_root = True
+                else:
+                    continue
+
+            # reverse the effects of alpha-renaming
+            with interpretation(lazy):
+                other_subs = {name: name.split("__BOUND")[0] for name in output.inputs if "__BOUND" in name}
+                inputs = _alpha_deconvert(fn(*inputs)(**other_subs))
+                output = type(output)(*_alpha_deconvert(output(**other_subs)))
+
+            in_adjs = adjoint_ops(fn, red_op, adjoint_values[output], output, *inputs)
+            for v, adjv in in_adjs.items():
+                multiplicities[v] += 1
+                adjoint_values[v] = bin_op(adjoint_values[v], adjv)
+
+        target_adjs = {}
+        for v in targets:
+            target_adjs[v] = adjoint_values[v] / multiplicities[v]
+            if not isinstance(v, Variable):
+                target_adjs[v] = bin_op(target_adjs[v], v)
+
+        return target_adjs
 
 
 # logaddexp/add
@@ -55,41 +89,44 @@ def _fail_default(*args):
 adjoint_ops = KeyedRegistry(default=_fail_default)
 
 
-@adjoint_ops.register(Tensor, Funsor, Funsor, torch.Tensor, tuple, object)
-def adjoint_tensor(out_adj, out, data, inputs, dtype):
+@adjoint_ops.register(Tensor, AssociativeOp, Funsor, Funsor, torch.Tensor, tuple, object)
+def adjoint_tensor(adj_op, out_adj, out, data, inputs, dtype):
     all_vars = frozenset(k for (k, v) in inputs)
     in_adjs = {}
     for (k, v) in inputs:
-        in_adj = (out_adj + out).reduce(ops.logaddexp, all_vars - {k})
+        in_adj = (out_adj + out).reduce(adj_op, all_vars - {k})  # TODO generalize beyond +
         in_adjs[Variable(k, v)] = in_adj
     return in_adjs
 
 
-@adjoint_ops.register(Binary, Funsor, Funsor, AssociativeOp, Funsor, Funsor)
-def adjoint_binary(out_adj, out, op, lhs, rhs):
-    assert op is ops.add
+@adjoint_ops.register(Binary, AssociativeOp, Funsor, Funsor, ops.AddOp, Funsor, Funsor)
+def adjoint_binary(adj_op, out_adj, out, op, lhs, rhs):
+    assert adj_op is ops.logaddexp
 
     lhs_reduced_vars = frozenset(rhs.inputs) - frozenset(lhs.inputs)
-    lhs_adj = (out_adj + rhs).reduce(ops.logaddexp, lhs_reduced_vars)
+    lhs_adj = op(out_adj, rhs).reduce(adj_op, lhs_reduced_vars)
 
     rhs_reduced_vars = frozenset(lhs.inputs) - frozenset(rhs.inputs)
-    rhs_adj = (out_adj + lhs).reduce(ops.logaddexp, rhs_reduced_vars)
+    rhs_adj = op(out_adj, lhs).reduce(adj_op, rhs_reduced_vars)
 
     return {lhs: lhs_adj, rhs: rhs_adj}
 
 
-@adjoint_ops.register(Reduce, Funsor, Funsor, AssociativeOp, Funsor, frozenset)
-def adjoint_reduce(out_adj, out, op, arg, reduced_vars):
+@adjoint_ops.register(Reduce, AssociativeOp, Funsor, Funsor, AssociativeOp, Funsor, frozenset)
+def adjoint_reduce(adj_op, out_adj, out, op, arg, reduced_vars):
     assert op in (ops.logaddexp, ops.add)
+    assert adj_op is ops.logaddexp  # TODO generalize
 
     if op is ops.logaddexp:
-        return {arg: out_adj + (arg * 0.)}  # XXX hack to simulate "expand"
+        return {arg: ops.add(out_adj, arg * 0.)}  # XXX hack to simulate "expand"
     elif op is ops.add:  # plate!
-        return {arg: out_adj + Binary(ops.safesub, out, arg)}
+        return {arg: ops.add(out_adj, Binary(ops.PRODUCT_INVERSES[op], out, arg))}
 
 
-@adjoint_ops.register(Contract, Funsor, Funsor, AssociativeOp, AssociativeOp, Funsor, Funsor, frozenset)
-def adjoint_contract(out_adj, out, sum_op, prod_op, lhs, rhs, reduced_vars):
+@adjoint_ops.register(Contract, AssociativeOp, Funsor, Funsor, AssociativeOp, AssociativeOp, Funsor, Funsor, frozenset)
+def adjoint_contract(adj_op, out_adj, out, sum_op, prod_op, lhs, rhs, reduced_vars):
+    assert adj_op is ops.logaddexp  # TODO generalize
+    assert sum_op is ops.logaddexp and prod_op is ops.add  # TODO generalize
 
     lhs_reduced_vars = frozenset(rhs.inputs) - frozenset(lhs.inputs)
     lhs_adj = Contract(sum_op, prod_op, out_adj, rhs, lhs_reduced_vars)

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -101,7 +101,6 @@ def adjoint_tensor(adj_redop, adj_binop, out_adj, data, inputs, dtype):
 
 @adjoint_ops.register(Binary, AssociativeOp, AssociativeOp, Funsor, AssociativeOp, Funsor, Funsor)
 def adjoint_binary(adj_redop, adj_binop, out_adj, op, lhs, rhs):
-    assert adj_binop is op
     assert (adj_redop, op) in ops.DISTRIBUTIVE_OPS
 
     lhs_reduced_vars = frozenset(rhs.inputs) - frozenset(lhs.inputs)
@@ -115,7 +114,6 @@ def adjoint_binary(adj_redop, adj_binop, out_adj, op, lhs, rhs):
 
 @adjoint_ops.register(Reduce, AssociativeOp, AssociativeOp, Funsor, AssociativeOp, Funsor, frozenset)
 def adjoint_reduce(adj_redop, adj_binop, out_adj, op, arg, reduced_vars):
-    assert adj_redop is op or (adj_redop, op) in ops.DISTRIBUTIVE_OPS
     assert adj_binop is op or (op, adj_binop) in ops.DISTRIBUTIVE_OPS
 
     if op is ops.logaddexp:
@@ -129,8 +127,6 @@ def adjoint_reduce(adj_redop, adj_binop, out_adj, op, arg, reduced_vars):
 @adjoint_ops.register(Contract, AssociativeOp, AssociativeOp, Funsor,
                       AssociativeOp, AssociativeOp, Funsor, Funsor, frozenset)
 def adjoint_contract(adj_redop, adj_binop, out_adj, sum_op, prod_op, lhs, rhs, reduced_vars):
-    assert adj_binop is prod_op
-    assert adj_redop is sum_op
 
     lhs_reduced_vars = frozenset(rhs.inputs) - frozenset(lhs.inputs)
     lhs_adj = Contract(sum_op, prod_op, out_adj, rhs, lhs_reduced_vars)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -34,11 +34,7 @@ def substitute(expr, subs):
         return interpreter.reinterpret(expr)
 
 
-def alpha_convert(expr):
-    alpha_subs = {name: interpreter.gensym(name + "__BOUND")
-                  for name in expr.bound if "__BOUND" not in name}
-    if not alpha_subs:
-        return expr
+def alpha_substitute(expr, alpha_subs):
 
     new_values = []
     for v in expr._ast_values:
@@ -56,6 +52,16 @@ def alpha_convert(expr):
             v = OrderedDict([(alpha_subs[k] if k in alpha_subs else k, vv) for k, vv in v.items()])
         new_values.append(v)
 
+    return tuple(new_values)
+
+
+def alpha_convert(expr):
+    alpha_subs = {name: interpreter.gensym(name + "__BOUND")
+                  for name in expr.bound if "__BOUND" not in name}
+    if not alpha_subs:
+        return expr
+
+    new_values = alpha_substitute(expr, alpha_subs)
     return reflect(type(expr), *new_values)
 
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -39,7 +39,7 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
 
     with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, ops.add, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)
@@ -68,7 +68,7 @@ def test_einsum_adjoint_unary_marginals(einsum_impl, equation, backend):
     targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
     with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    actuals = tape.adjoint(ops.logaddexp, fwd_expr, targets)
+    actuals = tape.adjoint(ops.logaddexp, ops.add, fwd_expr, targets)
 
     for target in targets:
         actual = actuals[target]
@@ -100,7 +100,7 @@ def test_plated_einsum_adjoint(einsum_impl, equation, plates, backend):
 
     with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, plates=plates, backend=backend)
-    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, ops.add, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)
@@ -134,7 +134,7 @@ def test_optimized_plated_einsum_adjoint(equation, plates, backend):
 
     with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum(equation, *funsor_operands, plates=plates, backend=backend)
-    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, ops.add, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -62,11 +62,11 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_einsum_adjoint_unary_marginals(einsum_impl, equation, backend):
-    inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    equation = ",".join(inputs) + "->"
 
-    targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
     with AdjointTape() as tape:  # interpretation(reflect):
+        inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
+        equation = ",".join(inputs) + "->"
+        targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
     actuals = tape.adjoint(ops.logaddexp, ops.add, fwd_expr, targets)
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -5,15 +5,12 @@ from pyro.ops.contract import einsum as pyro_einsum
 from pyro.ops.einsum.adjoint import require_backward as pyro_require_backward
 
 import funsor
-from funsor.adjoint import adjoint
+import funsor.ops as ops
+from funsor.adjoint import AdjointTape
 from funsor.domains import bint
 from funsor.einsum import einsum, naive_einsum, naive_plated_einsum
-from funsor.interpreter import interpretation
-from funsor.terms import Variable, reflect
+from funsor.terms import Variable
 from funsor.testing import make_einsum_example, make_plated_hmm_einsum
-
-# FIXME rewrite adjoint for compatibility with substitution changes
-xfail_with_new_subs = pytest.mark.xfail(True, reason="fails w/ new subs")
 
 
 EINSUM_EXAMPLES = [
@@ -34,16 +31,15 @@ EINSUM_EXAMPLES = [
 ]
 
 
-@xfail_with_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_einsum_adjoint(einsum_impl, equation, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
 
-    with interpretation(reflect):
+    with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    actuals = adjoint(fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)
@@ -62,7 +58,6 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
 
-@xfail_with_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_einsum, einsum])
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
@@ -71,9 +66,9 @@ def test_einsum_adjoint_unary_marginals(einsum_impl, equation, backend):
     equation = ",".join(inputs) + "->"
 
     targets = [Variable(k, bint(sizes[k])) for k in set(sizes)]
-    with interpretation(reflect):
+    with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, backend=backend)
-    actuals = adjoint(fwd_expr, targets)
+    actuals = tape.adjoint(ops.logaddexp, fwd_expr, targets)
 
     for target in targets:
         actual = actuals[target]
@@ -97,16 +92,15 @@ PLATED_EINSUM_EXAMPLES = [
 ]
 
 
-@xfail_with_new_subs
 @pytest.mark.parametrize('einsum_impl', [naive_plated_einsum, einsum])
 @pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_plated_einsum_adjoint(einsum_impl, equation, plates, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
 
-    with interpretation(reflect):
+    with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum_impl(equation, *funsor_operands, plates=plates, backend=backend)
-    actuals = adjoint(fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)
@@ -133,15 +127,14 @@ OPTIMIZED_PLATED_EINSUM_EXAMPLES = [
 ]
 
 
-@xfail_with_new_subs
 @pytest.mark.parametrize('equation,plates', OPTIMIZED_PLATED_EINSUM_EXAMPLES)
 @pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_marginal'])
 def test_optimized_plated_einsum_adjoint(equation, plates, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
 
-    with interpretation(reflect):
+    with AdjointTape() as tape:  # interpretation(reflect):
         fwd_expr = einsum(equation, *funsor_operands, plates=plates, backend=backend)
-    actuals = adjoint(fwd_expr, funsor_operands)
+    actuals = tape.adjoint(ops.logaddexp, fwd_expr, funsor_operands)
 
     for operand in operands:
         pyro_require_backward(operand)


### PR DESCRIPTION
Addresses #124.  Resolves #164.

This PR updates `funsor.adjoint` to be compatible with alpha-renaming and adds support for separate forward and backward interpretations, enabling use cases like Viterbi decoding and forward filtering/backward sampling algorithms.

The interface has changed somewhat - now the user explicitly creates a tape and records the forward computation, then separately calls `adjoint` to run the backward computation:
```py
with interpretation(some_interpretation), AdjointTape() as tape:
    y = do_some_stuff(targets)

with interpretation(another_interpretation):
    adjoints = tape.adjoint(ops.logaddexp, ops.add, y, targets)
```