### PR TITLE
Add a Poisson distribution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -463,6 +463,25 @@ def eager_mvn(loc, scale_tril, value):
     return Tensor(log_prob, int_inputs) + Gaussian(info_vec, precision, inputs)
 
 
+class Poisson(Distribution):
+    dist_class = dist.Poisson
+
+    @staticmethod
+    def _fill_defaults(rate, value='value'):
+        rate = to_funsor(rate)
+        assert rate.dtype == "real"
+        value = to_funsor(value, reals())
+        return rate, value
+
+    def __init__(self, rate, value=None):
+        super().__init__(rate, value)
+
+
+@eager.register(Poisson, Tensor, Tensor)
+def eager_poisson(rate, value):
+    return Poisson.eager_log_prob(rate=rate, value=value)
+
+
 __all__ = [
     'Bernoulli',
     'BernoulliLogits',
@@ -477,4 +496,5 @@ __all__ = [
     'Multinomial',
     'MultivariateNormal',
     'Normal',
+    'Poisson',
 ]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -486,3 +486,29 @@ def test_mvn_gaussian(batch_shape):
     check_funsor(actual, inputs, reals())
 
     assert_close(actual, expected, atol=1e-3, rtol=1e-4)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+@pytest.mark.parametrize('syntax', ['eager', 'lazy'])
+def test_poisson_probs_density(batch_shape, syntax):
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    @funsor.torch.function(reals(), reals(), reals())
+    def poisson(rate, value):
+        return torch.distributions.Poisson(rate).log_prob(value)
+
+    check_funsor(poisson, {'rate': reals(), 'value': reals()}, reals())
+
+    rate = Tensor(torch.rand(batch_shape), inputs)
+    value = Tensor(torch.randn(batch_shape).exp().round(), inputs)
+    expected = poisson(rate, value)
+    check_funsor(expected, inputs, reals())
+
+    d = Variable('value', reals())
+    if syntax == 'eager':
+        actual = dist.Poisson(rate, value)
+    elif syntax == 'lazy':
+        actual = dist.Poisson(rate, d)(value=value)
+    check_funsor(actual, inputs, reals())
+    assert_close(actual, expected)


### PR DESCRIPTION
This adds a `Poisson` distribution following the pattern of the `BernoulliProbs` distribution. This is required for a funsor implementation of the BART forecasting example.

Note that in Funsor we encode Poisson samples as `reals()` since they don't fit into the `bint` type; this is a slight type mismatch, but it would be a huge effort to add a `nat` datatype.

## Tested
- added a unit test following other examples