### PR TITLE
Add a .classname attribute

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -24,11 +24,18 @@ _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 _GENSYM_COUNTER = 0
 
 
+def _classname(cls):
+    return getattr(cls, "classname", cls.__name__)
+
+
 if _DEBUG:
     def interpret(cls, *args):
         global _STACK_SIZE
         indent = '  ' * _STACK_SIZE
-        typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
+        if _DEBUG > 1:
+            typenames = [_classname(cls)] + [_classname(type(arg)) for arg in args]
+        else:
+            typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
         print(indent + ' '.join(typenames))
 
         _STACK_SIZE += 1

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -16,7 +16,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec, lazy_classproperty
+from funsor.util import getargspec, lazy_property
 
 
 def substitute(expr, subs):
@@ -226,6 +226,12 @@ class FunsorMeta(type):
                     return False
         return True
 
+    @lazy_property
+    def classname(cls):
+        return cls.__name__ + "[{}]".format(", ".join(
+            str(getattr(t, "classname", t))  # Tuple doesn't have __name__
+            for t in cls.__args__))
+
 
 def _issubclass_tuple(subcls, cls):
     """
@@ -275,12 +281,6 @@ class Funsor(object, metaclass=FunsorMeta):
         self.output = output
         self.fresh = fresh
         self.bound = bound
-
-    @lazy_classproperty
-    def classname(cls):
-        return cls.__name__ + "[{}]".format(", ".join(
-            str(getattr(t, "classname", t))  # Tuple doesn't have __name__
-            for t in cls.__args__))
 
     @property
     def dtype(self):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -16,7 +16,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec
+from funsor.util import getargspec, lazy_classproperty
 
 
 def substitute(expr, subs):
@@ -199,12 +199,10 @@ class FunsorMeta(type):
         if arg_types not in cls._type_cache:
             assert not cls.__args__, "cannot subscript a subscripted type {}".format(cls)
             assert len(arg_types) == len(cls._ast_fields), "must provide types for all params"
-            new_name = cls.__name__ + "[{}]".format(", ".join(
-                t.__name__ if hasattr(t, "__name__") else str(t) for t in arg_types))  # Tuple doesn't have __name__
             new_dct = cls.__dict__.copy()
             new_dct.update({"__args__": arg_types})
             # type(cls) to handle FunsorMeta subclasses
-            cls._type_cache[arg_types] = type(cls)(new_name, (cls,), new_dct)
+            cls._type_cache[arg_types] = type(cls)(cls.__name__, (cls,), new_dct)
         return cls._type_cache[arg_types]
 
     def __subclasscheck__(cls, subcls):  # issubclass(subcls, cls)
@@ -277,6 +275,12 @@ class Funsor(object, metaclass=FunsorMeta):
         self.output = output
         self.fresh = fresh
         self.bound = bound
+
+    @lazy_classproperty
+    def classname(cls):
+        return cls.__name__ + "[{}]".format(", ".join(
+            str(getattr(t, "classname", t))  # Tuple doesn't have __name__
+            for t in cls.__args__))
 
     @property
     def dtype(self):

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -16,17 +16,6 @@ class lazy_property(object):
         return value
 
 
-class lazy_classproperty(object):
-    def __init__(self, fn):
-        self.fn = fn
-        functools.update_wrapper(self, fn)
-
-    def __get__(self, obj, owner):
-        value = self.fn(owner)
-        setattr(owner, self.fn.__name__, value)
-        return value
-
-
 def getargspec(fn):
     """
     Similar to Python 2's :py:func:`inspect.getargspec` but:

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -16,6 +16,17 @@ class lazy_property(object):
         return value
 
 
+class lazy_classproperty(object):
+    def __init__(self, fn):
+        self.fn = fn
+        functools.update_wrapper(self, fn)
+
+    def __get__(self, obj, owner):
+        value = self.fn(owner)
+        setattr(owner, self.fn.__name__, value)
+        return value
+
+
 def getargspec(fn):
     """
     Similar to Python 2's :py:func:`inspect.getargspec` but:

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -361,6 +361,8 @@ def test_align_simple():
 def test_parametric_subclass(subcls_expr, cls_expr):
     subcls = eval(subcls_expr)
     cls = eval(cls_expr)
+    print(subcls.classname)
+    print(cls.classname)
     assert issubclass(cls, (Funsor, Reduce)) and not issubclass(subcls, typing.Tuple)  # appease flake8
     assert issubclass(subcls, cls)
 
@@ -381,5 +383,7 @@ def test_parametric_subclass(subcls_expr, cls_expr):
 def test_not_parametric_subclass(subcls_expr, cls_expr):
     subcls = eval(subcls_expr)
     cls = eval(cls_expr)
+    print(subcls.classname)
+    print(cls.classname)
     assert issubclass(cls, (Funsor, Reduce)) and not issubclass(subcls, typing.Tuple)  # appease flake8
     assert not issubclass(subcls, cls)


### PR DESCRIPTION
This cleans up debug logging that became very verbose in #212 .

After this PR, the `.__name__` attribute of a subclass will be the same as of the class, and a more verbose name is accessible via a new `.classname` attribute. This `.classname` is printed under logging level `FUNSOR_DEBUG=2` or higher.

## Tested
- added smoke test invocations to `test_*_parametric_subclass()`
- ran tests under FUNSOR_DEBUG=1 to verify medium-verbose behavior
- ran tests under FUNSOR_DEBUG=2 to verify very-verbose behavior