### PR TITLE
Add additional einsum backend support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ format: FORCE
 	isort -y
 
 test: lint FORCE
-	pytest -v test
+	pytest -v test -n auto
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ format: FORCE
 	isort -y
 
 test: lint FORCE
-	pytest -v test -n auto
+	pytest -v -n auto test/
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -116,10 +116,10 @@ def adjoint_binary(adj_redop, adj_binop, out_adj, op, lhs, rhs):
 def adjoint_reduce(adj_redop, adj_binop, out_adj, op, arg, reduced_vars):
     assert adj_binop is op or (op, adj_binop) in ops.DISTRIBUTIVE_OPS
 
-    if op is ops.logaddexp:
+    if op is adj_redop:
         # XXX using a hack to simulate "expand"
         return {arg: adj_binop(out_adj, Binary(ops.PRODUCT_INVERSES[adj_binop], arg, arg))}
-    elif op is ops.add:  # plate!
+    elif op is adj_binop:  # plate!
         out = arg.reduce(op, reduced_vars)
         return {arg: adj_binop(out_adj, Binary(ops.PRODUCT_INVERSES[op], out, arg))}
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -222,7 +222,7 @@ def make_plated_hmm_einsum(num_steps, num_obs_plates=1, num_hidden_plates=0):
         inputs.append(str(opt_einsum.get_symbol(t)) + str(opt_einsum.get_symbol(t+1)) + hidden_plates)
         inputs.append(str(opt_einsum.get_symbol(t+1)) + obs_plates)
     equation = ",".join(inputs) + "->"
-    return (equation, ''.join(set(obs_plates + hidden_plates)))
+    return (equation, ''.join(sorted(tuple(set(obs_plates + hidden_plates)))))
 
 
 def make_chain_einsum(num_steps):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -129,6 +129,7 @@ def make_einsum_example(equation, fill=None, sizes=(2, 3)):
     for dims in inputs:
         shape = tuple(sizes[dim] for dim in dims)
         operands.append(torch.randn(shape) if fill is None else torch.full(shape, fill))
+        operands[-1]._pyro_dims = dims
     funsor_operands = [
         Tensor(operand, OrderedDict([(d, bint(sizes[d])) for d in inp]))
         for inp, operand in zip(inputs, operands)

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ setup(
         'unification',
     ],
     extras_require={
-        'test': ['flake8', 'pytest>=4.1', 'pytest-xdist>=1.27.0', 'torchvision==0.2.1'],
+        'test': ['flake8', 'pytest>=4.1', 'pytest-xdist==1.27.0', 'torchvision==0.2.1'],
         'dev': [
             'flake8',
             'isort',
             'pytest>=4.1',
-            'pytest-xdist>=1.27.0',
+            'pytest-xdist==1.27.0',
             'sphinx>=2.0',
             'sphinx_rtd_theme',
             'torchvision==0.2.1',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             'flake8',
             'isort',
             'pytest>=4.1',
+            'pytest-xdist',
             'sphinx>=2.0',
             'sphinx_rtd_theme',
             'torchvision==0.2.1',

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,18 @@ setup(
         'unification',
     ],
     extras_require={
-        'test': ['flake8', 'pytest>=4.1', 'pytest-xdist', 'torchvision==0.2.1'],
+        'test': ['flake8', 'pytest>=4.1', 'pytest-xdist>=1.27.0', 'torchvision==0.2.1'],
         'dev': [
             'flake8',
             'isort',
             'pytest>=4.1',
-            'pytest-xdist',
+            'pytest-xdist>=1.27.0',
             'sphinx>=2.0',
             'sphinx_rtd_theme',
             'torchvision==0.2.1',
         ],
     },
-    tests_require=['flake8', 'pytest>=4.1', 'pytest-xdist'],
+    tests_require=['flake8', 'pytest>=4.1'],
     keywords='probabilistic machine learning bayesian statistics pytorch',
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'unification',
     ],
     extras_require={
-        'test': ['flake8', 'pytest>=4.1', 'torchvision==0.2.1'],
+        'test': ['flake8', 'pytest>=4.1', 'pytest-xdist', 'torchvision==0.2.1'],
         'dev': [
             'flake8',
             'isort',
@@ -29,7 +29,7 @@ setup(
             'torchvision==0.2.1',
         ],
     },
-    tests_require=['flake8', 'pytest>=4.1'],
+    tests_require=['flake8', 'pytest>=4.1', 'pytest-xdist'],
     keywords='probabilistic machine learning bayesian statistics pytorch',
     classifiers=[
         'Intended Audience :: Developers',

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import opt_einsum
 import pytest
 import torch
-from pyro.ops.contract import naive_ubersum
+from pyro.ops.contract import einsum as pyro_einsum
 
 import funsor
 from funsor.distributions import Categorical
@@ -27,7 +27,11 @@ EINSUM_EXAMPLES = [
 
 
 @pytest.mark.parametrize('equation', EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['torch', 'pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', [
+    'torch',
+    'pyro.ops.einsum.torch_log',
+    'pyro.ops.einsum.torch_map',
+])
 def test_einsum(equation, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
     expected = opt_einsum.contract(equation, *operands, backend=backend)
@@ -106,10 +110,14 @@ PLATED_EINSUM_EXAMPLES = [
 
 
 @pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['torch', 'pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', [
+    'torch',
+    'pyro.ops.einsum.torch_log',
+    'pyro.ops.einsum.torch_map',
+])
 def test_plated_einsum(equation, plates, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    expected = naive_ubersum(equation, *operands, plates=plates, backend=backend, modulo_total=False)[0]
+    expected = pyro_einsum(equation, *operands, plates=plates, backend=backend, modulo_total=False)[0]
     with interpretation(reflect):
         naive_ast = naive_plated_einsum(equation, *funsor_operands, plates=plates, backend=backend)
         optimized_ast = apply_optimizer(naive_ast)

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
-import opt_einsum
-import pyro.ops.contract as pyro_einsum
+from pyro.ops.contract import einsum as pyro_einsum
 import pytest
 import torch
 
@@ -23,14 +22,17 @@ OPTIMIZED_EINSUM_EXAMPLES = [
 
 
 @pytest.mark.parametrize('equation', OPTIMIZED_EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', [
+    'pyro.ops.einsum.torch_log',
+    'pyro.ops.einsum.torch_map',
+])
 @pytest.mark.parametrize("einsum_impl", [
     naive_einsum,
     # naive_contract_einsum,  # XXX not working, probably issue with canonicalization
 ])
 def test_optimized_einsum(equation, backend, einsum_impl):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    expected = opt_einsum.contract(equation, *operands, backend=backend)
+    expected = pyro_einsum(equation, *operands, backend=backend)[0]
     with interpretation(lazy):
         naive_ast = einsum_impl(equation, *funsor_operands, backend=backend)
         optimized_ast = apply_optimizer(naive_ast)
@@ -53,8 +55,10 @@ def test_optimized_einsum(equation, backend, einsum_impl):
 ])
 @pytest.mark.parametrize("optimize1", [False, True])
 @pytest.mark.parametrize("optimize2", [False, True])
-@pytest.mark.parametrize("backend1", ['torch', 'pyro.ops.einsum.torch_log'])
-@pytest.mark.parametrize("backend2", ['torch', 'pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize("backend1", [
+    'torch', 'pyro.ops.einsum.torch_log', 'pyro.ops.einsum.torch_map'])
+@pytest.mark.parametrize("backend2", [
+    'torch', 'pyro.ops.einsum.torch_log', 'pyro.ops.einsum.torch_map'])
 @pytest.mark.parametrize("einsum_impl", [naive_einsum, naive_contract_einsum])
 def test_nested_einsum(eqn1, eqn2, optimize1, optimize2, backend1, backend2, einsum_impl):
     inputs1, outputs1, sizes1, operands1, _ = make_einsum_example(eqn1, sizes=(3,))
@@ -64,8 +68,9 @@ def test_nested_einsum(eqn1, eqn2, optimize1, optimize2, backend1, backend2, ein
     operands1 = [operand.abs() / operand.abs().sum(-1, keepdim=True)
                  for operand in operands1]
 
-    expected1 = opt_einsum.contract(eqn1, *operands1, backend=backend1)
-    expected2 = opt_einsum.contract(outputs1[0] + "," + eqn2, *([expected1] + operands2), backend=backend2)
+    expected1 = pyro_einsum(eqn1, *operands1, backend=backend1, modulo_total=True)[0]
+    expected2 = pyro_einsum(outputs1[0] + "," + eqn2, *([expected1] + operands2),
+                            backend=backend2, modulo_total=True)[0]
 
     with interpretation(lazy):
         funsor_operands1 = [
@@ -96,10 +101,13 @@ PLATED_EINSUM_EXAMPLES = [
 
 
 @pytest.mark.parametrize('equation,plates', PLATED_EINSUM_EXAMPLES)
-@pytest.mark.parametrize('backend', ['pyro.ops.einsum.torch_log'])
+@pytest.mark.parametrize('backend', [
+    'pyro.ops.einsum.torch_log',
+    'pyro.ops.einsum.torch_map',
+])
 def test_optimized_plated_einsum(equation, plates, backend):
     inputs, outputs, sizes, operands, funsor_operands = make_einsum_example(equation)
-    expected = pyro_einsum.einsum(equation, *operands, plates=plates, backend=backend)[0]
+    expected = pyro_einsum(equation, *operands, plates=plates, backend=backend)[0]
     actual = einsum(equation, *funsor_operands, plates=plates, backend=backend)
 
     if len(equation) < 10:


### PR DESCRIPTION
This PR adds some support for a couple other backends to `funsor.einsum`, includes `torch_map` in `test_einsum.py` and `test_optimizer.py`, and adds some xfailing adjoint tests for the `torch_map` backend.  To make these additional test cases less annoying, I also fixed a longstanding bug that made einsum test generation nondeterministic, which was preventing us from using `pytest-xdist` to parallelize test execution, and updated `make test` to use `pytest-xdist`.