### PR TITLE
Implement substitution into Slice funsors

### DIFF
--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -233,6 +233,9 @@ class AffineNormal(Funsor):
     :param ~funsor.terms.Funsor value_y: A value ``Y``.
     """
     def __init__(self, matrix, loc, scale, value_x, value_y):
+        assert len(matrix.output.shape) == 2
+        assert value_x.output == reals(matrix.output.shape[0])
+        assert value_y.output == reals(matrix.output.shape[1])
         inputs = OrderedDict()
         for f in (matrix, loc, scale, value_x, value_y):
             inputs.update(f.inputs)
@@ -247,6 +250,9 @@ class AffineNormal(Funsor):
 
 @eager.register(AffineNormal, Tensor, Tensor, Tensor, Tensor, (Funsor, Tensor))
 def eager_affine_normal(matrix, loc, scale, value_x, value_y):
+    assert len(matrix.output.shape) == 2
+    assert value_x.output == reals(matrix.output.shape[0])
+    assert value_y.output == reals(matrix.output.shape[1])
     tensors = (matrix, loc, scale, value_x)
     int_inputs, tensors = align_tensors(*tensors)
     matrix, loc, scale, value_x = tensors
@@ -265,6 +271,9 @@ def eager_affine_normal(matrix, loc, scale, value_x, value_y):
 
 @eager.register(AffineNormal, Tensor, Tensor, Tensor, Funsor, Tensor)
 def eager_affine_normal(matrix, loc, scale, value_x, value_y):
+    assert len(matrix.output.shape) == 2
+    assert value_x.output == reals(matrix.output.shape[0])
+    assert value_y.output == reals(matrix.output.shape[1])
     tensors = (matrix, loc, scale, value_y)
     int_inputs, tensors = align_tensors(*tensors)
     matrix, loc, scale, value_y = tensors

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -66,6 +66,7 @@ def test_cons_hash():
     assert Slice('x', 10) is Slice('x', 10)
     assert Slice('x', 10) is Slice('x', 0, 10)
     assert Slice('x', 10, 10) is not Slice('x', 0, 10)
+    assert Slice('x', 2, 10, 1) is Slice('x', 2, 10)
 
 
 @pytest.mark.parametrize('expr', [
@@ -262,6 +263,20 @@ def test_reduce_syntactic_sugar():
     assert x.reduce(ops.add, "i") is expected
     assert x.reduce(ops.add, {"i"}) is expected
     assert x.reduce(ops.add, frozenset(["i"])) is expected
+
+
+def test_slice():
+    t_slice = Slice("t", 10)
+
+    s_slice = t_slice(t="s")
+    assert isinstance(s_slice, Slice)
+    assert s_slice.slice == t_slice.slice
+    assert s_slice(s="t") is t_slice
+
+    assert t_slice(t=0) is Number(0, 10)
+    assert t_slice(t=1) is Number(1, 10)
+    assert t_slice(t=2) is Number(2, 10)
+    assert t_slice(t=t_slice) is t_slice
 
 
 @pytest.mark.parametrize('base_shape', [(), (4,), (3, 2)], ids=str)


### PR DESCRIPTION
Addresses #228 

This implements substitution into `Slice` funsors and fixes a bug in `.fresh`.

This also adds some assertions in funsor.pyro.convert that helped catch the missing patterns.

## Tested
- added unit tests
- refactoring is exercised by `test_sum_product.py` and `test_torch.py`
- tested in BART forecasting example #228