### PR TITLE
Add passing+failing tests for biased filtering

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -114,6 +114,24 @@ def eager(cls, *args):
 
 
 @dispatched_interpretation
+def eager_or_die(cls, *args):
+    """
+    Eagerly execute ops with known implementations.
+    Disallows lazy :class:`Subs` , :class:`Unary` , :class:`Binary` , and
+    :class:`Reduce` .
+
+    :raises: :py:class:`NotImplementedError` no pattern is found.
+    """
+    result = eager.dispatch(cls, *args)
+    if result is None:
+        if cls in (Subs, Unary, Binary, Reduce):
+            raise NotImplementedError("Missing pattern for {}({})".format(
+                cls.__name__, ", ".join(map(str, args))))
+        result = reflect(cls, *args)
+    return result
+
+
+@dispatched_interpretation
 def sequential(cls, *args):
     """
     Eagerly execute ops with known implementations; additonally execute
@@ -1417,6 +1435,7 @@ __all__ = [
     'Unary',
     'Variable',
     'eager',
+    'eager_or_die',
     'lazy',
     'moment_matching',
     'of_shape',

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -15,7 +15,7 @@ from funsor.sum_product import (
     sequential_sum_product,
     sum_product
 )
-from funsor.terms import Variable, moment_matching, reflect
+from funsor.terms import Variable, eager_or_die, moment_matching, reflect
 from funsor.testing import assert_close, random_gaussian, random_tensor
 from funsor.torch import Tensor
 
@@ -228,7 +228,8 @@ def test_sequential_sum_product_bias_2(num_steps, num_sensors, dim):
     # Each time step only a single sensor observes x,
     # and each sensor has a different bias.
     sensor_id = Tensor(torch.arange(num_steps) % 2, OrderedDict(time=bint(num_steps)), dtype=2)
-    factor = trans + obs(bias=bias[sensor_id]) + bias_dist
+    with interpretation(eager_or_die):
+        factor = trans + obs(bias=bias[sensor_id]) + bias_dist
     assert set(factor.inputs) == {"time", "bias", "x_prev", "x_curr"}
 
     result = sequential_sum_product(ops.logaddexp, ops.add, factor, "time", {"x_prev": "x_curr"})

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -21,6 +21,7 @@ from funsor.terms import (
     Slice,
     Stack,
     Variable,
+    eager_or_die,
     sequential,
     to_data,
     to_funsor
@@ -79,6 +80,31 @@ def test_cons_hash():
 def test_reinterpret(expr):
     x = eval(expr)
     assert funsor.reinterpret(x) is x
+
+
+@pytest.mark.parametrize("expr", [
+    "Variable('x', reals())",
+    "Number(1)",
+    "Number(1).log()",
+    "Number(1) + Number(2)",
+    "Stack('t', (Number(1), Number(2)))",
+    "Stack('t', (Number(1), Number(2))).reduce(ops.add, 't')",
+])
+def test_eager_or_die_ok(expr):
+    with interpretation(eager_or_die):
+        eval(expr)
+
+
+@pytest.mark.parametrize("expr", [
+    "Variable('x', reals()).log()",
+    "Number(1) / Variable('x', reals())",
+    "Variable('x', reals()) ** Number(2)",
+    "Stack('t', (Number(1), Variable('x', reals()))).reduce(ops.logaddexp, 't')",
+])
+def test_eager_or_die_error(expr):
+    with interpretation(eager_or_die):
+        with pytest.raises(NotImplementedError):
+            eval(expr)
 
 
 @pytest.mark.parametrize('domain', [bint(3), reals()])


### PR DESCRIPTION
Addresses #72 
Based on #221 
Pair coded with @jpchen 

This adds two tests (one passing, one failing) for `sequential_sum_product()` with global bias terms. The failing test involves a pattern `Gaussian(x=y[z])`, where we currently cannot recognize `y[z]` as a linear function of `y`.

I'm adding this now because it is somewhat blocking @jpchen and I'd like to track progress.