### PR TITLE
Implement Cat funsor

### DIFF
--- a/examples/pcfg.py
+++ b/examples/pcfg.py
@@ -17,7 +17,7 @@ def Uniform(components):
     if size == 1:
         return components[0]
     var = Variable('v', bint(size))
-    return (Stack(components, var.name).reduce(ops.logaddexp, var.name)
+    return (Stack(var.name, components).reduce(ops.logaddexp, var.name)
             - math.log(size))
 
 

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,7 +1,7 @@
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
-from funsor.terms import Funsor, Independent, Lambda, Number, Slice, Variable, of_shape, to_data, to_funsor
+from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange
 
 from . import (
@@ -27,6 +27,7 @@ from . import (
 )
 
 __all__ = [
+    'Cat',
     'Domain',
     'Funsor',
     'Independent',
@@ -34,6 +35,7 @@ __all__ = [
     'Lambda',
     'Number',
     'Slice',
+    'Stack',
     'Tensor',
     'Variable',
     'adjoint',

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -1,14 +1,8 @@
 from collections import OrderedDict, defaultdict
 from functools import reduce
 
-import torch
-
-from funsor.domains import bint
-from funsor.gaussian import Gaussian, align_gaussian
-from funsor.joint import Joint
 from funsor.ops import UNITS, AssociativeOp
-from funsor.terms import Funsor, Number, Slice
-from funsor.torch import Tensor, align_tensor
+from funsor.terms import Cat, Funsor, Number, Slice
 
 
 def _partition(terms, sum_vars):
@@ -101,71 +95,6 @@ def sum_product(sum_op, prod_op, factors, eliminate=frozenset(), plates=frozense
     return reduce(prod_op, factors, Number(UNITS[prod_op]))
 
 
-# TODO Promote this to a first class funsor and move this logic
-# into eager_cat for Tensor.
-def Cat(parts, name):
-    if len(parts) == 1:
-        return parts[0]
-    if len(set(part.output for part in parts)) > 1:
-        raise NotImplementedError("TODO")
-    inputs = OrderedDict()
-    for x in parts:
-        inputs.update(x.inputs)
-
-    if all(isinstance(part, Tensor) for part in parts):
-        tensors = []
-        for part in parts:
-            inputs[name] = part.inputs[name]  # typically a smaller bint
-            shape = tuple(d.size for d in inputs.values())
-            tensors.append(align_tensor(inputs, part).expand(shape))
-
-        dim = tuple(inputs).index(name)
-        tensor = torch.cat(tensors, dim=dim)
-        inputs[name] = bint(tensor.size(dim))
-        return Tensor(tensor, inputs, dtype=parts[0].dtype)
-
-    if all(isinstance(part, (Gaussian, Joint)) for part in parts):
-        int_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype != "real")
-        real_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype == "real")
-        inputs = int_inputs.copy()
-        inputs.update(real_inputs)
-        discretes = []
-        info_vecs = []
-        precisions = []
-        for part in parts:
-            inputs[name] = part.inputs[name]  # typically a smaller bint
-            int_inputs[name] = inputs[name]
-            shape = tuple(d.size for d in int_inputs.values())
-            if isinstance(part, Gaussian):
-                discrete = None
-                gaussian = part
-            elif isinstance(part, Joint):
-                if part.deltas:
-                    raise NotImplementedError("TODO")
-                discrete = align_tensor(int_inputs, part.discrete).expand(shape)
-                gaussian = part.gaussian
-            discretes.append(discrete)
-            info_vec, precision = align_gaussian(inputs, gaussian)
-            info_vecs.append(info_vec.expand(shape + (-1,)))
-            precisions.append(precision.expand(shape + (-1, -1)))
-
-        dim = tuple(inputs).index(name)
-        info_vec = torch.cat(info_vecs, dim=dim)
-        precision = torch.cat(precisions, dim=dim)
-        inputs[name] = bint(info_vec.size(dim))
-        int_inputs[name] = inputs[name]
-        result = Gaussian(info_vec, precision, inputs)
-        if any(d is not None for d in discretes):
-            for i, d in enumerate(discretes):
-                if d is None:
-                    discretes[i] = info_vecs[i].new_zeros(info_vecs[i].shape[:-1])
-            discrete = torch.cat(discretes, dim=dim)
-            result += Tensor(discrete, int_inputs)
-        return result
-
-    raise NotImplementedError("TODO")
-
-
 def naive_sequential_sum_product(sum_op, prod_op, trans, time, step):
     assert isinstance(sum_op, AssociativeOp)
     assert isinstance(prod_op, AssociativeOp)
@@ -239,6 +168,6 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
         contracted = prod_op(x, y).reduce(sum_op, drop)
         if duration > even_duration:
             extra = trans(**{time: Slice(time, duration - 1, duration)})
-            contracted = Cat((contracted, extra), time)
+            contracted = Cat(time, (contracted, extra))
         trans = contracted
     return trans(**{time: 0})

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1145,8 +1145,11 @@ def eager_cat_homogeneous(name, *parts):
 
 @dispatch(str, Variadic[Stack])
 def eager_cat_homogeneous(name, *parts):
-    parts = sum((p.parts for p in parts), ())
-    return Stack(name, parts)
+    if all(p.name == name for p in parts):
+        parts = sum((p.parts for p in parts), ())
+        return Stack(name, parts)
+
+    return None  # defer to default implementation
 
 
 class Lambda(Funsor):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1058,8 +1058,8 @@ class Stack(Funsor):
     """
     Stack of funsors along a new input dimension.
 
-    :param tuple parts: A tuple of Funsors of homogenous output domain.
     :param str name: The name of the new input variable along which to stack.
+    :param tuple parts: A tuple of Funsors of homogenous output domain.
     """
     def __init__(self, name, parts):
         assert isinstance(name, str)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -9,7 +9,19 @@ import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
-from funsor.terms import Binary, Independent, Lambda, Number, Slice, Stack, Variable, sequential, to_data, to_funsor
+from funsor.terms import (
+    Binary,
+    Cat,
+    Independent,
+    Lambda,
+    Number,
+    Slice,
+    Stack,
+    Variable,
+    sequential,
+    to_data,
+    to_funsor
+)
 from funsor.testing import assert_close, check_funsor, random_tensor
 from funsor.torch import REDUCE_OP_TO_TORCH
 
@@ -259,7 +271,7 @@ def test_stack_simple():
     y = Number(1.)
     z = Number(4.)
 
-    xyz = Stack((x, y, z), 'i')
+    xyz = Stack('i', (x, y, z))
     check_funsor(xyz, {'i': bint(3)}, reals())
 
     assert xyz(i=Number(0, 3)) is x
@@ -274,34 +286,48 @@ def test_stack_subs():
     z = Variable('z', reals())
     j = Variable('j', bint(3))
 
-    f = Stack((Number(0), x, y * z), 'i')
+    f = Stack('i', (Number(0), x, y * z))
     check_funsor(f, {'i': bint(3), 'x': reals(), 'y': reals(), 'z': reals()},
                  reals())
 
     assert f(i=Number(0, 3)) is Number(0)
     assert f(i=Number(1, 3)) is x
     assert f(i=Number(2, 3)) is y * z
-    assert f(i=j) is Stack((Number(0), x, y * z), 'j')
-    assert f(i='j') is Stack((Number(0), x, y * z), 'j')
+    assert f(i=j) is Stack('j', (Number(0), x, y * z))
+    assert f(i='j') is Stack('j', (Number(0), x, y * z))
     assert f.reduce(ops.add, 'i') is Number(0) + x + (y * z)
 
-    assert f(x=0) is Stack((Number(0), Number(0), y * z), 'i')
-    assert f(y=x) is Stack((Number(0), x, x * z), 'i')
-    assert f(x=0, y=x) is Stack((Number(0), Number(0), x * z), 'i')
+    assert f(x=0) is Stack('i', (Number(0), Number(0), y * z))
+    assert f(y=x) is Stack('i', (Number(0), x, x * z))
+    assert f(x=0, y=x) is Stack('i', (Number(0), Number(0), x * z))
     assert f(x=0, y=x, i=Number(2, 3)) is x * z
-    assert f(x=0, i=j) is Stack((Number(0), Number(0), y * z), 'j')
-    assert f(x=0, i='j') is Stack((Number(0), Number(0), y * z), 'j')
+    assert f(x=0, i=j) is Stack('j', (Number(0), Number(0), y * z))
+    assert f(x=0, i='j') is Stack('j', (Number(0), Number(0), y * z))
 
 
 @pytest.mark.parametrize("start,stop", [(0, 1), (0, 2), (0, 10), (1, 2), (1, 10), (2, 10)])
 @pytest.mark.parametrize("step", [1, 2, 5, 10])
 def test_stack_slice(start, stop, step):
     xs = tuple(map(Number, range(10)))
-    actual = Stack(xs, 'i')(i=Slice('j', start, stop, step, dtype=10))
-    expected = Stack(xs[start: stop: step], 'j')
+    actual = Stack('i', xs)(i=Slice('j', start, stop, step, dtype=10))
+    expected = Stack('j', xs[start: stop: step])
     assert type(actual) == type(expected)
     assert actual.name == expected.name
-    assert actual.components == expected.components
+    assert actual.parts == expected.parts
+
+
+def test_cat_simple():
+    x = Stack('i', (Number(0), Number(1), Number(2)))
+    y = Stack('i', (Number(3), Number(4)))
+
+    assert Cat('i', (x,)) is x
+    assert Cat('i', (y,)) is y
+
+    xy = Cat('i', (x, y))
+    assert xy.inputs == OrderedDict(i=bint(5))
+    assert xy.name == 'i'
+    for i in range(5):
+        assert xy(i=i) is Number(i)
 
 
 def test_align_simple():

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7,7 +7,7 @@ import torch
 import funsor
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.terms import Lambda, Number, Slice, Variable
+from funsor.terms import Cat, Lambda, Number, Slice, Variable
 from funsor.testing import assert_close, assert_equiv, check_funsor, random_tensor
 from funsor.torch import REDUCE_OP_TO_TORCH, Einsum, Tensor, align_tensors, torch_stack, torch_tensordot
 
@@ -695,3 +695,39 @@ def test_stack(n, shape, dim):
     actual = torch_stack(tuple(Tensor(t) for t in tensors), dim=dim)
     expected = Tensor(torch.stack(tensors, dim=dim))
     assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('output', [bint(2), reals(), reals(4), reals(2, 3)], ids=str)
+def test_cat_simple(output):
+    x = random_tensor(OrderedDict([
+        ('i', bint(2)),
+    ]), output)
+    y = random_tensor(OrderedDict([
+        ('i', bint(3)),
+        ('j', bint(4)),
+    ]), output)
+    z = random_tensor(OrderedDict([
+        ('i', bint(5)),
+        ('k', bint(6)),
+    ]), output)
+
+    assert Cat('i', (x,)) is x
+    assert Cat('i', (y,)) is y
+    assert Cat('i', (z,)) is z
+
+    xy = Cat('i', (x, y))
+    assert isinstance(xy, Tensor)
+    assert xy.inputs == OrderedDict([
+        ('i', bint(2 + 3)),
+        ('j', bint(4)),
+    ])
+    assert xy.output == output
+
+    xyz = Cat('i', (x, y, z))
+    assert isinstance(xyz, Tensor)
+    assert xyz.inputs == OrderedDict([
+        ('i', bint(2 + 3 + 5)),
+        ('j', bint(4)),
+        ('k', bint(6)),
+    ])
+    assert xy.output == output


### PR DESCRIPTION
Addresses #162, #177 

This promotes `Cat` to a funsor, implemented using variadic pattern matching following #157 so that homogeneous Stack/Tensor/Gaussian/Joint funsors can be concatenated eagerly.

This also reorders `Stack(components,name)` -> `Stack(name,parts)` to agree with `Cat` and make it a little cleaner for both funsors to use variadic pattern matching.

This does not implement every possible `Cat` pattern; rather this PR aims to implement only what is needed for `sequential_sum_product()`.

## Tested
- unit tests for `Cat` and eager Tensor fusion
- refactoring is exercised by `sequential_sum_product()` tests 