### PR TITLE
Implement ops.matmul and align_tensors(..., expand=True)

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -368,8 +368,7 @@ def eager_normal(loc, scale, value):
     if isinstance(loc, Variable):
         loc, value = value, loc
 
-    inputs, (loc, scale) = align_tensors(loc, scale)
-    loc, scale = torch.broadcast_tensors(loc, scale)
+    inputs, (loc, scale) = align_tensors(loc, scale, expand=True)
     inputs.update(value.inputs)
     int_inputs = OrderedDict((k, v) for k, v in inputs.items() if v.dtype != 'real')
 
@@ -407,8 +406,7 @@ def eager_normal(loc, scale, value):
         coeffs[c] = affine(**{k: 1. if c == k else 0. for k in real_inputs.keys()}) - const
 
     tensors = [const] + list(coeffs.values())
-    inputs, tensors = align_tensors(*tensors)
-    tensors = torch.broadcast_tensors(*tensors)
+    inputs, tensors = align_tensors(*tensors, expand=True)
     const, coeffs = tensors[0], tensors[1:]
 
     dim = sum(d.num_elements for d in real_inputs.values())

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -97,6 +97,18 @@ def find_domain(op, *domains):
         dtype = lhs.dtype
         shape = lhs.shape[:op.offset] + lhs.shape[1 + op.offset:]
         return Domain(shape, dtype)
+    elif op == ops.matmul:
+        assert lhs.shape and rhs.shape
+        if len(rhs.shape) == 1:
+            assert lhs.shape[-1] == rhs.shape[-1]
+            shape = lhs.shape[:-1]
+        elif len(lhs.shape) == 1:
+            assert lhs.shape[-1] == rhs.shape[-2]
+            shape = rhs.shape[:-2] + rhs.shape[-1:]
+        else:
+            assert lhs.shape[-1] == rhs.shape[-2]
+            shape = broadcast_shape(lhs.shape[:-1], rhs.shape[:-2] + (1,)) + rhs.shape[-1:]
+        return Domain(shape, 'real')
 
     if lhs.dtype == 'real' or rhs.dtype == 'real':
         dtype = 'real'

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -65,6 +65,10 @@ class MulOp(AssociativeOp):
     pass
 
 
+class MatmulOp(AssociativeOp):
+    pass
+
+
 class LogAddExpOp(AssociativeOp):
     pass
 
@@ -157,6 +161,7 @@ truediv = DivOp(operator.truediv)
 add = AddOp(operator.add)
 and_ = AssociativeOp(operator.and_)
 mul = MulOp(operator.mul)
+matmul = MatmulOp(operator.matmul)
 or_ = AssociativeOp(operator.or_)
 xor = AssociativeOp(operator.xor)
 
@@ -325,6 +330,7 @@ __all__ = [
     'log',
     'log1p',
     'lt',
+    'matmul',
     'max',
     'min',
     'mul',

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -254,16 +254,13 @@ def eager_affine_normal(matrix, loc, scale, value_x, value_y):
     assert len(matrix.output.shape) == 2
     assert value_x.output == reals(matrix.output.shape[0])
     assert value_y.output == reals(matrix.output.shape[1])
-    tensors = (matrix, loc, scale, value_x)
-    int_inputs, tensors = align_tensors(*tensors)
-    matrix, loc, scale, value_x = tensors
+    loc += value_x @ matrix
+    int_inputs, (loc, scale) = align_tensors(loc, scale, expand=True)
 
-    loc = loc + value_x.unsqueeze(-2).matmul(matrix).squeeze(-2)
     i_name = gensym("i")
     y_name = gensym("y")
     y_i_name = gensym("y_i")
     int_inputs[i_name] = bint(value_y.output.shape[0])
-    loc, scale = torch.broadcast_tensors(loc, scale)
     loc = Tensor(loc, int_inputs)
     scale = Tensor(scale, int_inputs)
     y_dist = Independent(Normal(loc, scale, y_i_name), y_name, i_name, y_i_name)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -620,6 +620,12 @@ class Funsor(object, metaclass=FunsorMeta):
     def __rtruediv__(self, other):
         return Binary(ops.truediv, to_funsor(other), self)
 
+    def __matmul__(self, other):
+        return Binary(ops.matmul, self, to_funsor(other))
+
+    def __rmatmul__(self, other):
+        return Binary(ops.matmul, to_funsor(other), self)
+
     def __pow__(self, other):
         return Binary(ops.pow, self, to_funsor(other))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -322,6 +322,26 @@ def test_binary_broadcast(inputs1, inputs2, output_shape1, output_shape2):
     assert_close(actual_block, expected_block)
 
 
+@pytest.mark.parametrize('output_shape2', [(2,), (2, 5), (4, 2, 5)], ids=str)
+@pytest.mark.parametrize('output_shape1', [(2,), (3, 2), (4, 3, 2)], ids=str)
+@pytest.mark.parametrize('inputs2', [(), ('a',), ('b', 'a'), ('b', 'c', 'a')], ids=str)
+@pytest.mark.parametrize('inputs1', [(), ('a',), ('a', 'b'), ('b', 'a', 'c')], ids=str)
+def test_matmul(inputs1, inputs2, output_shape1, output_shape2):
+    sizes = {'a': 6, 'b': 7, 'c': 8}
+    inputs1 = OrderedDict((k, bint(sizes[k])) for k in inputs1)
+    inputs2 = OrderedDict((k, bint(sizes[k])) for k in inputs2)
+    x1 = random_tensor(inputs1, reals(*output_shape1))
+    x2 = random_tensor(inputs1, reals(*output_shape2))
+
+    actual = x1 @ x2
+    assert actual.output == find_domain(ops.matmul, x1.output, x2.output)
+
+    block = {'a': 1, 'b': 2, 'c': 3}
+    actual_block = actual(**block)
+    expected_block = Tensor(x1(**block).data @ x2(**block).data)
+    assert_close(actual_block, expected_block)
+
+
 @pytest.mark.parametrize('scalar', [0.5])
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b'), ('b', 'a', 'c')])
 @pytest.mark.parametrize('symbol', BINARY_OPS)


### PR DESCRIPTION
Blocking #245 

This adds an op `x @ y = ops.matmul(x, y)` which is proving to simplify math in #245 . This is a step in the direction of performing more underlying math on Funsors and less on torch.Tensors, addressing #207 .

This also adds an `expand=True` kwarg to `align_tensor()` and `align_tensors()`, thereby avoiding an error-prone `torch.broadcast_tensors()` in subsequent code.

## Tested
- [x] unit tests for matmul
- [x] refactored to use `x @ y` in some code (covered by existing tests)
- [x] refactored to use `expand=True` in some code (covered by existing tests)