### PR TITLE
Add sigmoid op

### DIFF
--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -167,6 +167,11 @@ def log1p(x):
 
 
 @Op
+def sigmoid(x):
+    return 1 / (1 + np.exp(-x))
+
+
+@Op
 def pow(x, y):
     return x ** y
 
@@ -268,6 +273,7 @@ __all__ = [
     'pow',
     'safediv',
     'safesub',
+    'sigmoid',
     'sqrt',
     'sub',
     'truediv',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -445,6 +445,9 @@ class Funsor(object, metaclass=FunsorMeta):
     def log1p(self):
         return Unary(ops.log1p, self)
 
+    def sigmoid(self):
+        return Unary(ops.sigmoid, self)
+
     # The following reductions are treated as Unary ops because they
     # reduce over output shape while preserving all inputs.
     # To reduce over inputs, instead call .reduce(op, reduced_vars).
@@ -1247,6 +1250,11 @@ def _log(x):
 @ops.log1p.register(Funsor)
 def _log1p(x):
     return Unary(ops.log1p, x)
+
+
+@ops.sigmoid.register(Funsor)
+def _sigmoid(x):
+    return Unary(ops.sigmoid, x)
 
 
 __all__ = [

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -110,7 +110,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('data', [0, 0.5, 1])
 @pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
+    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid',
 ])
 def test_unary(symbol, data):
     dtype = 'real'

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -231,7 +231,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p',
+    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid',
 ])
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}


### PR DESCRIPTION
This adds a `.sigmoid()` op as in PyTorch. This will make it easier to convert the BART example to funsor. This basically follows the pattern of `log1p`.

## Tested
- added to test_terms.py
- added to test_torch.py