### PR TITLE
Add support for nested union types

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -192,8 +192,6 @@ class FunsorMeta(type):
         if not isinstance(arg_types, tuple):
             arg_types = (arg_types,)
         assert not any(isvariadic(arg_type) for arg_type in arg_types), "nested variadic types not supported"
-        # TODO add support for nested union types (i.e. remove the following assertion)
-        assert not any(isinstance(arg_type, tuple) for arg_type in arg_types), "nested union types not supported"
         # switch tuple to typing.Tuple
         arg_types = tuple(typing.Tuple if arg_type is tuple else arg_type for arg_type in arg_types)
         if arg_types not in cls._type_cache:
@@ -237,7 +235,18 @@ def _issubclass_tuple(subcls, cls):
     """
     utility for pattern matching with tuple subexpressions
     """
-    subcls_is_tuple = hasattr(cls, "__origin__") and (subcls.__origin__ or subcls) in (tuple, typing.Tuple)
+    # so much boilerplate...
+    cls_is_union = hasattr(cls, "__origin__") and (cls.__origin__ or cls) is typing.Union
+    if isinstance(cls, tuple) or cls_is_union:
+        return any(_issubclass_tuple(subcls, option)
+                   for option in (getattr(cls, "__args__", []) if cls_is_union else cls))
+
+    subcls_is_union = hasattr(subcls, "__origin__") and (subcls.__origin__ or subcls) is typing.Union
+    if isinstance(subcls, tuple) or subcls_is_union:
+        return any(_issubclass_tuple(option, cls)
+                   for option in (getattr(subcls, "__args__", []) if subcls_is_union else subcls))
+
+    subcls_is_tuple = hasattr(subcls, "__origin__") and (subcls.__origin__ or subcls) in (tuple, typing.Tuple)
     cls_is_tuple = hasattr(cls, "__origin__") and (cls.__origin__ or cls) in (tuple, typing.Tuple)
     if subcls_is_tuple != cls_is_tuple:
         return False
@@ -247,10 +256,8 @@ def _issubclass_tuple(subcls, cls):
         return True
     if not subcls.__args__ or len(subcls.__args__) != len(cls.__args__):
         return False
-    for a, b in zip(subcls.__args__, cls.__args__):
-        if not _issubclass_tuple(a, b):
-            return False
-    return True
+
+    return all(_issubclass_tuple(a, b) for a, b in zip(subcls.__args__, cls.__args__))
 
 
 class Funsor(object, metaclass=FunsorMeta):

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -366,6 +366,11 @@ def test_align_simple():
      "Reduce[ops.AssociativeOp, Reduce, frozenset]"),
     ("Stack[str, typing.Tuple[Number, Number, Number]]", "Stack"),
     ("Stack[str, typing.Tuple[Number, Number, Number]]", "Stack[str, tuple]"),
+    # Unions
+    ("Reduce[ops.AssociativeOp, (Number, Stack[str, (tuple, typing.Tuple[Number, Number])]), frozenset]", "Funsor"),
+    ("Reduce[ops.AssociativeOp, (Number, Stack), frozenset]", "Reduce[ops.Op, Funsor, frozenset]"),
+    ("Reduce[ops.AssociativeOp, (Stack, Reduce[ops.AssociativeOp, (Number, Stack), frozenset]), frozenset]",
+     "Reduce[(ops.Op, ops.AssociativeOp), Stack, frozenset]"),
 ])
 def test_parametric_subclass(subcls_expr, cls_expr):
     subcls = eval(subcls_expr)
@@ -388,6 +393,11 @@ def test_parametric_subclass(subcls_expr, cls_expr):
     ("Stack[str, tuple]", "Stack[str, typing.Tuple[Number, Number, Number]]"),
     ("Stack[str, typing.Tuple[Number, Number]]", "Stack[str, typing.Tuple[Number, Reduce]]"),
     ("Stack[str, typing.Tuple[Number, Reduce]]", "Stack[str, typing.Tuple[Number, Number]]"),
+    # Unions
+    ("Funsor", "Reduce[ops.AssociativeOp, (Number, Funsor), frozenset]"),
+    ("Reduce[ops.Op, Funsor, frozenset]", "Reduce[ops.AssociativeOp, (Number, Stack), frozenset]"),
+    ("Reduce[(ops.Op, ops.AssociativeOp), Stack, frozenset]",
+     "Reduce[ops.AssociativeOp, (Stack[str, tuple], Reduce[ops.AssociativeOp, (Cat, Stack), frozenset]), frozenset]"),
 ])
 def test_not_parametric_subclass(subcls_expr, cls_expr):
     subcls = eval(subcls_expr)


### PR DESCRIPTION
This PR follows up on #212 by adding support for pattern matching with nested union types:
```py
@eager.register(Binary, AssociativeOp, (Tensor, Reduce[Op, (Reduce[Op, Funsor, frozenset], Gaussian), frozenset]), Funsor)
```
This should probably be used somewhat sparingly since it hasn't been optimized for performance.  Note that type variables and nested variadic types are still disallowed and I currently have no plans to support them.

Tested:
- Added extra test cases in `test_terms.py`