### PR TITLE
Implement ReshapeOp, .shape attribute and .reshape() method

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -88,6 +88,8 @@ def find_domain(op, *domains):
         shape = domains[0].shape
         if op is ops.log or op is ops.exp:
             dtype = 'real'
+        elif isinstance(op, ops.ReshapeOp):
+            shape = op.shape
         return Domain(shape, dtype)
 
     lhs, rhs = domains

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -91,6 +91,28 @@ def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
 
 
+class ReshapeMeta(type):
+    _cache = {}
+
+    def __call__(cls, shape):
+        shape = tuple(shape)
+        try:
+            return ReshapeMeta._cache[shape]
+        except KeyError:
+            instance = super().__call__(shape)
+            ReshapeMeta._cache[shape] = instance
+            return instance
+
+
+class ReshapeOp(Op, metaclass=ReshapeMeta):
+    def __init__(self, shape):
+        self.shape = shape
+        super().__init__(self._default)
+
+    def _default(self, x):
+        return x.reshape(self.shape)
+
+
 class GetitemMeta(type):
     _cache = {}
 
@@ -288,6 +310,7 @@ __all__ = [
     'PRODUCT_INVERSES',
     'ReciprocalOp',
     'SubOp',
+    'ReshapeOp',
     'UNITS',
     'abs',
     'add',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -325,6 +325,10 @@ class Funsor(object, metaclass=FunsorMeta):
     def dtype(self):
         return self.output.dtype
 
+    @property
+    def shape(self):
+        return self.output.shape
+
     def __hash__(self):
         return id(self)
 
@@ -563,6 +567,9 @@ class Funsor(object, metaclass=FunsorMeta):
 
     def sigmoid(self):
         return Unary(ops.sigmoid, self)
+
+    def reshape(self, shape):
+        return Unary(ops.ReshapeOp(shape), self)
 
     # The following reductions are treated as Unary ops because they
     # reduce over output shape while preserving all inputs.

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -11,7 +11,7 @@ from multipledispatch.variadic import Variadic
 import funsor.ops as ops
 from funsor.delta import Delta
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.ops import GetitemOp, Op
+from funsor.ops import GetitemOp, Op, ReshapeOp
 from funsor.terms import (
     Binary,
     Funsor,
@@ -19,6 +19,7 @@ from funsor.terms import (
     Lambda,
     Number,
     Slice,
+    Unary,
     Variable,
     eager,
     substitute,
@@ -427,6 +428,15 @@ def eager_binary_tensor_tensor(op, lhs, rhs):
 
     data = op(lhs_data, rhs_data)
     return Tensor(data, inputs, dtype)
+
+
+@eager.register(Unary, ReshapeOp, Tensor)
+def eager_reshape_tensor(op, arg):
+    if arg.shape == op.shape:
+        return arg
+    batch_shape = arg.data.shape[:arg.data.dim() - len(arg.shape)]
+    data = arg.data.reshape(batch_shape + op.shape)
+    return Tensor(data, arg.inputs, arg.dtype)
 
 
 @eager.register(Binary, GetitemOp, Tensor, Number)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -352,6 +352,31 @@ def test_binary_scalar_funsor(symbol, dims, scalar):
     check_funsor(actual, inputs, reals(), expected_data)
 
 
+@pytest.mark.parametrize("batch_shape", [(), (5,), (4, 3)])
+@pytest.mark.parametrize("old_shape,new_shape", [
+    ((), ()),
+    ((), (1,)),
+    ((2,), (2, 1)),
+    ((2,), (1, 2)),
+    ((6,), (2, 3)),
+    ((6,), (2, 1, 3)),
+    ((2, 3, 2), (3, 2, 2)),
+    ((2, 3, 2), (2, 2, 3)),
+])
+def test_reshape(batch_shape, old_shape, new_shape):
+    inputs = OrderedDict(zip("abc", map(bint, batch_shape)))
+    old = random_tensor(inputs, reals(*old_shape))
+    assert old.reshape(old.shape) is old
+
+    new = old.reshape(new_shape)
+    assert new.inputs == inputs
+    assert new.shape == new_shape
+    assert new.dtype == old.dtype
+
+    old2 = new.reshape(old_shape)
+    assert_close(old2, old)
+
+
 def test_getitem_number_0_inputs():
     data = torch.randn((5, 4, 3, 2))
     x = Tensor(data)


### PR DESCRIPTION
Blocking #245 

This adds a `.shape` attribute and `.reshape()` method for two purposes:
- to make it easier to write PyTorch-compatible code in funsor minipyro, and
- to make it easier to work with batched Tensors e.g. in #245 

## Tested
- added a unit test for `Tensor`