### PR TITLE
Implement affine funsor approximation

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -7,6 +7,7 @@ from funsor.util import pretty, quote
 
 from . import (
     adjoint,
+    affine,
     cnf,
     delta,
     distributions,
@@ -38,6 +39,7 @@ __all__ = [
     'Tensor',
     'Variable',
     'adjoint',
+    'affine',
     'arange',
     'backward',
     'bint',

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -19,7 +19,12 @@ def extract_affine(fn):
                 for var, (coeff, eqn) in coeffs.items())
         assert_close(y, x)
 
-    :param Funsor fn: A funsor assumed to be affine (this is not checked).
+    The affine approximation is computed by ev evaluating ``fn`` at
+    zero and each basis vector. To improve performance, users may want to run
+    under the :func:`~funsor.memoize.memoize` interpretation.
+
+    :param Funsor fn: A funsor assumed to be affine wrt the (add,mul) semiring.
+       The affine assumption is not checked.
     :return: A pair ``(const, coeffs)`` where const is a funsor with no real
         inputs and ``coeffs`` is an OrderedDict mapping input name to a
         ``(coefficient, eqn)`` pair in einsum form.

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -1,0 +1,48 @@
+from collections import OrderedDict
+
+import opt_einsum
+import torch
+
+from funsor.interpreter import gensym
+from funsor.terms import Lambda, Variable, bint
+from funsor.torch import Tensor
+
+
+def extract_affine(fn):
+    """
+    Extracts an affine representation of a funsor, which is exact for affine
+    funsors and approximate otherwise. For affine funsors this satisfies::
+
+        x = Contraction(...)
+        assert x.is_affine
+        const, coeffs = x.extract_affine()
+        y = sum(Einsum(eqn, (coeff, Variable(var, coeff.output)))
+                for var, (coeff, eqn) in coeffs.items())
+        assert_close(y, x)
+
+    :param Funsor fn: A funsor.
+    :return: A pair ``(const, coeffs)`` where const is a funsor with no real
+        inputs and ``coeffs`` is an OrderedDict mapping input name to a
+        ``(coefficient, eqn)`` pair in einsum form.
+    :rtype: tuple
+    """
+    # Determine constant part by evaluating fn at zero.
+    real_inputs = OrderedDict((k, v) for k, v in fn.inputs.items() if v.dtype == 'real')
+    zeros = {k: Tensor(torch.zeros(v.shape)) for k, v in real_inputs.items()}
+    const = fn(**zeros)
+
+    # Determine linear coefficients by evaluating fn on basis vectors.
+    name = gensym('probe')
+    coeffs = OrderedDict()
+    for k, v in real_inputs.items():
+        dim = v.num_elements
+        var = Variable(name, bint(dim))
+        subs = zeros.copy()
+        subs[k] = Tensor(torch.eye(dim).reshape((dim,) + v.shape))[var]
+        coeff = Lambda(var, fn(**subs) - const).reshape(v.shape + const.shape)
+        inputs1 = ''.join(map(opt_einsum.get_symbol, range(len(coeff.shape))))
+        inputs2 = inputs1[:len(v.shape)]
+        output = inputs1[len(v.shape):]
+        eqn = f'{inputs1},{inputs2}->{output}'
+        coeffs[k] = coeff, eqn
+    return const, coeffs

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -13,14 +13,13 @@ def extract_affine(fn):
     Extracts an affine representation of a funsor, which is exact for affine
     funsors and approximate otherwise. For affine funsors this satisfies::
 
-        x = Contraction(...)
-        assert x.is_affine
-        const, coeffs = x.extract_affine()
+        x = ...
+        const, coeffs = extract_affine(x)
         y = sum(Einsum(eqn, (coeff, Variable(var, coeff.output)))
                 for var, (coeff, eqn) in coeffs.items())
         assert_close(y, x)
 
-    :param Funsor fn: A funsor.
+    :param Funsor fn: A funsor assumed to be affine (this is not checked).
     :return: A pair ``(const, coeffs)`` where const is a funsor with no real
         inputs and ``coeffs`` is an OrderedDict mapping input name to a
         ``(coefficient, eqn)`` pair in einsum form.

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -784,6 +784,7 @@ def eager_einsum(equation, operands):
             symbol = next(get_symbol)
             while symbol in symbols:
                 symbol = next(get_symbol)
+            symbols.add(symbol)
             new_symbols[k] = symbol
 
         # Manually broadcast using einsum symbols.

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -3,11 +3,12 @@ from collections import OrderedDict
 import pytest
 import torch
 
+from funsor.affine import extract_affine
 from funsor.cnf import Contraction
 from funsor.domains import bint, reals
 from funsor.terms import Number, Variable
-from funsor.testing import check_funsor
-from funsor.torch import Tensor
+from funsor.testing import assert_close, check_funsor, random_tensor
+from funsor.torch import Einsum, Tensor
 
 SMOKE_TESTS = [
     ('t+x', Contraction),
@@ -75,3 +76,42 @@ def test_affine_subs(expr, expected_type, expected_inputs):
     assert isinstance(result, expected_type)
     check_funsor(result, expected_inputs, expected_output)
     assert result.is_affine
+
+
+@pytest.mark.parametrize('expr', [
+    "Variable('x', reals()) + 0.5",
+    "Variable('x', reals(2)) + Variable('y', reals(2))",
+    "Variable('x', reals(2)) + torch.ones(2)",
+    "Variable('x', reals(2)) * torch.randn(2)",
+    "Variable('x', reals(2)) * torch.randn(2) + torch.ones(2)",
+    "Variable('x', reals(2)) + Tensor(torch.randn(3, 2), OrderedDict(i=bint(3)))",
+    "Einsum('abcd,ac->bd',"
+    " (Tensor(torch.randn(2, 3, 4, 5)), Variable('x', reals(2, 4))))",
+    "Tensor(torch.randn(3, 5)) + Einsum('abcd,ac->bd',"
+    " (Tensor(torch.randn(2, 3, 4, 5)), Variable('x', reals(2, 4))))",
+    "Variable('x', reals(2, 8))[0] + torch.randn(8)",
+    "Variable('x', reals(2, 8))[Variable('i', bint(2))] / 4 - 3.5",
+])
+def test_extract_affine(expr):
+    x = eval(expr)
+    assert isinstance(x, (Contraction, Einsum))
+    real_inputs = OrderedDict((k, d) for k, d in x.inputs.items()
+                              if d.dtype == 'real')
+
+    const, coeffs = extract_affine(x)
+    assert isinstance(const, Tensor)
+    assert const.shape == x.shape
+    assert list(coeffs) == list(real_inputs)
+    for name, (coeff, eqn) in coeffs.items():
+        assert isinstance(name, str)
+        assert isinstance(coeff, Tensor)
+        assert isinstance(eqn, str)
+
+    subs = {k: random_tensor(OrderedDict(), d) for k, d in real_inputs.items()}
+    expected = x(**subs)
+    assert isinstance(expected, Tensor)
+
+    actual = const + sum(Einsum(eqn, (coeff, subs[k]))
+                         for k, (coeff, eqn) in coeffs.items())
+    assert isinstance(actual, Tensor)
+    assert_close(actual, expected)


### PR DESCRIPTION
Addresses #72 
Blocking #245 (from which this PR was extracted)

This implements a general `extract_affine(-)` function that produces a canonical representation of any affine function, including constants, sums, einsums, indexing, reshaping and any other linear combination. The only requirement is that the function can be eagerly evaluated on `Tensor`s. I was surprised how general this turned out to be.

This required some fixes to `Einsum` to handle differently-batched inputs.

## Tested
- [x] unit test for `extract_affine()`
- [x] extra test for batched `Einsum`