### PR TITLE
Fix alpha conversion bugs in Subs, Cat, Slice

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -279,9 +279,6 @@ def eager_cat_homogeneous(name, part_name, *parts):
     discretes = []
     info_vecs = []
     precisions = []
-    if part_name != name:
-        del inputs[name]
-        del int_inputs[name]
     for part in parts:
         inputs[part_name] = part.inputs[part_name]
         int_inputs[part_name] = inputs[part_name]

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -805,7 +805,7 @@ class Subs(Funsor):
         for key, value in subs:
             inputs.update(value.inputs)
         fresh = frozenset()
-        bound = frozenset(key for key, value in subs if key not in inputs)
+        bound = frozenset(key for key, value in subs)
         super(Subs, self).__init__(inputs, arg.output, fresh, bound)
         self.arg = arg
         self.subs = OrderedDict(subs)
@@ -814,9 +814,11 @@ class Subs(Funsor):
         return 'Subs({}, {})'.format(self.arg, self.subs)
 
     def _alpha_convert(self, alpha_subs):
+        assert self.bound.issuperset(alpha_subs)
         alpha_subs = {k: to_funsor(v, self.subs[k].output)
                       for k, v in alpha_subs.items()}
-        arg, subs = super()._alpha_convert(alpha_subs)
+        arg, subs = self._ast_values
+        arg = substitute(arg, alpha_subs)
         subs = tuple((str(alpha_subs.get(k, k)), v) for k, v in subs)
         return arg, subs
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1317,10 +1317,11 @@ class Cat(Funsor, metaclass=CatMeta):
         self.part_name = part_name
 
     def _alpha_convert(self, alpha_subs):
-        assert len(alpha_subs) == 1 and self.name in alpha_subs
+        assert len(alpha_subs) == 1
         part_name = alpha_subs[self.part_name]
         parts = tuple(
-            substitute(p, {self.part_name: to_funsor(part_name, p.inputs[self.name])})
+            substitute(p, {self.part_name:
+                           to_funsor(part_name, p.inputs[self.part_name])})
             for p in self.parts)
         return self.name, parts, part_name
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -528,23 +528,27 @@ def eager_stack_homogeneous(name, *parts):
     return Tensor(data, inputs, dtype=output.dtype)
 
 
-@dispatch(str, Variadic[Tensor])
-def eager_cat_homogeneous(name, *parts):
+@dispatch(str, str, Variadic[Tensor])
+def eager_cat_homogeneous(name, part_name, *parts):
     assert parts
     output = parts[0].output
-    inputs = OrderedDict()
+    inputs = OrderedDict([(part_name, None)])
     for part in parts:
         assert part.output == output
-        assert name in part.inputs
+        assert part_name in part.inputs
         inputs.update(part.inputs)
 
     tensors = []
+    if part_name != name:
+        del inputs[name]
     for part in parts:
-        inputs[name] = part.inputs[name]  # typically a smaller bint
+        inputs[part_name] = part.inputs[part_name]
         shape = tuple(d.size for d in inputs.values()) + output.shape
         tensors.append(align_tensor(inputs, part).expand(shape))
+    if part_name != name:
+        del inputs[part_name]
 
-    dim = tuple(inputs).index(name)
+    dim = 0
     tensor = torch.cat(tensors, dim=dim)
     inputs[name] = bint(tensor.size(dim))
     return Tensor(tensor, inputs, dtype=output.dtype)

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -539,8 +539,6 @@ def eager_cat_homogeneous(name, part_name, *parts):
         inputs.update(part.inputs)
 
     tensors = []
-    if part_name != name:
-        del inputs[name]
     for part in parts:
         inputs[part_name] = part.inputs[part_name]
         shape = tuple(d.size for d in inputs.values()) + output.shape

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -55,11 +55,12 @@ def test_lazy_subs_type_clash():
         Slice('t', 3)(t=Slice('t', 2, dtype=3)).reduce(ops.add)
 
 
-def test_cat():
+@pytest.mark.parametrize("name", ["s", "t"])
+def test_cat(name):
     with interpretation(reflect):
         x = Stack("t", (Number(1), Number(2)))
         y = Stack("t", (Number(4), Number(8), Number(16)))
-        xy = Cat("t", (x, y))
+        xy = Cat(name, (x, y), "t")
         xy.reduce(ops.add)
 
 

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -5,7 +5,7 @@ import pytest
 import funsor.ops as ops
 from funsor.domains import bint, reals
 from funsor.interpreter import gensym, interpretation
-from funsor.terms import Independent, Lambda, Slice, Variable, reflect
+from funsor.terms import Cat, Independent, Lambda, Number, Slice, Stack, Variable, reflect
 from funsor.testing import assert_close, check_funsor, random_tensor
 
 
@@ -53,6 +53,14 @@ def test_distribute_reduce(lhs_vars, rhs_vars):
 def test_lazy_subs_type_clash():
     with interpretation(reflect):
         Slice('t', 3)(t=Slice('t', 2, dtype=3)).reduce(ops.add)
+
+
+def test_cat():
+    with interpretation(reflect):
+        x = Stack("t", (Number(1), Number(2)))
+        y = Stack("t", (Number(4), Number(8), Number(16)))
+        xy = Cat("t", (x, y))
+        xy.reduce(ops.add)
 
 
 def test_subs_lambda():

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -5,7 +5,7 @@ import pytest
 import funsor.ops as ops
 from funsor.domains import bint, reals
 from funsor.interpreter import gensym, interpretation
-from funsor.terms import Independent, Lambda, Variable, reflect
+from funsor.terms import Independent, Lambda, Slice, Variable, reflect
 from funsor.testing import assert_close, check_funsor, random_tensor
 
 
@@ -48,6 +48,11 @@ def test_distribute_reduce(lhs_vars, rhs_vars):
         ops.add, frozenset(lhs_subs.values()) | frozenset(rhs_subs.values()))
 
     assert_close(actual, expected)
+
+
+def test_lazy_subs_type_clash():
+    with interpretation(reflect):
+        Slice('t', 3)(t=Slice('t', 2, dtype=3)).reduce(ops.add)
 
 
 def test_subs_lambda():


### PR DESCRIPTION
Addresses #228 

This fixes bugs in alpha conversion logic of `Subs`, `Cat`, and `Slice`. Additionally this moves type checking logic from `substitute` down to `SubsMeta` so that type mismatch errors are caught earlier.

The `Subs` bugs involve an incorrect definition of `.bound` and incorrect handling of substitution in `._alpha_convert()`. For example this case previously failed:
```py
with interpretation(reflect):
    Slice('t', 3)(t=Slice('t', 2, dtype=3)).reduce(ops.add)
```

The main `Cat` bug is deeper and involves type mismatch between the axis variable of the component parts (this variable is bound) and the resulting axis variable of the concatenation. Before this PR `Cat` did not bind any variables. After this PR `Cat` has two real variables that can share the same name: a longer `fresh` concatenated variable and a shorter `bound` part variable; only the bound variable is renamed during `._alpha_convert()`; and only the fresh variable is substituted during `.eager_subs()`.

The `Slice.eager_subs` bug from #230 involved not preserving `.dtype` information.

## Tested

- [x] refactoring is exercised by existing tests
- [x] made substitution type checking stricter
- [x] added a regression test for `Subs` and `Slice`
- [x] added a regression test for `Cat`
- [x] ran BART example #228