### PR TITLE
Support set-valued args to Funsor.reduce()

### DIFF
--- a/examples/slds.py
+++ b/examples/slds.py
@@ -44,8 +44,7 @@ def main(args):
 
             # Marginalize out previous delayed sample statements.
             if t > 0:
-                log_prob = log_prob.reduce(
-                    ops.logaddexp, frozenset([s_prev.name, x_prev.name]))
+                log_prob = log_prob.reduce(ops.logaddexp, {s_prev.name, x_prev.name})
 
             # An observe statement.
             log_prob += dist.Normal(x_curr, emit_noise, value=y)

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -62,7 +62,7 @@ def main(args):
         # Evaluate the model likelihood at the lazy value z.
         probs = decode('z')
         p = dist.Bernoulli(probs['x', 'y'], value=data['x', 'y'])
-        p = p.reduce(ops.add, frozenset(['x', 'y']))
+        p = p.reduce(ops.add, {'x', 'y'})
 
         # Construct an elbo. This is where sampling happens.
         elbo = funsor.Integrate(q, p - q, frozenset(['z']))

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -377,6 +377,9 @@ class Funsor(object, metaclass=FunsorMeta):
         elif isinstance(reduced_vars, str):
             # A single name means "reduce over this one variable".
             reduced_vars = frozenset([reduced_vars])
+        elif isinstance(reduced_vars, set):
+            # Support set syntax because it is less verbose.
+            reduced_vars = frozenset(reduced_vars)
         assert isinstance(reduced_vars, frozenset), reduced_vars
         if not reduced_vars:
             return self

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -229,6 +229,15 @@ def test_reduce_subset(op, reduced_vars):
         assert actual is f
 
 
+def test_reduce_syntactic_sugar():
+    x = Stack("i", (Number(1), Number(2), Number(3)))
+    expected = Number(1 + 2 + 3)
+    assert x.reduce(ops.add) is expected
+    assert x.reduce(ops.add, "i") is expected
+    assert x.reduce(ops.add, {"i"}) is expected
+    assert x.reduce(ops.add, frozenset(["i"])) is expected
+
+
 @pytest.mark.parametrize('base_shape', [(), (4,), (3, 2)], ids=str)
 def test_lambda(base_shape):
     z = Variable('z', reals(*base_shape))


### PR DESCRIPTION
Addresses #211 

This extends `.reduce()` to accept `set`s of strings, since those are much easier to read and write than `frozenset([])`s. I've intentionally avoided generalizing this gratuitously, e.g. to lists, tuples, iterables etc.

## Tested
- added a unit test
- converted some examples to use this terser notation