### PR TITLE
Add an invertible quote() function : funsor -> str

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -3,6 +3,7 @@ from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange
+from funsor.util import pretty, to_python
 
 from . import (
     adjoint,
@@ -55,11 +56,13 @@ __all__ = [
     'montecarlo',
     'of_shape',
     'ops',
+    'pretty',
     'reals',
     'reinterpret',
     'sum_product',
     'terms',
     'to_data',
     'to_funsor',
+    'to_python',
     'torch',
 ]

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -57,12 +57,12 @@ __all__ = [
     'of_shape',
     'ops',
     'pretty',
+    'quote',
     'reals',
     'reinterpret',
     'sum_product',
     'terms',
     'to_data',
     'to_funsor',
-    'quote',
     'torch',
 ]

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -3,7 +3,7 @@ from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange
-from funsor.util import pretty, to_python
+from funsor.util import pretty, quote
 
 from . import (
     adjoint,
@@ -63,6 +63,6 @@ __all__ = [
     'terms',
     'to_data',
     'to_funsor',
-    'to_python',
+    'quote',
     'torch',
 ]

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -9,20 +9,9 @@ from funsor.delta import Delta
 from funsor.domains import find_domain
 from funsor.gaussian import Gaussian
 from funsor.interpreter import recursion_reinterpret
-from funsor.ops import AssociativeOp, DISTRIBUTIVE_OPS
-from funsor.terms import Align, Binary, Funsor, Number, Reduce, Subs, Unary, Variable, \
-    eager, normalize, to_funsor
+from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
+from funsor.terms import Align, Binary, Funsor, Number, Reduce, Subs, Unary, Variable, eager, normalize, to_funsor
 from funsor.torch import Tensor
-
-
-class NullOp(AssociativeOp):
-    """Placeholder associative op that unifies with any other op"""
-    pass
-
-
-@NullOp
-def nullop(x, y):
-    raise ValueError("should never actually evaluate this!")
 
 
 class Contraction(Funsor):

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -6,7 +6,7 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
-from funsor.util import lazy_property, to_python
+from funsor.util import lazy_property, quote
 
 
 class Domain(namedtuple('Domain', ['shape', 'dtype'])):
@@ -53,7 +53,7 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
         return self.dtype
 
 
-@to_python.register(Domain)
+@quote.register(Domain)
 def _(arg, indent, out):
     out.append((indent, repr(arg)))
 

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -6,7 +6,7 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
-from funsor.util import lazy_property
+from funsor.util import lazy_property, to_python
 
 
 class Domain(namedtuple('Domain', ['shape', 'dtype'])):
@@ -51,6 +51,11 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     def size(self):
         assert isinstance(self.dtype, int)
         return self.dtype
+
+
+@to_python.register(Domain)
+def _(arg, indent, out):
+    out.append((indent, repr(arg)))
 
 
 def reals(*shape):

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -10,20 +10,7 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import (
-    Align,
-    Binary,
-    Funsor,
-    FunsorMeta,
-    Number,
-    Slice,
-    Subs,
-    Unary,
-    Variable,
-    eager,
-    reflect,
-    to_funsor
-)
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Slice, Subs, Unary, Variable, eager, reflect
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 
@@ -343,7 +330,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
     def eager_subs(self, subs):
         assert isinstance(subs, tuple)
-        subs = tuple((k, materialize(to_funsor(v, self.inputs[k])))
+        subs = tuple((k, v if isinstance(v, (Variable, Slice)) else materialize(v))
                      for k, v in subs if k in self.inputs)
         if not subs:
             return self

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -6,24 +6,11 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
-from funsor.delta import Delta, Delta
+from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import (
-    Align,
-    Binary,
-    Funsor,
-    FunsorMeta,
-    Number,
-    Slice,
-    Subs,
-    Unary,
-    Variable,
-    eager,
-    reflect,
-    to_funsor
-)
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Slice, Subs, Unary, Variable, eager, reflect
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -10,7 +10,20 @@ from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Slice, Subs, Unary, Variable, eager, reflect
+from funsor.terms import (
+    Align,
+    Binary,
+    Funsor,
+    FunsorMeta,
+    Number,
+    Slice,
+    Subs,
+    Unary,
+    Variable,
+    eager,
+    reflect,
+    to_funsor
+)
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -19,7 +19,7 @@ class Op(Dispatcher):
             self.add(default_signature, fn)
 
     def __repr__(self):
-        return self.__name__
+        return "ops." + self.__name__
 
     def __str__(self):
         return self.__name__
@@ -79,6 +79,16 @@ class NegOp(Op):
 
 class DivOp(Op):
     pass
+
+
+class NullOp(AssociativeOp):
+    """Placeholder associative op that unifies with any other op"""
+    pass
+
+
+@NullOp
+def nullop(x, y):
+    raise ValueError("should never actually evaluate this!")
 
 
 class GetitemMeta(type):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -15,7 +15,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec, lazy_property, pretty, to_python
+from funsor.util import getargspec, lazy_property, pretty, quote
 
 
 def substitute(expr, subs):
@@ -334,8 +334,8 @@ class Funsor(object, metaclass=FunsorMeta):
     def __str__(self):
         return '{}({})'.format(type(self).__name__, ', '.join(map(str, self._ast_values)))
 
-    def to_python(self):
-        return to_python(self)
+    def quote(self):
+        return quote(self)
 
     def pretty(self, maxlen=40):
         return pretty(self, maxlen=maxlen)
@@ -695,18 +695,18 @@ class Funsor(object, metaclass=FunsorMeta):
         return result
 
 
-@to_python.register(Funsor)
+@quote.register(Funsor)
 def _(arg, indent, out):
     name = type(arg).__name__
     if type(arg).__module__ == 'funsor.distributions':
         name = 'dist.' + name
     out.append((indent, name + "("))
     for value in arg._ast_values[:-1]:
-        to_python.inplace(value, indent + 1, out)
+        quote.inplace(value, indent + 1, out)
         i, line = out[-1]
         out[-1] = i, line + ","
     for value in arg._ast_values[-1:]:
-        to_python.inplace(value, indent + 1, out)
+        quote.inplace(value, indent + 1, out)
         i, line = out[-1]
         out[-1] = i, line + ")"
 
@@ -1462,24 +1462,24 @@ def of_shape(*shape):
 ################################################################################
 
 
-@to_python.register(Variable)
-@to_python.register(Number)
-@to_python.register(Slice)
+@quote.register(Variable)
+@quote.register(Number)
+@quote.register(Slice)
 def _(arg, indent, out):
     out.append((indent, repr(arg)))
 
 
-@to_python.register(Unary)
-@to_python.register(Binary)
-@to_python.register(Reduce)
+@quote.register(Unary)
+@quote.register(Binary)
+@quote.register(Reduce)
 def _(arg, indent, out):
     out.append((indent, f"{type(arg).__name__}({repr(arg.op)},"))
     for value in arg._ast_values[1:-1]:
-        to_python.inplace(value, indent + 1, out)
+        quote.inplace(value, indent + 1, out)
         i, line = out[-1]
         out[-1] = i, line + ","
     for value in arg._ast_values[-1:]:
-        to_python.inplace(value, indent + 1, out)
+        quote.inplace(value, indent + 1, out)
         i, line = out[-1]
         out[-1] = i, line + ")"
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -2,7 +2,6 @@ import functools
 import itertools
 import math
 import numbers
-import re
 import typing
 from collections import Hashable, OrderedDict
 from functools import reduce, singledispatch
@@ -16,7 +15,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.interpreter import dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec, lazy_property
+from funsor.util import getargspec, lazy_property, pretty, to_python
 
 
 def substitute(expr, subs):
@@ -335,10 +334,11 @@ class Funsor(object, metaclass=FunsorMeta):
     def __str__(self):
         return '{}({})'.format(type(self).__name__, ', '.join(map(str, self._ast_values)))
 
+    def to_python(self):
+        return to_python(self)
+
     def pretty(self, maxlen=40):
-        lines = []
-        _pretty(self, lines, maxlen)
-        return '\n'.join(u'\u2502 ' * indent + text for indent, text in lines)
+        return pretty(self, maxlen=maxlen)
 
     def __contains__(self, item):
         raise TypeError
@@ -695,32 +695,20 @@ class Funsor(object, metaclass=FunsorMeta):
         return result
 
 
-@singledispatch
-def _pretty(arg, lines, maxlen, indent=0):
-    line = re.sub('\n\\s*', ' ', str(arg))
-    if len(line) > maxlen:
-        line = line[:maxlen] + "..."
-    lines.append((indent, line))
-
-
-@_pretty.register(Funsor)
-def _(arg, lines, maxlen, indent=0):
-    lines.append((indent, type(arg).__name__))
-    for arg in arg._ast_values:
-        _pretty(arg, lines, maxlen, indent + 1)
-
-
-@_pretty.register(tuple)
-def _(arg, lines, maxlen, indent=0):
-    lines.append((indent, type(arg).__name__))
-    for item in arg:
-        _pretty(item, lines, maxlen, indent + 1)
-
-
-@_pretty.register(str)
-@_pretty.register(Domain)
-def _(arg, lines, maxlen, indent=0):
-    lines.append((indent, repr(arg)))
+@to_python.register(Funsor)
+def _(arg, indent, out):
+    name = type(arg).__name__
+    if type(arg).__module__ == 'funsor.distributions':
+        name = 'dist.' + name
+    out.append((indent, name + "("))
+    for value in arg._ast_values[:-1]:
+        to_python.inplace(value, indent + 1, out)
+        i, line = out[-1]
+        out[-1] = i, line + ","
+    for value in arg._ast_values[-1:]:
+        to_python.inplace(value, indent + 1, out)
+        i, line = out[-1]
+        out[-1] = i, line + ")"
 
 
 interpreter.recursion_reinterpret.register(Funsor)(interpreter.reinterpret_funsor)
@@ -1122,6 +1110,9 @@ class Slice(Funsor, metaclass=SliceMeta):
         self.name = name
         self.slice = slice(start, stop, step)
 
+    def __repr__(self):
+        return "Slice({})".format(", ".join(map(repr, self._ast_values)))
+
     def eager_subs(self, subs):
         assert len(subs) == 1 and subs[0][0] == self.name
         index = subs[0][1]
@@ -1469,6 +1460,29 @@ def of_shape(*shape):
 ################################################################################
 # Register Ops
 ################################################################################
+
+
+@to_python.register(Variable)
+@to_python.register(Number)
+@to_python.register(Slice)
+def _(arg, indent, out):
+    out.append((indent, repr(arg)))
+
+
+@to_python.register(Unary)
+@to_python.register(Binary)
+@to_python.register(Reduce)
+def _(arg, indent, out):
+    out.append((indent, f"{type(arg).__name__}({repr(arg.op)},"))
+    for value in arg._ast_values[1:-1]:
+        to_python.inplace(value, indent + 1, out)
+        i, line = out[-1]
+        out[-1] = i, line + ","
+    for value in arg._ast_values[-1:]:
+        to_python.inplace(value, indent + 1, out)
+        i, line = out[-1]
+        out[-1] = i, line + ")"
+
 
 @ops.abs.register(Funsor)
 def _abs(x):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1465,15 +1465,19 @@ def of_shape(*shape):
 @quote.register(Variable)
 @quote.register(Number)
 @quote.register(Slice)
-def _(arg, indent, out):
+def quote_inplace_oneline(arg, indent, out):
     out.append((indent, repr(arg)))
 
 
 @quote.register(Unary)
 @quote.register(Binary)
 @quote.register(Reduce)
-def _(arg, indent, out):
-    out.append((indent, f"{type(arg).__name__}({repr(arg.op)},"))
+@quote.register(Stack)
+@quote.register(Cat)
+@quote.register(Lambda)
+def quote_inplace_first_arg_on_first_line(arg, indent, out):
+    line = f"{type(arg).__name__}({repr(arg._ast_values[0])},"
+    out.append((indent, line))
     for value in arg._ast_values[1:-1]:
         quote.inplace(value, indent + 1, out)
         i, line = out[-1]

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -587,6 +587,7 @@ class Function(Funsor):
     """
     def __init__(self, fn, output, args):
         assert callable(fn)
+        assert not isinstance(fn, Function)
         assert isinstance(args, tuple)
         inputs = OrderedDict()
         for arg in args:

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -25,7 +25,7 @@ from funsor.terms import (
     to_data,
     to_funsor
 )
-from funsor.util import getargspec, to_python
+from funsor.util import getargspec, quote
 
 
 @contextmanager
@@ -35,7 +35,7 @@ def ignore_jit_warnings():
         yield
 
 
-@to_python.register(torch.Tensor)
+@quote.register(torch.Tensor)
 def _(x, indent, out):
     """
     Work around PyTorch not supporting reproducible repr.
@@ -607,13 +607,13 @@ class Function(Funsor):
                                        str(self.output), str(self.args))
 
 
-@to_python.register(Function)
+@quote.register(Function)
 def _(arg, indent, out):
     out.append((indent, f"Function({arg.fn.__name__},"))
-    to_python.inplace(arg.output, indent + 1, out)
+    quote.inplace(arg.output, indent + 1, out)
     i, line = out[-1]
     out[-1] = i, line + ","
-    to_python.inplace(arg.args, indent + 1, out)
+    quote.inplace(arg.args, indent + 1, out)
     i, line = out[-1]
     out[-1] = i, line + ")"
 

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -48,7 +48,7 @@ def quote(arg):
     This is useful to save intermediate funsors to add to tests.
     """
     out = []
-    quote_inplace(arg, 0, out)
+    _quote_inplace(arg, 0, out)
     lines = []
     for indent, line in out:
         if indent + len(line) >= 80:
@@ -62,7 +62,7 @@ def pretty(arg, maxlen=40):
     Pretty print an expression. This is useful for debugging.
     """
     out = []
-    quote_inplace(arg, 0, out)
+    _quote_inplace(arg, 0, out)
     fill = u'   \u2502' * 100
     lines = []
     for indent, line in out:
@@ -73,13 +73,13 @@ def pretty(arg, maxlen=40):
 
 
 @functools.singledispatch
-def quote_inplace(arg, indent, out):
+def _quote_inplace(arg, indent, out):
     line = re.sub('\n\\s*', ' ', repr(arg))
     out.append((indent, line))
 
 
-quote.inplace = quote_inplace
-quote.register = quote_inplace.register
+quote.inplace = _quote_inplace
+quote.register = _quote_inplace.register
 
 
 @quote.register(tuple)

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -41,14 +41,14 @@ def getargspec(fn):
     return args, vargs, kwargs, defaults
 
 
-def to_python(arg):
+def quote(arg):
     """
     Serialize an object to text that can be parsed by Python.
 
     This is useful to save intermediate funsors to add to tests.
     """
     out = []
-    to_python_inplace(arg, 0, out)
+    quote_inplace(arg, 0, out)
     lines = []
     for indent, line in out:
         if indent + len(line) >= 80:
@@ -62,7 +62,7 @@ def pretty(arg, maxlen=40):
     Pretty print an expression. This is useful for debugging.
     """
     out = []
-    to_python_inplace(arg, 0, out)
+    quote_inplace(arg, 0, out)
     fill = u'   \u2502' * 100
     lines = []
     for indent, line in out:
@@ -73,30 +73,30 @@ def pretty(arg, maxlen=40):
 
 
 @functools.singledispatch
-def to_python_inplace(arg, indent, out):
+def quote_inplace(arg, indent, out):
     line = re.sub('\n\\s*', ' ', repr(arg))
     out.append((indent, line))
 
 
-to_python.inplace = to_python_inplace
-to_python.register = to_python_inplace.register
+quote.inplace = quote_inplace
+quote.register = quote_inplace.register
 
 
-@to_python.register(tuple)
+@quote.register(tuple)
 def _(arg, indent, out):
     if not arg:
         out.append((indent, "()"))
         return
     for value in arg[:1]:
         temp = []
-        to_python.inplace(value, indent + 1, temp)
+        quote.inplace(value, indent + 1, temp)
         i, line = temp[0]
         temp[0] = i - 1, "(" + line
         out.extend(temp)
         i, line = out[-1]
         out[-1] = i, line + ','
     for value in arg[1:]:
-        to_python.inplace(value, indent + 1, out)
+        quote.inplace(value, indent + 1, out)
         i, line = out[-1]
         out[-1] = i, line + ','
     i, line = out[-1]

--- a/test/examples/conftest.py
+++ b/test/examples/conftest.py
@@ -1,0 +1,6 @@
+import pyro
+
+
+def pytest_runtest_setup(item):
+    pyro.set_rng_seed(0)
+    pyro.enable_validation(True)

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -2,7 +2,6 @@ import math
 
 import torch
 
-import funsor
 import funsor.distributions as dist
 import funsor.ops as ops
 from funsor.cnf import Contraction

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -245,4 +245,5 @@ def test_bart():
         pq = p - q
 
     with interpretation(monte_carlo):
-        Integrate(q, pq, frozenset(['gate_rate_t']))
+        elbo = Integrate(q, pq, frozenset(['gate_rate_t']))
+        assert isinstance(elbo, Tensor)

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -1,6 +1,5 @@
 import math
 
-import pytest
 import torch
 
 import funsor
@@ -13,7 +12,7 @@ from funsor.integrate import Integrate
 from funsor.interpreter import interpretation
 from funsor.montecarlo import monte_carlo
 from funsor.pyro.convert import AffineNormal
-from funsor.terms import Binary, Independent, Number, Reduce, Slice, Stack, Subs, Variable, eager, reflect
+from funsor.terms import Binary, Independent, Number, Reduce, Slice, Stack, Subs, Variable, reflect
 from funsor.torch import Function, Tensor
 
 num_origins = 2
@@ -40,9 +39,7 @@ unpack_gate_rate_0 = unpack_gate_rate[0]
 unpack_gate_rate_1 = unpack_gate_rate[1]
 
 
-@pytest.mark.parametrize('interp', [eager, monte_carlo],
-                         ids=lambda i: i.__name__)
-def test_bart(interp):
+def test_bart():
     with interpretation(reflect):
         q = Independent(
          Independent(
@@ -247,5 +244,5 @@ def test_bart(interp):
         p = p_prior + p_likelihood
         pq = p - q
 
-    with interpretation(interp):
+    with interpretation(monte_carlo):
         Integrate(q, pq, frozenset(['gate_rate_t']))

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -1,0 +1,251 @@
+import math
+
+import pytest
+import torch
+
+import funsor
+import funsor.distributions as dist
+import funsor.ops as ops
+from funsor.cnf import Contraction
+from funsor.domains import bint, reals
+from funsor.gaussian import Gaussian
+from funsor.integrate import Integrate
+from funsor.interpreter import interpretation
+from funsor.montecarlo import monte_carlo
+from funsor.pyro.convert import AffineNormal
+from funsor.terms import Binary, Independent, Number, Reduce, Slice, Stack, Subs, Variable, eager, reflect
+from funsor.torch import Function, Tensor
+
+num_origins = 2
+num_destins = 2
+
+
+def bounded_exp(x, bound):
+    return (x - math.log(bound)).sigmoid() * bound
+
+
+@funsor.torch.function(reals(2 * num_origins * num_destins),
+                       (reals(num_origins, num_destins, 2),
+                        reals(num_origins, num_destins)))
+def unpack_gate_rate(gate_rate):
+    batch_shape = gate_rate.shape[:-1]
+    event_shape = (2, num_origins, num_destins)
+    gate, rate = gate_rate.reshape(batch_shape + event_shape).unbind(-3)
+    rate = bounded_exp(rate, bound=1e4)
+    gate = torch.stack((torch.zeros_like(gate), gate), dim=-1)
+    return gate, rate
+
+
+unpack_gate_rate_0 = unpack_gate_rate[0]
+unpack_gate_rate_1 = unpack_gate_rate[1]
+
+
+@pytest.mark.parametrize('interp', [eager, monte_carlo],
+                         ids=lambda i: i.__name__)
+def test_bart(interp):
+    with interpretation(reflect):
+        q = Independent(
+         Independent(
+          Contraction(
+           ops.nullop,
+           ops.add,
+           frozenset(),
+           (Tensor(
+             torch.tensor([[-0.6077086925506592, -1.1546266078948975, -0.7021151781082153, -0.5303535461425781, -0.6365622282028198, -1.2423288822174072, -0.9941254258155823, -0.6287292242050171], [-0.6987162828445435, -1.0875964164733887, -0.7337473630905151, -0.4713417589664459, -0.6674002408981323, -1.2478348016738892, -0.8939017057418823, -0.5238542556762695]], dtype=torch.float32),  # noqa
+             (('time__BOUND_3',
+               bint(2),),
+              ('_event_1__BOUND_2',
+               bint(8),),),
+             'real'),
+            Gaussian(
+             torch.tensor([[[-0.3536059558391571], [-0.21779225766658783], [0.2840439975261688], [0.4531521499156952], [-0.1220812276005745], [-0.05519985035061836], [0.10932210087776184], [0.6656699776649475]], [[-0.39107921719551086], [-0.20241987705230713], [0.2170514464378357], [0.4500560462474823], [0.27945515513420105], [-0.0490039587020874], [-0.06399798393249512], [0.846565842628479]]], dtype=torch.float32),  # noqa
+             torch.tensor([[[[1.984686255455017]], [[0.6699360013008118]], [[1.6215802431106567]], [[2.372016668319702]], [[1.77385413646698]], [[0.526767373085022]], [[0.8722561597824097]], [[2.1879124641418457]]], [[[1.6996612548828125]], [[0.7535632252693176]], [[1.4946647882461548]], [[2.642792224884033]], [[1.7301604747772217]], [[0.5203893780708313]], [[1.055436372756958]], [[2.8370864391326904]]]], dtype=torch.float32),  # noqa
+             (('time__BOUND_3',
+               bint(2),),
+              ('_event_1__BOUND_2',
+               bint(8),),
+              ('value__BOUND_1',
+               reals(),),)),)),
+          'gate_rate__BOUND_4',
+          '_event_1__BOUND_2',
+          'value__BOUND_1'),
+         'gate_rate_t',
+         'time__BOUND_3',
+         'gate_rate__BOUND_4')
+        p_prior = Reduce(ops.logaddexp,
+         Binary(ops.add,
+          Subs(
+           Reduce(ops.logaddexp,
+            Binary(ops.add,
+             Subs(
+              Binary(ops.add,
+               Binary(ops.add,
+                Tensor(
+                 torch.tensor(2.7672932147979736, dtype=torch.float32),
+                 (),
+                 'real'),
+                Subs(
+                 Subs(
+                  Gaussian(
+                   torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
+                   torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
+                   (('state__BOUND_13',
+                     reals(2,),),
+                    ('state(time=1)__BOUND_7',
+                     reals(2,),),)),
+                  ()),
+                 ())),
+               Subs(
+                AffineNormal(
+                 Tensor(
+                  torch.tensor([[0.03488487750291824, 0.07356668263673782, 0.19946961104869843, 0.5386509299278259, -0.708323061466217, 0.24411526322364807, -0.20855577290058136, -0.2421337217092514], [0.41762110590934753, 0.5272183418273926, -0.49835553765296936, -0.0363837406039238, -0.0005282597267068923, 0.2704298794269562, -0.155222088098526, -0.44802337884902954]], dtype=torch.float32),  # noqa
+                  (),
+                  'real'),
+                 Tensor(
+                  torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
+                  (('time__BOUND_8',
+                    bint(2),),),
+                  'real'),
+                 Tensor(
+                  torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
+                  (('time__BOUND_8',
+                    bint(2),),),
+                  'real'),
+                 Variable('state(time=1)__BOUND_7', reals(2,)),
+                 Variable('gate_rate__BOUND_6', reals(8,))),
+                (('gate_rate__BOUND_6',
+                  Binary(ops.GetitemOp(0),
+                   Variable('gate_rate_t', reals(2, 8)),
+                   Variable('time__BOUND_8', bint(2))),),))),
+              (('state(time=1)__BOUND_7',
+                Variable('_drop_0__BOUND_11', reals(2,)),),
+               ('time__BOUND_8',
+                Slice('time__BOUND_12', 0, 2, 2, 2),),)),
+             Subs(
+              Binary(ops.add,
+               Binary(ops.add,
+                Tensor(
+                 torch.tensor(2.7672932147979736, dtype=torch.float32),
+                 (),
+                 'real'),
+                Subs(
+                 Subs(
+                  Gaussian(
+                   torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
+                   torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
+                   (('state__BOUND_9',
+                     reals(2,),),
+                    ('state(time=1)__BOUND_14',
+                     reals(2,),),)),
+                  ()),
+                 ())),
+               Subs(
+                AffineNormal(
+                 Tensor(
+                  torch.tensor([[0.03488487750291824, 0.07356668263673782, 0.19946961104869843, 0.5386509299278259, -0.708323061466217, 0.24411526322364807, -0.20855577290058136, -0.2421337217092514], [0.41762110590934753, 0.5272183418273926, -0.49835553765296936, -0.0363837406039238, -0.0005282597267068923, 0.2704298794269562, -0.155222088098526, -0.44802337884902954]], dtype=torch.float32),  # noqa
+                  (),
+                  'real'),
+                 Tensor(
+                  torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
+                  (('time__BOUND_10',
+                    bint(2),),),
+                  'real'),
+                 Tensor(
+                  torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
+                  (('time__BOUND_10',
+                    bint(2),),),
+                  'real'),
+                 Variable('state(time=1)__BOUND_14', reals(2,)),
+                 Variable('gate_rate__BOUND_6', reals(8,))),
+                (('gate_rate__BOUND_6',
+                  Binary(ops.GetitemOp(0),
+                   Variable('gate_rate_t', reals(2, 8)),
+                   Variable('time__BOUND_10', bint(2))),),))),
+              (('state__BOUND_9',
+                Variable('_drop_0__BOUND_11', reals(2,)),),
+               ('time__BOUND_10',
+                Slice('time__BOUND_12', 1, 2, 2, 2),),))),
+            frozenset({'_drop_0__BOUND_11'})),
+           (('time__BOUND_12',
+             Number(0, 1),),)),
+          Subs(
+           dist.MultivariateNormal(
+            Tensor(
+             torch.tensor([0.0, 0.0], dtype=torch.float32),
+             (),
+             'real'),
+            Tensor(
+             torch.tensor([[10.0, 0.0], [0.0, 10.0]], dtype=torch.float32),
+             (),
+             'real'),
+            Variable('value__BOUND_5', reals(2,))),
+           (('value__BOUND_5',
+             Variable('state__BOUND_13', reals(2,)),),))),
+         frozenset({'state(time=1)__BOUND_14', 'state__BOUND_13'}))
+        p_likelihood = Reduce(ops.add,
+         Reduce(ops.logaddexp,
+          Binary(ops.add,
+           dist.Categorical(
+            Binary(ops.GetitemOp(0),
+             Binary(ops.GetitemOp(0),
+              Subs(
+               Function(unpack_gate_rate_0,
+                reals(2, 2, 2),
+                (Variable('gate_rate__BOUND_15', reals(8,)),)),
+               (('gate_rate__BOUND_15',
+                 Binary(ops.GetitemOp(0),
+                  Variable('gate_rate_t', reals(2, 8)),
+                  Variable('time__BOUND_18', bint(2))),),)),
+              Variable('origin__BOUND_20', bint(2))),
+             Variable('destin__BOUND_19', bint(2))),
+            Variable('gated__BOUND_17', bint(2))),
+           Stack(
+            'gated__BOUND_17',
+            (dist.Poisson(
+              Binary(ops.GetitemOp(0),
+               Binary(ops.GetitemOp(0),
+                Subs(
+                 Function(unpack_gate_rate_1,
+                  reals(2, 2),
+                  (Variable('gate_rate__BOUND_16', reals(8,)),)),
+                 (('gate_rate__BOUND_16',
+                   Binary(ops.GetitemOp(0),
+                    Variable('gate_rate_t', reals(2, 8)),
+                    Variable('time__BOUND_18', bint(2))),),)),
+                Variable('origin__BOUND_20', bint(2))),
+               Variable('destin__BOUND_19', bint(2))),
+              Tensor(
+               torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
+               (('time__BOUND_18',
+                 bint(2),),
+                ('origin__BOUND_20',
+                 bint(2),),
+                ('destin__BOUND_19',
+                 bint(2),),),
+               'real')),
+             dist.Delta(
+              Tensor(
+               torch.tensor(0.0, dtype=torch.float32),
+               (),
+               'real'),
+              Tensor(
+               torch.tensor(0.0, dtype=torch.float32),
+               (),
+               'real'),
+              Tensor(
+               torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
+               (('time__BOUND_18',
+                 bint(2),),
+                ('origin__BOUND_20',
+                 bint(2),),
+                ('destin__BOUND_19',
+                 bint(2),),),
+               'real')),))),
+          frozenset({'gated__BOUND_17'})),
+         frozenset({'time__BOUND_18', 'origin__BOUND_20', 'destin__BOUND_19'}))
+
+        p = p_prior + p_likelihood
+        pq = p - q
+
+    with interpretation(interp):
+        Integrate(q, pq, frozenset(['gate_rate_t']))

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -52,26 +52,26 @@ def test_bart(interp):
            frozenset(),
            (Tensor(
              torch.tensor([[-0.6077086925506592, -1.1546266078948975, -0.7021151781082153, -0.5303535461425781, -0.6365622282028198, -1.2423288822174072, -0.9941254258155823, -0.6287292242050171], [-0.6987162828445435, -1.0875964164733887, -0.7337473630905151, -0.4713417589664459, -0.6674002408981323, -1.2478348016738892, -0.8939017057418823, -0.5238542556762695]], dtype=torch.float32),  # noqa
-             (('time__BOUND_3',
+             (('time_b3',
                bint(2),),
-              ('_event_1__BOUND_2',
+              ('_event_1_b2',
                bint(8),),),
              'real'),
             Gaussian(
              torch.tensor([[[-0.3536059558391571], [-0.21779225766658783], [0.2840439975261688], [0.4531521499156952], [-0.1220812276005745], [-0.05519985035061836], [0.10932210087776184], [0.6656699776649475]], [[-0.39107921719551086], [-0.20241987705230713], [0.2170514464378357], [0.4500560462474823], [0.27945515513420105], [-0.0490039587020874], [-0.06399798393249512], [0.846565842628479]]], dtype=torch.float32),  # noqa
              torch.tensor([[[[1.984686255455017]], [[0.6699360013008118]], [[1.6215802431106567]], [[2.372016668319702]], [[1.77385413646698]], [[0.526767373085022]], [[0.8722561597824097]], [[2.1879124641418457]]], [[[1.6996612548828125]], [[0.7535632252693176]], [[1.4946647882461548]], [[2.642792224884033]], [[1.7301604747772217]], [[0.5203893780708313]], [[1.055436372756958]], [[2.8370864391326904]]]], dtype=torch.float32),  # noqa
-             (('time__BOUND_3',
+             (('time_b3',
                bint(2),),
-              ('_event_1__BOUND_2',
+              ('_event_1_b2',
                bint(8),),
-              ('value__BOUND_1',
+              ('value_b1',
                reals(),),)),)),
-          'gate_rate__BOUND_4',
-          '_event_1__BOUND_2',
-          'value__BOUND_1'),
+          'gate_rate_b4',
+          '_event_1_b2',
+          'value_b1'),
          'gate_rate_t',
-         'time__BOUND_3',
-         'gate_rate__BOUND_4')
+         'time_b3',
+         'gate_rate_b4')
         p_prior = Reduce(ops.logaddexp,
          Binary(ops.add,
           Subs(
@@ -89,9 +89,9 @@ def test_bart(interp):
                   Gaussian(
                    torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
                    torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
-                   (('state__BOUND_13',
+                   (('state_b13',
                      reals(2,),),
-                    ('state(time=1)__BOUND_7',
+                    ('state(time=1)_b7',
                      reals(2,),),)),
                   ()),
                  ())),
@@ -103,24 +103,24 @@ def test_bart(interp):
                   'real'),
                  Tensor(
                   torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
-                  (('time__BOUND_8',
+                  (('time_b8',
                     bint(2),),),
                   'real'),
                  Tensor(
                   torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
-                  (('time__BOUND_8',
+                  (('time_b8',
                     bint(2),),),
                   'real'),
-                 Variable('state(time=1)__BOUND_7', reals(2,)),
-                 Variable('gate_rate__BOUND_6', reals(8,))),
-                (('gate_rate__BOUND_6',
+                 Variable('state(time=1)_b7', reals(2,)),
+                 Variable('gate_rate_b6', reals(8,))),
+                (('gate_rate_b6',
                   Binary(ops.GetitemOp(0),
                    Variable('gate_rate_t', reals(2, 8)),
-                   Variable('time__BOUND_8', bint(2))),),))),
-              (('state(time=1)__BOUND_7',
-                Variable('_drop_0__BOUND_11', reals(2,)),),
-               ('time__BOUND_8',
-                Slice('time__BOUND_12', 0, 2, 2, 2),),)),
+                   Variable('time_b8', bint(2))),),))),
+              (('state(time=1)_b7',
+                Variable('_drop_0_b11', reals(2,)),),
+               ('time_b8',
+                Slice('time_b12', 0, 2, 2, 2),),)),
              Subs(
               Binary(ops.add,
                Binary(ops.add,
@@ -133,9 +133,9 @@ def test_bart(interp):
                   Gaussian(
                    torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
                    torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
-                   (('state__BOUND_9',
+                   (('state_b9',
                      reals(2,),),
-                    ('state(time=1)__BOUND_14',
+                    ('state(time=1)_b14',
                      reals(2,),),)),
                   ()),
                  ())),
@@ -147,26 +147,26 @@ def test_bart(interp):
                   'real'),
                  Tensor(
                   torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
-                  (('time__BOUND_10',
+                  (('time_b10',
                     bint(2),),),
                   'real'),
                  Tensor(
                   torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
-                  (('time__BOUND_10',
+                  (('time_b10',
                     bint(2),),),
                   'real'),
-                 Variable('state(time=1)__BOUND_14', reals(2,)),
-                 Variable('gate_rate__BOUND_6', reals(8,))),
-                (('gate_rate__BOUND_6',
+                 Variable('state(time=1)_b14', reals(2,)),
+                 Variable('gate_rate_b6', reals(8,))),
+                (('gate_rate_b6',
                   Binary(ops.GetitemOp(0),
                    Variable('gate_rate_t', reals(2, 8)),
-                   Variable('time__BOUND_10', bint(2))),),))),
-              (('state__BOUND_9',
-                Variable('_drop_0__BOUND_11', reals(2,)),),
-               ('time__BOUND_10',
-                Slice('time__BOUND_12', 1, 2, 2, 2),),))),
-            frozenset({'_drop_0__BOUND_11'})),
-           (('time__BOUND_12',
+                   Variable('time_b10', bint(2))),),))),
+              (('state_b9',
+                Variable('_drop_0_b11', reals(2,)),),
+               ('time_b10',
+                Slice('time_b12', 1, 2, 2, 2),),))),
+            frozenset({'_drop_0_b11'})),
+           (('time_b12',
              Number(0, 1),),)),
           Subs(
            dist.MultivariateNormal(
@@ -178,10 +178,10 @@ def test_bart(interp):
              torch.tensor([[10.0, 0.0], [0.0, 10.0]], dtype=torch.float32),
              (),
              'real'),
-            Variable('value__BOUND_5', reals(2,))),
-           (('value__BOUND_5',
-             Variable('state__BOUND_13', reals(2,)),),))),
-         frozenset({'state(time=1)__BOUND_14', 'state__BOUND_13'}))
+            Variable('value_b5', reals(2,))),
+           (('value_b5',
+             Variable('state_b13', reals(2,)),),))),
+         frozenset({'state(time=1)_b14', 'state_b13'}))
         p_likelihood = Reduce(ops.add,
          Reduce(ops.logaddexp,
           Binary(ops.add,
@@ -191,36 +191,36 @@ def test_bart(interp):
               Subs(
                Function(unpack_gate_rate_0,
                 reals(2, 2, 2),
-                (Variable('gate_rate__BOUND_15', reals(8,)),)),
-               (('gate_rate__BOUND_15',
+                (Variable('gate_rate_b15', reals(8,)),)),
+               (('gate_rate_b15',
                  Binary(ops.GetitemOp(0),
                   Variable('gate_rate_t', reals(2, 8)),
-                  Variable('time__BOUND_18', bint(2))),),)),
-              Variable('origin__BOUND_20', bint(2))),
-             Variable('destin__BOUND_19', bint(2))),
-            Variable('gated__BOUND_17', bint(2))),
+                  Variable('time_b18', bint(2))),),)),
+              Variable('origin_b20', bint(2))),
+             Variable('destin_b19', bint(2))),
+            Variable('gated_b17', bint(2))),
            Stack(
-            'gated__BOUND_17',
+            'gated_b17',
             (dist.Poisson(
               Binary(ops.GetitemOp(0),
                Binary(ops.GetitemOp(0),
                 Subs(
                  Function(unpack_gate_rate_1,
                   reals(2, 2),
-                  (Variable('gate_rate__BOUND_16', reals(8,)),)),
-                 (('gate_rate__BOUND_16',
+                  (Variable('gate_rate_b16', reals(8,)),)),
+                 (('gate_rate_b16',
                    Binary(ops.GetitemOp(0),
                     Variable('gate_rate_t', reals(2, 8)),
-                    Variable('time__BOUND_18', bint(2))),),)),
-                Variable('origin__BOUND_20', bint(2))),
-               Variable('destin__BOUND_19', bint(2))),
+                    Variable('time_b18', bint(2))),),)),
+                Variable('origin_b20', bint(2))),
+               Variable('destin_b19', bint(2))),
               Tensor(
                torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
-               (('time__BOUND_18',
+               (('time_b18',
                  bint(2),),
-                ('origin__BOUND_20',
+                ('origin_b20',
                  bint(2),),
-                ('destin__BOUND_19',
+                ('destin_b19',
                  bint(2),),),
                'real')),
              dist.Delta(
@@ -234,15 +234,15 @@ def test_bart(interp):
                'real'),
               Tensor(
                torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
-               (('time__BOUND_18',
+               (('time_b18',
                  bint(2),),
-                ('origin__BOUND_20',
+                ('origin_b20',
                  bint(2),),
-                ('destin__BOUND_19',
+                ('destin_b19',
                  bint(2),),),
                'real')),))),
-          frozenset({'gated__BOUND_17'})),
-         frozenset({'time__BOUND_18', 'origin__BOUND_20', 'destin__BOUND_19'}))
+          frozenset({'gated_b17'})),
+         frozenset({'time_b18', 'origin_b20', 'destin_b19'}))
 
         p = p_prior + p_likelihood
         pq = p - q

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -23,9 +23,6 @@ def bounded_exp(x, bound):
     return (x - math.log(bound)).sigmoid() * bound
 
 
-@funsor.torch.function(reals(2 * num_origins * num_destins),
-                       (reals(num_origins, num_destins, 2),
-                        reals(num_origins, num_destins)))
 def unpack_gate_rate(gate_rate):
     batch_shape = gate_rate.shape[:-1]
     event_shape = (2, num_origins, num_destins)
@@ -35,8 +32,12 @@ def unpack_gate_rate(gate_rate):
     return gate, rate
 
 
-unpack_gate_rate_0 = unpack_gate_rate[0]
-unpack_gate_rate_1 = unpack_gate_rate[1]
+def unpack_gate_rate_0(gate_rate):
+    return unpack_gate_rate(gate_rate)[0]
+
+
+def unpack_gate_rate_1(gate_rate):
+    return unpack_gate_rate(gate_rate)[1]
 
 
 def test_bart():

--- a/test/test_cnf.py
+++ b/test/test_cnf.py
@@ -1,12 +1,14 @@
 import pytest
+import torch  # noqa F403
 
 from funsor.cnf import Contraction
+from funsor.domains import bint  # noqa F403
 from funsor.einsum import einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.terms import Number, eager, normalize, reflect
 from funsor.testing import assert_close, check_funsor, make_einsum_example  # , xfail_param
 from funsor.torch import Tensor
-
+from funsor.util import quote
 
 EINSUM_EXAMPLES = [
     ("a,b->", ''),
@@ -54,3 +56,6 @@ def test_normalize_einsum(equation, plates, backend, einsum_impl):
         expected = reinterpret(expr)
 
     assert_close(actual, expected, rtol=1e-4)
+
+    actual = eval(quote(expected))  # requires torch, bint
+    assert_close(actual, expected)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -282,10 +282,19 @@ def test_eager_subs_variable():
 
     g2 = g1(x='z')
     assert set(g2.inputs) == {'i', 'y', 'z'}
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
 
     g2 = g1(x='y', y='x')
     assert set(g2.inputs) == {'i', 'x', 'y'}
     assert g2.inputs['x'] == reals(2)
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
+
+    g2 = g1(i='j')
+    assert set(g2.inputs) == {'j', 'x', 'y'}
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
 
 
 @pytest.mark.parametrize('int_inputs', [

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -8,6 +8,7 @@ import pytest
 
 import funsor
 import funsor.ops as ops
+from funsor.cnf import Contraction
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
 from funsor.terms import (
@@ -36,6 +37,7 @@ from funsor.torch import REDUCE_OP_TO_TORCH
 
 assert Binary  # flake8
 assert Subs  # flake8
+assert Contraction  # flake8
 
 np.seterr(all='ignore')
 
@@ -84,7 +86,7 @@ def check_quote(x):
     assert x is y
 
 
-@pytest.mark.parametrize('interp', [reflect, lazy, eager], ids=lambda i: i.__name__)
+@pytest.mark.parametrize('interp', [reflect, lazy, normalize, eager], ids=lambda i: i.__name__)
 def test_quote(interp):
     with interpretation(interp):
         x = Variable('x', bint(8))

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -99,6 +99,8 @@ def test_quote(interp):
         check_quote(z(i=0))
         check_quote(z(i=Slice('i', 0, 1, 1, 2)))
         check_quote(z.reduce(ops.add, 'i'))
+        check_quote(Cat('i', (z, z, z)))
+        check_quote(Lambda(Variable('i', bint(2)), z))
 
 
 @pytest.mark.parametrize('expr', [

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -11,6 +11,7 @@ import funsor.ops as ops
 from funsor.domains import Domain, bint, reals
 from funsor.interpreter import interpretation
 from funsor.terms import (
+    Binary,
     Cat,
     Funsor,
     Independent,
@@ -19,15 +20,22 @@ from funsor.terms import (
     Reduce,
     Slice,
     Stack,
+    Subs,
     Variable,
+    eager,
     eager_or_die,
+    lazy,
     normalize,
+    reflect,
     sequential,
     to_data,
     to_funsor
 )
 from funsor.testing import assert_close, check_funsor, random_tensor
 from funsor.torch import REDUCE_OP_TO_TORCH
+
+assert Binary  # flake8
+assert Subs  # flake8
 
 np.seterr(all='ignore')
 
@@ -67,6 +75,30 @@ def test_cons_hash():
     assert Slice('x', 10) is Slice('x', 0, 10)
     assert Slice('x', 10, 10) is not Slice('x', 0, 10)
     assert Slice('x', 2, 10, 1) is Slice('x', 2, 10)
+
+
+def check_quote(x):
+    s = funsor.quote(x)
+    assert isinstance(s, str)
+    y = eval(s)
+    assert x is y
+
+
+@pytest.mark.parametrize('interp', [reflect, lazy, eager], ids=lambda i: i.__name__)
+def test_quote(interp):
+    with interpretation(interp):
+        x = Variable('x', bint(8))
+        check_quote(x)
+
+        y = Variable('y', reals(8, 3, 3))
+        check_quote(y)
+        check_quote(y[x])
+
+        z = Stack('i', (Number(0), Variable('z', reals())))
+        check_quote(z)
+        check_quote(z(i=0))
+        check_quote(z(i=Slice('i', 0, 1, 1, 2)))
+        check_quote(z.reduce(ops.add, 'i'))
 
 
 @pytest.mark.parametrize('expr', [

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13,6 +13,17 @@ from funsor.testing import assert_close, assert_equiv, check_funsor, random_tens
 from funsor.torch import REDUCE_OP_TO_TORCH, Einsum, Tensor, align_tensors, torch_stack, torch_tensordot
 
 
+@pytest.mark.parametrize('output_shape', [(), (2,), (3, 2)], ids=str)
+@pytest.mark.parametrize('inputs', [(), ('a',), ('a', 'b'), ('b', 'a', 'c')], ids=str)
+def test_quote(output_shape, inputs):
+    sizes = {'a': 4, 'b': 5, 'c': 6}
+    inputs = OrderedDict((k, bint(sizes[k])) for k in inputs)
+    x = random_tensor(inputs, reals(*output_shape))
+    s = funsor.quote(x)
+    assert isinstance(s, str)
+    assert_close(eval(s), x)
+
+
 @pytest.mark.parametrize('shape', [(), (4,), (3, 2)])
 @pytest.mark.parametrize('dtype', [torch.float, torch.long, torch.uint8, torch.bool])
 def test_to_funsor(shape, dtype):


### PR DESCRIPTION
Based on: #242 

This adds an invertible `quote()` helper for funsors and things involving funsors:
```py
f = ...   # a Funsor
assert_close(f, eval(quote(f)))  # or something like this for lazy funsors
```
This indents in a flake8-compatible way so output can be pasted in tests, e.g:
```py
Independent(
 Independent(
  Contraction(
   ops.nullop,
   ops.add,
   frozenset(),
   (Tensor(
     torch.tensor([[-0.6077086925506592, -1.1546266078948975, -0.7021151781082153, -0.5303535461425781, -0.6365622282028198, -1.2423288822174072, -0.9941254258155823, -0.6287292242050171], [-0.6987162828445435, -1.0875964164733887, -0.7337473630905151, -0.4713417589664459, -0.6674002408981323, -1.2478348016738892, -0.8939017057418823, -0.5238542556762695]], dtype=torch.float32),  # noqa
     (('time__BOUND_4',
       bint(2),),
      ('_event_1__BOUND_2',
       bint(8),),),
     'real'),
    Gaussian(
     torch.tensor([[[-0.3536059558391571], [-0.21779225766658783], [0.2840439975261688], [0.4531521499156952], [-0.1220812276005745], [-0.05519985035061836], [0.10932210087776184], [0.6656699776649475]], [[-0.39107921719551086], [-0.20241987705230713], [0.2170514464378357], [0.4500560462474823], [0.27945515513420105], [-0.0490039587020874], [-0.06399798393249512], [0.846565842628479]]], dtype=torch.float32),  # noqa
     torch.tensor([[[[1.984686255455017]], [[0.6699360013008118]], [[1.6215802431106567]], [[2.372016668319702]], [[1.77385413646698]], [[0.526767373085022]], [[0.8722561597824097]], [[2.1879124641418457]]], [[[1.6996612548828125]], [[0.7535632252693176]], [[1.4946647882461548]], [[2.642792224884033]], [[1.7301604747772217]], [[0.5203893780708313]], [[1.055436372756958]], [[2.8370864391326904]]]], dtype=torch.float32),  # noqa
     (('time__BOUND_4',
       bint(2),),
      ('_event_1__BOUND_2',
       bint(8),),
      ('value__BOUND_1',
       reals(),),)),)),
  'gate_rate__BOUND_3',
  '_event_1__BOUND_2',
  'value__BOUND_1'),
 'gate_rate_t',
 'time__BOUND_4',
 'gate_rate__BOUND_3')
```
After this PR, `pretty()` is implemented on top of `quote()`.

Note: Ideally this method would be called `repr`, but since `repr` isn't invertible for e.g. `torch.Tensor`s (which abbreviate output) or functions (which print a pointer) we need to special-case such classes.

## Questions for reviewers

- What should I do about alpha renaming? Of course the global gensym state won't be serialized.
  One workaround is to `s/__BOUND/_b/` in pasted code?

## Tested
- [x] add unit test for invertibility
- [x] fix test/examples/test_bart.py using output from `quote()`