### PR TITLE
Fix renaming of int variable in Gaussian

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -6,24 +6,11 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
-from funsor.delta import Delta, Delta
+from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.integrate import Integrate
 from funsor.ops import AddOp, NegOp, SubOp
-from funsor.terms import (
-    Align,
-    Binary,
-    Funsor,
-    FunsorMeta,
-    Number,
-    Slice,
-    Subs,
-    Unary,
-    Variable,
-    eager,
-    reflect,
-    to_funsor
-)
+from funsor.terms import Align, Binary, Funsor, FunsorMeta, Number, Slice, Subs, Unary, Variable, eager, reflect
 from funsor.torch import Tensor, align_tensor, align_tensors, materialize
 from funsor.util import lazy_property
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -343,7 +343,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
     def eager_subs(self, subs):
         assert isinstance(subs, tuple)
-        subs = tuple((k, materialize(to_funsor(v, self.inputs[k])))
+        subs = tuple((k, v if isinstance(v, (Variable, Slice)) else materialize(v))
                      for k, v in subs if k in self.inputs)
         if not subs:
             return self

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -282,10 +282,19 @@ def test_eager_subs_variable():
 
     g2 = g1(x='z')
     assert set(g2.inputs) == {'i', 'y', 'z'}
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
 
     g2 = g1(x='y', y='x')
     assert set(g2.inputs) == {'i', 'x', 'y'}
     assert g2.inputs['x'] == reals(2)
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
+
+    g2 = g1(i='j')
+    assert set(g2.inputs) == {'j', 'x', 'y'}
+    assert g2.info_vec is g1.info_vec
+    assert g2.precision is g1.precision
 
 
 @pytest.mark.parametrize('int_inputs', [


### PR DESCRIPTION
This fixes a performance bug where renaming an int variable of a `Gaussian` triggered an expensive tensor indexing op; after this PR there isn't even a tensor copy.

## Tested
- added a regression test