### PR TITLE
Include reinterpret() in debug logging

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -24,6 +24,43 @@ _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 _GENSYM_COUNTER = 0
 
 
+def _indent():
+    result = u'    \u2502' * (_STACK_SIZE // 4 + 3)
+    return result[:_STACK_SIZE]
+
+
+if _DEBUG:
+    class DebugLogged(object):
+        def __init__(self, fn):
+            self.fn = fn
+            while isinstance(fn, functools.partial):
+                fn = fn.func
+            path = inspect.getabsfile(fn)
+            lineno = inspect.getsourcelines(fn)[1]
+            self._message = "{} file://{} {}".format(fn.__name__, path, lineno)
+
+        def __call__(self, *args, **kwargs):
+            global _STACK_SIZE
+            print(_indent() + self._message)
+            _STACK_SIZE += 1
+            try:
+                return self.fn(*args, **kwargs)
+            finally:
+                _STACK_SIZE -= 1
+
+        @property
+        def register(self):
+            return self.fn.register
+
+    def debug_logged(fn):
+        if isinstance(fn, DebugLogged):
+            return fn
+        return DebugLogged(fn)
+else:
+    def debug_logged(fn):
+        return fn
+
+
 def _classname(cls):
     return getattr(cls, "classname", cls.__name__)
 
@@ -31,7 +68,7 @@ def _classname(cls):
 if _DEBUG:
     def interpret(cls, *args):
         global _STACK_SIZE
-        indent = '  ' * _STACK_SIZE
+        indent = _indent()
         if _DEBUG > 1:
             typenames = [_classname(cls)] + [_classname(type(arg)) for arg in args]
         else:
@@ -93,6 +130,7 @@ def recursion_reinterpret(x):
 
 # We need to register this later in terms.py after declaring Funsor.
 # reinterpret.register(Funsor)
+@debug_logged
 def reinterpret_funsor(x):
     return _INTERPRETATION(type(x), *map(recursion_reinterpret, x._ast_values))
 
@@ -114,21 +152,25 @@ def recursion_reinterpret_ground(x):
 
 
 @recursion_reinterpret.register(tuple)
+@debug_logged
 def recursion_reinterpret_tuple(x):
     return tuple(map(recursion_reinterpret, x))
 
 
 @recursion_reinterpret.register(frozenset)
+@debug_logged
 def recursion_reinterpret_frozenset(x):
     return frozenset(map(recursion_reinterpret, x))
 
 
 @recursion_reinterpret.register(dict)
+@debug_logged
 def recursion_reinterpret_dict(x):
     return {key: recursion_reinterpret(value) for key, value in x.items()}
 
 
 @recursion_reinterpret.register(OrderedDict)
+@debug_logged
 def recursion_reinterpret_ordereddict(x):
     return OrderedDict((key, recursion_reinterpret(value)) for key, value in x.items())
 
@@ -276,29 +318,6 @@ def reinterpret(x):
         return stack_reinterpret(x)
     else:
         return recursion_reinterpret(x)
-
-
-if _DEBUG:
-    class DebugLogged(object):
-        def __init__(self, fn):
-            self.fn = fn
-            while isinstance(fn, functools.partial):
-                fn = fn.func
-            path = inspect.getabsfile(fn)
-            lineno = inspect.getsourcelines(fn)[1]
-            self._message = "{} file://{} {}".format(fn.__name__, path, lineno)
-
-        def __call__(self, *args, **kwargs):
-            print('  ' * _STACK_SIZE + self._message)
-            return self.fn(*args, **kwargs)
-
-    def debug_logged(fn):
-        if isinstance(fn, DebugLogged):
-            return fn
-        return DebugLogged(fn)
-else:
-    def debug_logged(fn):
-        return fn
 
 
 def dispatched_interpretation(fn):


### PR DESCRIPTION
This includes `recursion_reinterpret_*()` in the debug log. This log had been obfuscated by increased use of reinterpretation in `Subs()` evaluation leading to pages of unstructured no-op rules. After this PR, reinterpretation recursion is printed and causes indentation so that it is clear what rules are being evaluated. Because this increases indentation depth, I've tweaked indentation to be one-character-per-level and added guide lines every 4 characters.

**Before this PR:**

<details>

```
Independent Normal str str str
  eager_independent_trivial file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 1471
  Variable str Domain
  -> Variable
  Variable str Domain
  -> Variable
  Tensor Tensor tuple str
  -> Tensor
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 177
  Tensor Tensor tuple str
  -> Tensor
  Tensor Tensor tuple str
  -> Tensor
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 177
  Tensor Tensor tuple str
  -> Tensor
  Variable str Domain
  -> Variable
  eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 779
  Normal Tensor Tensor Variable
    eager_normal file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/distributions.py 392
    Binary SubOp Tensor Variable
      eager_binary file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 173
      Unary NegOp Variable
        eager_negate_variable file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 185
        Number float str
        -> Number
        Number int str
        -> Number
        Affine Number tuple
          eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
        -> Affine
      -> Affine
      Binary AddOp Affine Tensor
        eager_binary_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 54
        Binary AddOp Number Tensor
          eager_binary_number_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 387
          Tensor Tensor tuple str
          -> Tensor
        -> Tensor
        Affine Tensor tuple
          eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
        -> Affine
      -> Affine
    -> Affine
    Binary Op Affine Tensor
      eager_binary_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 54
      Binary Op Tensor Tensor
        eager_binary_tensor_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 393
        Tensor Tensor tuple str
        -> Tensor
      -> Tensor
      Binary Op Number Tensor
        eager_binary_number_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 387
        Tensor Tensor tuple str
        -> Tensor
      -> Tensor
      Affine Tensor tuple
        eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
      -> Affine
    -> Affine
    Tensor Tensor tuple str
    -> Tensor
    Gaussian Tensor Tensor tuple
    -> Gaussian
    Binary AddOp Tensor Gaussian
      eager_add file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/joint.py 413
      Joint tuple Tensor Gaussian
        eager_joint file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/joint.py 214
        Number int str
        -> Number
        Number int str
        -> Number
        Number int str
        -> Number
      -> Joint
    -> Joint
  -> Joint
-> Independent
```
</details>

**After this PR:**

<details>

```
Independent Normal str str str
 eager_independent_trivial file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 1471
 Variable str Domain
 -> Variable
 Variable str Domain
 -> Variable
 reinterpret_funsor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 133
  reinterpret_funsor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 133
   recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
    recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
    recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
   Tensor Tensor tuple str
   -> Tensor
   eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 177
    Tensor Tensor tuple str
    -> Tensor
  reinterpret_funsor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 133
   recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
    recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
    recursion_reinterpret_tuple file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 154
   Tensor Tensor tuple str
   -> Tensor
   eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 177
    Tensor Tensor tuple str
    -> Tensor
  reinterpret_funsor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py 133
   Variable str Domain
   -> Variable
   eager_subs file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py 779
  Normal Tensor Tensor Variable
   eager_normal file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/distributions.py 392
    Binary SubOp Tensor Variable
    │eager_binary file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 173
    │ Unary NegOp Variable
    │  eager_negate_variable file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 185
    │   Number float str
    │   -> Number
    │   Number int str
    │   -> Number
    │   Affine Number tuple
    │    eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
    │   -> Affine
    │ -> Affine
    │ Binary AddOp Affine Tensor
    │  eager_binary_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 54
    │   Binary AddOp Number Tensor
    │    eager_binary_number_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 387
    │    │Tensor Tensor tuple str
    │    │-> Tensor
    │   -> Tensor
    │   Affine Tensor tuple
    │    eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
    │   -> Affine
    │ -> Affine
    -> Affine
    Binary Op Affine Tensor
    │eager_binary_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 54
    │ Binary Op Tensor Tensor
    │  eager_binary_tensor_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 393
    │   Tensor Tensor tuple str
    │   -> Tensor
    │ -> Tensor
    │ Binary Op Number Tensor
    │  eager_binary_number_tensor file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/torch.py 387
    │   Tensor Tensor tuple str
    │   -> Tensor
    │ -> Tensor
    │ Affine Tensor tuple
    │  eager_affine file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/affine.py 41
    │ -> Affine
    -> Affine
    Tensor Tensor tuple str
    -> Tensor
    Gaussian Tensor Tensor tuple
    -> Gaussian
    Binary AddOp Tensor Gaussian
    │eager_add file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/joint.py 413
    │ Joint tuple Tensor Gaussian
    │  eager_joint file:///Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/joint.py 214
    │   Number int str
    │   -> Number
    │   Number int str
    │   -> Number
    │  Number int str
    │  -> Number
    │ -> Joint
    -> Joint
  -> Joint
-> Independent
```

</details>