### PR TITLE
Add eager_or_die interpretation to diagnose missing patterns

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -869,6 +869,13 @@ def eager_unary(op, arg):
     return interpreter.debug_logged(arg.eager_unary)(op)
 
 
+@eager.register(Unary, AssociativeOp, Funsor)
+def eager_unary(op, arg):
+    if not arg.output.shape:
+        return arg
+    return interpreter.debug_logged(arg.eager_unary)(op)
+
+
 _INFIX = {
     ops.add: '+',
     ops.sub: '-',

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -21,6 +21,7 @@ from funsor.terms import (
     Slice,
     Stack,
     Variable,
+    eager_or_die,
     sequential,
     to_data,
     to_funsor
@@ -79,6 +80,31 @@ def test_cons_hash():
 def test_reinterpret(expr):
     x = eval(expr)
     assert funsor.reinterpret(x) is x
+
+
+@pytest.mark.parametrize("expr", [
+    "Variable('x', reals())",
+    "Number(1)",
+    "Number(1).log()",
+    "Number(1) + Number(2)",
+    "Stack('t', (Number(1), Number(2)))",
+    "Stack('t', (Number(1), Number(2))).reduce(ops.add, 't')",
+])
+def test_eager_or_die_ok(expr):
+    with interpretation(eager_or_die):
+        eval(expr)
+
+
+@pytest.mark.parametrize("expr", [
+    "Variable('x', reals()).log()",
+    "Number(1) / Variable('x', reals())",
+    "Variable('x', reals()) ** Number(2)",
+    "Stack('t', (Number(1), Variable('x', reals()))).reduce(ops.logaddexp, 't')",
+])
+def test_eager_or_die_error(expr):
+    with interpretation(eager_or_die):
+        with pytest.raises(NotImplementedError):
+            eval(expr)
 
 
 @pytest.mark.parametrize('domain', [bint(3), reals()])


### PR DESCRIPTION
This adds an interpretation like `eager` but that raises `NotImplemntedError` if it is unable to match a pattern for the most common funsor types: `Subs`, `Unary`, `Binary`, `Reduce`.

The motivation is that, in large computations missing patterns result in huge difficult-to-debug lazy expressions (e.g. @jpchen and I both hit missing-pattern bugs today and ended up with multi-page funsors). An extreme solution would be to error as soon as any pattern is missing.

## Questions

1. Is the set `{Subs, Unary, Binary, Reduce}` reasonable? In practice I find almost all missing patterns result in Binary, Reduce, or Subs.

## Tested
- unit tests
- ran on a failing test #220 and received a helpful error message 😄 
  ```
  NotImplementedError: Missing pattern for Binary(GetitemOp(0), bias, Tensor(tensor([0]), OrderedDict([('time', bint(1))]), 2))
  ```