### PR TITLE
Support Independent(Normal) in matrix_and_mvn_to_funsor()

### DIFF
--- a/docs/source/pyro.rst
+++ b/docs/source/pyro.rst
@@ -27,6 +27,5 @@ Conversion Utilities
 ====================
 .. automodule:: funsor.pyro.convert
     :members:
-    :undoc-members:
     :show-inheritance:
     :member-order: bysource

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -223,12 +223,14 @@ class AffineNormal(Funsor):
 
         Normal(x @ matrix + loc, scale).to_event(1).log_prob(y)
 
-    :param torch.Tensor matrix: A transformation from ``X`` to ``Y``.
+    :param ~funsor.terms.Funsor matrix: A transformation from ``X`` to ``Y``.
         Should have rightmost shape ``(x_dim, y_dim)``.
-    :param torch.Tensor loc: A constant offset for ``Y``'s mean.
+    :param ~funsor.terms.Funsor loc: A constant offset for ``Y``'s mean.
         Should have output shape ``(y_dim,)``.
-    :param torch.Tensor scale: Standard deviation for ``Y``.
+    :param ~funsor.terms.Funsor scale: Standard deviation for ``Y``.
         Should have output shape ``(y_dim,)``.
+    :param ~funsor.terms.Funsor value_x: A value ``X``.
+    :param ~funsor.terms.Funsor value_y: A value ``Y``.
     """
     def __init__(self, matrix, loc, scale, value_x, value_y):
         inputs = OrderedDict()
@@ -291,8 +293,10 @@ def matrix_and_mvn_to_funsor(matrix, mvn, event_dims=(), x_name="value_x", y_nam
     real vector ``y` given real vector ``x``.
 
     :param torch.Tensor matrix: A matrix with rightmost shape ``(x_size, y_size)``.
-    :param torch.distributions.MultivariateNormal mvn: A multivariate normal
-        distribution with ``event_shape == (y_size,)``.
+    :param mvn: A multivariate normal distribution with
+        ``event_shape == (y_size,)``.
+    :type mvn: torch.distributions.MultivariateNormal or
+        torch.distributions.Independent of torch.distributions.Normal
     :param tuple event_dims: A tuple of names for rightmost dimensions.
         These will be assigned to ``result.inputs`` of type ``bint``.
     :param str x_name: The name of the ``x`` random variable.

--- a/test/pyro/test_convert.py
+++ b/test/pyro/test_convert.py
@@ -146,6 +146,11 @@ def test_matrix_and_mvn_to_funsor_diag(batch_shape, x_size, y_size):
     expected_like = expected(value_y=y)
     assert_close(actual_like, expected_like, atol=1e-4, rtol=1e-4)
 
+    x = tensor_to_funsor(torch.randn(batch_shape + (x_size,)), (), 1)
+    actual_norm = actual_like(value_x=x)
+    expected_norm = expected_like(value_x=x)
+    assert_close(actual_norm, expected_norm, atol=1e-4, rtol=1e-4)
+
 
 @pytest.mark.parametrize("real_size", [1, 2, 3])
 @pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)

--- a/test/pyro/test_convert.py
+++ b/test/pyro/test_convert.py
@@ -7,6 +7,7 @@ from pyro.distributions.torch_distribution import MaskedDistribution
 
 from funsor.domains import bint, reals
 from funsor.pyro.convert import (
+    AffineNormal,
     dist_to_funsor,
     funsor_to_cat_and_mvn,
     funsor_to_mvn,
@@ -15,8 +16,8 @@ from funsor.pyro.convert import (
     mvn_to_funsor,
     tensor_to_funsor
 )
-from funsor.terms import Funsor
-from funsor.testing import assert_close, random_mvn
+from funsor.terms import Funsor, Variable
+from funsor.testing import assert_close, random_mvn, random_tensor
 from funsor.torch import Tensor
 
 EVENT_SHAPES = [(), (1,), (5,), (4, 3)]
@@ -73,6 +74,28 @@ def test_mvn_to_funsor(batch_shape, event_shape, event_sizes):
 
 @pytest.mark.parametrize("x_size", [1, 2, 3])
 @pytest.mark.parametrize("y_size", [1, 2, 3])
+@pytest.mark.parametrize("shape", EVENT_SHAPES, ids=str)
+def test_affine_normal(shape, x_size, y_size):
+    int_inputs = OrderedDict(zip("abcdef", map(bint, shape)))
+    matrix = random_tensor(int_inputs, reals(x_size, y_size))
+    loc = random_tensor(int_inputs, reals(y_size))
+    scale = random_tensor(int_inputs, reals(y_size)).exp()
+    value_x = random_tensor(int_inputs, reals(x_size))
+    value_y = random_tensor(int_inputs, reals(y_size))
+
+    f = AffineNormal(matrix, loc, scale,
+                     Variable("x", reals(x_size)),
+                     Variable("y", reals(y_size)))
+    assert isinstance(f, AffineNormal)
+
+    # Evaluate via two different patterns.
+    expected = f(x=value_x)(y=value_y)
+    actual = f(y=value_y)(x=value_x)
+    assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("x_size", [1, 2, 3])
+@pytest.mark.parametrize("y_size", [1, 2, 3])
 @pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
 @pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
 def test_matrix_and_mvn_to_funsor(batch_shape, event_shape, x_size, y_size):
@@ -101,6 +124,27 @@ def test_matrix_and_mvn_to_funsor(batch_shape, event_shape, x_size, y_size):
     expected_log_prob = tensor_to_funsor(
         xy_mvn.log_prob(xy) + y_mvn.log_prob(y - y_pred), tuple(int_inputs))
     assert_close(actual_log_prob, expected_log_prob, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("x_size", [1, 2, 3])
+@pytest.mark.parametrize("y_size", [1, 2, 3])
+def test_matrix_and_mvn_to_funsor_diag(batch_shape, x_size, y_size):
+    matrix = torch.randn(batch_shape + (x_size, y_size))
+    loc = torch.randn(batch_shape + (y_size,))
+    scale = torch.randn(batch_shape + (y_size,)).exp()
+
+    normal = dist.Normal(loc, scale).to_event(1)
+    actual = matrix_and_mvn_to_funsor(matrix, normal)
+    assert isinstance(actual, AffineNormal)
+
+    mvn = dist.MultivariateNormal(loc, scale_tril=scale.diag_embed())
+    expected = matrix_and_mvn_to_funsor(matrix, mvn)
+
+    y = tensor_to_funsor(torch.randn(batch_shape + (y_size,)), (), 1)
+    actual_like = actual(value_y=y)
+    expected_like = expected(value_y=y)
+    assert_close(actual_like, expected_like, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.parametrize("real_size", [1, 2, 3])


### PR DESCRIPTION
This ports Pyro's https://github.com/pyro-ppl/pyro/pull/2005 to funsor. The math and code structure are nearly identical. As in Pyro we create a temporary `AffineNormal` object to avoid expensive intermediate computations.

One difference in Funsor is that the `AffineNormal.condition()` method becomes a pattern. For testing purposes I've added another simple pattern, fixing `x` rather than `y`.

## Tested
- added unit test for the `AffineNormal` funsor
- added a unit test comparing `Independent(Normal)` vs `MultivariateNormal(..., scale.diag_embed())` (ported from Pyro)