### PR TITLE
Refactor alpha conversion logic to allow overloads

### DIFF
--- a/funsor/contract.py
+++ b/funsor/contract.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 import funsor.interpreter as interpreter
 import funsor.ops as ops
-from funsor.terms import Funsor, eager
+from funsor.terms import Funsor, eager, to_funsor
 
 
 def _simplify_contract(fn, sum_op, prod_op, lhs, rhs, reduced_vars):
@@ -60,8 +60,10 @@ class Contract(Funsor):
         self.reduced_vars = reduced_vars
 
     def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.lhs.inputs.get(k, self.rhs.inputs.get(k)))
+                      for k, v in alpha_subs.items()}
         sum_op, prod_op, lhs, rhs, reduced_vars = super()._alpha_convert(alpha_subs)
-        reduced_vars = frozenset(alpha_subs.get(k, k) for k in reduced_vars)
+        reduced_vars = frozenset(str(alpha_subs.get(k, k)) for k in reduced_vars)
         return sum_op, prod_op, lhs, rhs, reduced_vars
 
 

--- a/funsor/contract.py
+++ b/funsor/contract.py
@@ -59,6 +59,11 @@ class Contract(Funsor):
         self.rhs = rhs
         self.reduced_vars = reduced_vars
 
+    def _alpha_convert(self, alpha_subs):
+        sum_op, prod_op, lhs, rhs, reduced_vars = super()._alpha_convert(alpha_subs)
+        reduced_vars = frozenset(alpha_subs.get(k, k) for k in reduced_vars)
+        return sum_op, prod_op, lhs, rhs, reduced_vars
+
 
 @eager.register(Contract, ops.AssociativeOp, ops.AssociativeOp, Funsor, Funsor, frozenset)
 @contractor

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -26,6 +26,11 @@ class Integrate(Funsor):
         self.integrand = integrand
         self.reduced_vars = reduced_vars
 
+    def _alpha_convert(self, alpha_subs):
+        log_measure, integrand, reduced_vars = super()._alpha_convert(alpha_subs)
+        reduced_vars = frozenset(alpha_subs.get(k, k) for k in reduced_vars)
+        return log_measure, integrand, reduced_vars
+
 
 def _simplify_integrate(fn, log_measure, integrand, reduced_vars):
     """

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -23,6 +23,7 @@ def substitute(expr, subs):
     if isinstance(subs, (dict, OrderedDict)):
         subs = tuple(subs.items())
     assert isinstance(subs, tuple)
+    assert all(isinstance(v, Funsor) for k, v in subs)
 
     @interpreter.interpretation(interpreter._INTERPRETATION)  # use base
     def subs_interpreter(cls, *args):
@@ -48,7 +49,7 @@ def _alpha_mangle(expr):
         return expr
 
     ast_values = expr._alpha_convert(alpha_subs)
-    return reflect(type(expr), *ast_values, alpha_mangle=False)
+    return reflect(type(expr), *ast_values)
 
 
 def reflect(cls, *args, **kwargs):
@@ -69,8 +70,7 @@ def reflect(cls, *args, **kwargs):
     result._ast_values = args
 
     # alpha-convert eagerly upon binding any variable
-    if kwargs.pop("alpha_mangle", True):
-        result = _alpha_mangle(result)
+    result = _alpha_mangle(result)
 
     cls._cons_cache[cache_key] = result
     return result
@@ -779,8 +779,7 @@ class Variable(Funsor):
 
     def eager_subs(self, subs):
         assert len(subs) == 1 and subs[0][0] == self.name
-        v = subs[0][1]
-        return v if isinstance(v, Funsor) else to_funsor(v, self.output)
+        return subs[0][1]
 
 
 @dispatch(str, Domain)
@@ -814,8 +813,10 @@ class Subs(Funsor):
         return 'Subs({}, {})'.format(self.arg, self.subs)
 
     def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.subs[k].output)
+                      for k, v in alpha_subs.items()}
         arg, subs = super()._alpha_convert(alpha_subs)
-        subs = tuple((alpha_subs.get(k, k), v) for k, v in subs)
+        subs = tuple((str(alpha_subs.get(k, k)), v) for k, v in subs)
         return arg, subs
 
     def unscaled_sample(self, sampled_vars, sample_inputs):
@@ -949,8 +950,10 @@ class Reduce(Funsor):
             self.op.__name__, self.arg, self.reduced_vars)
 
     def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.arg.inputs[k])
+                      for k, v in alpha_subs.items()}
         op, arg, reduced_vars = super()._alpha_convert(alpha_subs)
-        reduced_vars = frozenset(alpha_subs.get(k, k) for k in reduced_vars)
+        reduced_vars = frozenset(str(alpha_subs.get(k, k)) for k in reduced_vars)
         return op, arg, reduced_vars
 
     def eager_reduce(self, op, reduced_vars):
@@ -1304,6 +1307,11 @@ class Lambda(Funsor):
         self.var = var
         self.expr = expr
 
+    def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.var.inputs[k])
+                      for k, v in alpha_subs.items()}
+        return super()._alpha_convert(alpha_subs)
+
 
 @eager.register(Binary, GetitemOp, Lambda, (Funsor, Align))
 def eager_getitem_lambda(op, lhs, rhs):
@@ -1354,8 +1362,10 @@ class Independent(Funsor):
         self.reals_var_bound = reals_var_bound
 
     def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.fn.inputs[k])
+                      for k, v in alpha_subs.items()}
         fn, reals_var, bint_var = super()._alpha_convert(alpha_subs)
-        bint_var = alpha_subs.get(bint_var, bint_var)
+        bint_var = str(alpha_subs.get(bint_var, bint_var))
         return fn, reals_var, bint_var
 
     def unscaled_sample(self, sampled_vars, sample_inputs):
@@ -1367,8 +1377,7 @@ class Independent(Funsor):
         return Independent(fn, self.reals_var, self.bint_var)
 
     def eager_subs(self, subs):
-        subs = tuple((self.reals_var_bound,
-                      to_funsor(v, self.inputs[k])[self.bint_var])
+        subs = tuple((self.reals_var_bound, v[self.bint_var])
                      if k == self.reals_var
                      else (k, v)
                      for k, v in subs)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -319,6 +319,7 @@ class Funsor(object, metaclass=FunsorMeta):
         """
         # Substitute all funsor values.
         # Subclasses must handle string conversion.
+        assert self.bound.issuperset(alpha_subs)
         return tuple(substitute(v, alpha_subs) for v in self._ast_values)
 
     def __call__(self, *args, **kwargs):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -36,38 +36,22 @@ def substitute(expr, subs):
         return interpreter.reinterpret(expr)
 
 
-def alpha_substitute(expr, alpha_subs):
+def _alpha_mangle(expr):
+    """
+    Rename bound variables in expr to avoid conflict with any free variables.
 
-    new_values = []
-    for v in expr._ast_values:
-        v = substitute(v, alpha_subs)
-        if isinstance(v, str) and v not in expr.fresh:
-            v = alpha_subs.get(v, v)
-        elif isinstance(v, frozenset):
-            swapped = v & frozenset(alpha_subs.keys())
-            v |= frozenset(alpha_subs[k] for k in swapped)
-            v -= swapped
-        elif isinstance(v, tuple) and isinstance(v[0], tuple) and len(v[0]) == 2 and \
-                isinstance(v[0][0], str) and isinstance(v[0][1], Funsor):
-            v = tuple((alpha_subs[k] if k in alpha_subs else k, vv) for k, vv in v)
-        elif isinstance(v, OrderedDict):  # XXX is this case ever actually triggered?
-            v = OrderedDict([(alpha_subs[k] if k in alpha_subs else k, vv) for k, vv in v.items()])
-        new_values.append(v)
-
-    return tuple(new_values)
-
-
-def alpha_convert(expr):
+    FIXME this does not avoid conflict with other bound variables.
+    """
     alpha_subs = {name: interpreter.gensym(name + "__BOUND")
                   for name in expr.bound if "__BOUND" not in name}
     if not alpha_subs:
         return expr
 
-    new_values = alpha_substitute(expr, alpha_subs)
-    return reflect(type(expr), *new_values)
+    ast_values = expr._alpha_convert(alpha_subs)
+    return reflect(type(expr), *ast_values, alpha_mangle=False)
 
 
-def reflect(cls, *args):
+def reflect(cls, *args, **kwargs):
     """
     Construct a funsor, populate ``._ast_values``, and cons hash.
     This is the only interpretation allowed to construct funsors.
@@ -85,7 +69,8 @@ def reflect(cls, *args):
     result._ast_values = args
 
     # alpha-convert eagerly upon binding any variable
-    result = alpha_convert(result)
+    if kwargs.pop("alpha_mangle", True):
+        result = _alpha_mangle(result)
 
     cls._cons_cache[cache_key] = result
     return result
@@ -327,6 +312,26 @@ class Funsor(object, metaclass=FunsorMeta):
 
     def __contains__(self, item):
         raise TypeError
+
+    def _alpha_convert(self, alpha_subs):
+        """
+        Rename bound variables while preserving all free variables.
+        """
+        ast_values = []
+        for v in self._ast_values:
+            v = substitute(v, alpha_subs)
+            if isinstance(v, str) and v not in self.fresh:
+                v = alpha_subs.get(v, v)
+            elif isinstance(v, frozenset):
+                swapped = v & frozenset(alpha_subs.keys())
+                v |= frozenset(alpha_subs[k] for k in swapped)
+                v -= swapped
+            elif isinstance(v, tuple) and isinstance(v[0], tuple) and len(v[0]) == 2 and \
+                    isinstance(v[0][0], str) and isinstance(v[0][1], Funsor):
+                v = tuple((alpha_subs[k] if k in alpha_subs else k, vv) for k, vv in v)
+            ast_values.append(v)
+
+        return tuple(ast_values)
 
     def __call__(self, *args, **kwargs):
         """


### PR DESCRIPTION
Addresses #228 
Blocking #226

This PR has two aims.

1. Refactor alpha conversion logic to allow a fix to `Independent` in #226 .
Before this PR, `alpha_substitute()` was a single function with ad hoc logic to hopefully cover most cases. This PR refactors to a method `._alpha_subs()`, splitting the old if-else handling into method overloads, and adds new method overloads for a few Funsors.

2. Ensure `to_funsor()` is called outside of `substitute()`.
Before this PR, alpha_convert would sometimes call `substitute()` with non-funsor values, necessitating `to_funsor()` conversions in various `eager_subs()` methods. This PR removes those old `to_funsor()` calls and adds new `to_funsor()` calls in the `._alpha_subs()` methods of each `Funsor` subclass with bound variables. This appears to be the narrowest place where relevant type information is available, since types of bound variables are not available in the `.inputs` dict.

## Tested
- refactoring is exercised by existing tests
- added an assertion to `substitute()` checking that all inputs are funsors.