### PR TITLE
Ensure all funsor.* modules are imported in funsor/__init__.py

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -20,9 +20,11 @@ from . import (
     memoize,
     minipyro,
     montecarlo,
+    numpy,
     ops,
     sum_product,
     terms,
+    testing,
     torch
 )
 
@@ -56,6 +58,7 @@ __all__ = [
     'memoize',
     'minipyro',
     'montecarlo',
+    'numpy',
     'of_shape',
     'ops',
     'pretty',
@@ -64,6 +67,7 @@ __all__ = [
     'reinterpret',
     'sum_product',
     'terms',
+    'testing',
     'to_data',
     'to_funsor',
     'torch',

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,0 +1,15 @@
+import glob
+import os
+from importlib import import_module
+
+
+def test_all_modules_are_imported():
+    root = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'funsor')
+    for path in glob.glob(os.path.join(root, '*.py')):
+        name = os.path.basename(path)[:-3]
+        if name.startswith('__'):
+            continue
+        assert hasattr(import_module('funsor'), name), f'funsor/__init__.py does not import {name}'
+        actual = getattr(import_module('funsor'), name)
+        expected = import_module(f'funsor.{name}')
+        assert actual == expected


### PR DESCRIPTION
This enforces the requirement that all top-level modules funsor.* are imported in funsor/__init__.py, thus guaranteeing all patterns are registered. This is especially important for files like joint.py that only register patterns.

The second-level module funsor.pyro.* modules are not loaded by default; for now I think it is safe to consider second-level modules optional.

## Tested
- added a test to ensure all top-level modules are loaded