### PR TITLE
Omit typing information from .__str__() and .pretty() methods

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -72,7 +72,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         self.params = params
 
     def __repr__(self):
-        return '{}({})'.format(type(self).__name__,
+        return '{}({})'.format(type(self).__origin__.__name__,
                                ', '.join('{}={}'.format(*kv) for kv in self.params))
 
     def eager_reduce(self, op, reduced_vars):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -24,11 +24,15 @@ _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 _GENSYM_COUNTER = 0
 
 
+def _get_name(cls):
+    return getattr(cls, '__origin__', cls).__name__
+
+
 if _DEBUG:
     def interpret(cls, *args):
         global _STACK_SIZE
         indent = '  ' * _STACK_SIZE
-        typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
+        typenames = [_get_name(cls)] + [_get_name(type(arg)) for arg in args]
         print(indent + ' '.join(typenames))
 
         _STACK_SIZE += 1
@@ -40,7 +44,7 @@ if _DEBUG:
         if _DEBUG > 1:
             result_str = re.sub('\n', '\n          ' + indent, str(result))
         else:
-            result_str = type(result).__name__
+            result_str = _get_name(type(result))
         print(indent + '-> ' + result_str)
         return result
 else:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -289,10 +289,10 @@ class Funsor(object, metaclass=FunsorMeta):
         return '{}({})'.format(type(self).__name__, ', '.join(map(repr, self._ast_values)))
 
     def __str__(self):
-        return '{}({})'.format(type(self).__name__, ', '.join(map(str, self._ast_values)))
+        return '{}({})'.format(type(self).__origin__.__name__, ', '.join(map(str, self._ast_values)))
 
     def _pretty(self, lines, indent=0):
-        lines.append((indent, type(self).__name__))
+        lines.append((indent, type(self).__origin__.__name__))
         for arg in self._ast_values:
             if isinstance(arg, Funsor):
                 arg._pretty(lines, indent + 1)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -286,7 +286,7 @@ class Funsor(object, metaclass=FunsorMeta):
         return id(self)
 
     def __repr__(self):
-        return '{}({})'.format(type(self).__name__, ', '.join(map(repr, self._ast_values)))
+        return '{}({})'.format(type(self).__origin__.__name__, ', '.join(map(repr, self._ast_values)))
 
     def __str__(self):
         return '{}({})'.format(type(self).__origin__.__name__, ', '.join(map(str, self._ast_values)))
@@ -431,7 +431,7 @@ class Funsor(object, metaclass=FunsorMeta):
         assert isinstance(sample_inputs, OrderedDict)
         if sampled_vars.isdisjoint(self.inputs):
             return self
-        raise ValueError("Cannot sample from a {}".format(type(self).__name__))
+        raise ValueError("Cannot sample from a {}".format(type(self).__origin__.__name__))
 
     def align(self, names):
         """


### PR DESCRIPTION
This removes extraneous information introduced in #212, which creates unreadably complex debug messages.

@eb8680 would it instead be possible to avoid munging the `.__name__` attribute?