### PR TITLE
Add xfailing test for BART analytic kls

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -98,6 +98,9 @@ class Contraction(Funsor):
 def _(arg, indent, out):
     line = f"{type(arg).__name__}({repr(arg.red_op)}, {repr(arg.bin_op)},"
     out.append((indent, line))
+    quote.inplace(arg.reduced_vars, indent + 1, out)
+    i, line = out[-1]
+    out[-1] = i, line + ","
     quote.inplace(arg.terms, indent + 1, out)
     i, line = out[-1]
     out[-1] = i, line + ")"

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -12,6 +12,7 @@ from funsor.interpreter import recursion_reinterpret
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
 from funsor.terms import Align, Binary, Funsor, Number, Reduce, Subs, Unary, Variable, eager, normalize, to_funsor
 from funsor.torch import Tensor
+from funsor.util import quote
 
 
 class Contraction(Funsor):
@@ -91,6 +92,15 @@ class Contraction(Funsor):
         alpha_subs = {k: to_funsor(v, bound_types[k]) for k, v in alpha_subs.items()}
         red_op, bin_op, _, terms = super()._alpha_convert(alpha_subs)
         return red_op, bin_op, reduced_vars, terms
+
+
+@quote.register(Contraction)
+def _(arg, indent, out):
+    line = f"{type(arg).__name__}({repr(arg.red_op)}, {repr(arg.bin_op)},"
+    out.append((indent, line))
+    quote.inplace(arg.terms, indent + 1, out)
+    i, line = out[-1]
+    out[-1] = i, line + ")"
 
 
 @recursion_reinterpret.register(Contraction)


### PR DESCRIPTION
This adds an xfailing test so we can track progress of pattern implementation.

I've also condensed `quote(Contraction(...))` to make the error message more readable:

<details>

```
>       assert isinstance(elbo, Tensor), elbo.pretty()
E       AssertionError: Contraction(ops.nullop, ops.add,
E          frozenset(),
E          (Contraction(ops.add, ops.mul,
E            frozenset({'gate_rate_t__BOUND_47'}),
E            (Unary(ops.exp,
E            │ Independent(
E            │  Independent(
E            │   Contraction(ops.nullop, ops.add,
E            │   │frozenset(),
E            │   │(Tensor(
E            │   │  torch.tensor([[-0.6077086925506592, -1.1...
E            │   │  (('time_b3__BOUND_29',
E            │   │   │bint(2),),
E            │   │   ('_event_1_b2__BOUND_26',
E            │   │   │bint(8),),),
E            │   │  'real'),
E            │   │ Gaussian(
E            │   │  torch.tensor([[[-0.3536059558391571], [-...
E            │   │  torch.tensor([[[[1.984686255455017]], [[...
E            │   │  (('time_b3__BOUND_29',
E            │   │   │bint(2),),
E            │   │   ('_event_1_b2__BOUND_26',
E            │   │   │bint(8),),
E            │   │   ('value_b1__BOUND_27',
E            │   │   │reals(),),)),)),
E            │   'gate_rate_b4__BOUND_28',
E            │   '_event_1_b2__BOUND_26',
E            │   'value_b1__BOUND_27'),
E            │  'gate_rate_t__BOUND_47',
E            │  'time_b3__BOUND_29',
E            │  'gate_rate_b4__BOUND_28')),
E            │Contraction(ops.nullop, ops.add,
E            │ frozenset(),
E            │ (Contraction(ops.logaddexp, ops.add,
E            │   frozenset({'state(time=1)_b14__BOUND_40'...
E            │   (Contraction(ops.logaddexp, ops.add,
E            │   │ frozenset({'_drop_0_b11__BOUND_36'}),
E            │   │ (Tensor(
E            │   │   torch.tensor(5.534586429595947, dtype=to...
E            │   │   (),
E            │   │   'real'),
E            │   │  Gaussian(
E            │   │   torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 0...
E            │   │   torch.tensor([[198.01004028320312, 0.0, ...
E            │   │   (('_drop_0_b11__BOUND_36',
E            │   │   │ reals(2,),),
E            │   │   │('state(time=1)_b14__BOUND_40',
E            │   │   │ reals(2,),),
E            │   │   │('state_b13__BOUND_39',
E            │   │   │ reals(2,),),)),
E            │   │  AffineNormal(
E            │   │   Tensor(
E            │   │   │torch.tensor([[0.03488487750291824, 0.07...
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Tensor(
E            │   │   │torch.tensor([0.0021788496524095535, -0....
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Tensor(
E            │   │   │torch.tensor([0.5787821412086487, 0.9178...
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Variable('state(time=1)_b14__BOUND_40', ...
E            │   │   Binary(ops.GetitemOp(0),
E            │   │   │Variable('gate_rate_t__BOUND_47', reals(...
E            │   │   │Number(1, 2))),
E            │   │  AffineNormal(
E            │   │   Tensor(
E            │   │   │torch.tensor([[0.03488487750291824, 0.07...
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Tensor(
E            │   │   │torch.tensor([-0.003566693514585495, -0....
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Tensor(
E            │   │   │torch.tensor([0.5974780917167664, 0.8640...
E            │   │   │(),
E            │   │   │'real'),
E            │   │   Variable('_drop_0_b11__BOUND_36', reals(...
E            │   │   Binary(ops.GetitemOp(0),
E            │   │   │Variable('gate_rate_t__BOUND_47', reals(...
E            │   │   │Number(0, 2))),)),
E            │   │Tensor(
E            │   │ torch.tensor(-6.443047523498535, dtype=t...
E            │   │ (),
E            │   │ 'real'),
E            │   │Gaussian(
E            │   │ torch.tensor([0.0, 0.0], dtype=torch.flo...
E            │   │ torch.tensor([[0.010000000707805157, -0....
E            │   │ (('state_b13__BOUND_39',
E            │   │   reals(2,),),)),)),
E            │  Unary(ops.neg,
E            │   Independent(
E            │   │Independent(
E            │   │ Contraction(ops.nullop, ops.add,
E            │   │  frozenset(),
E            │   │  (Tensor(
E            │   │   │torch.tensor([[-0.6077086925506592, -1.1...
E            │   │   │(('time_b3__BOUND_29',
E            │   │   │  bint(2),),
E            │   │   │ ('_event_1_b2__BOUND_26',
E            │   │   │  bint(8),),),
E            │   │   │'real'),
E            │   │   Gaussian(
E            │   │   │torch.tensor([[[-0.3536059558391571], [-...
E            │   │   │torch.tensor([[[[1.984686255455017]], [[...
E            │   │   │(('time_b3__BOUND_29',
E            │   │   │  bint(2),),
E            │   │   │ ('_event_1_b2__BOUND_26',
E            │   │   │  bint(8),),
E            │   │   │ ('value_b1__BOUND_27',
E            │   │   │  reals(),),)),)),
E            │   │ 'gate_rate_b4__BOUND_28',
E            │   │ '_event_1_b2__BOUND_26',
E            │   │ 'value_b1__BOUND_27'),
E            │   │'gate_rate_t__BOUND_47',
E            │   │'time_b3__BOUND_29',
E            │   │'gate_rate_b4__BOUND_28')),)),)),
E           Tensor(
E            torch.tensor(-132.045654296875, dtype=to...
E            (),
E            'real'),))
E       assert False
E        +  where False = isinstance(Contraction(ops.nullop, ops.add, frozenset(), (Contraction(ops.add, ops.mul, frozenset({'gate_rate_t__BOUND_47'}), (Un...te_rate_t__BOUND_47, time_b3__BOUND_29, gate_rate_b4__BOUND_28))))), Tensor(-132.045654296875, OrderedDict(), 'real'))), Tensor)
```

</details>