### PR TITLE
Fix strategy of gaussian mixture .unscaled_sample()

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -17,7 +17,12 @@ from funsor.util import quote
 
 class Contraction(Funsor):
     """
-    Declarative representation of a finitary sum-product operation
+    Declarative representation of a finitary sum-product operation.
+
+    After normalization via the :func:`~funsor.terms.normalize` interpretation
+    contractions will canonically order their terms by type::
+
+        Delta, Number, Tensor, Gaussian
     """
     def __init__(self, red_op, bin_op, reduced_vars, terms):
         terms = (terms,) if isinstance(terms, Funsor) else terms
@@ -70,9 +75,46 @@ class Contraction(Funsor):
         return True
 
     def unscaled_sample(self, sampled_vars, sample_inputs):
-        if self.red_op in (ops.logaddexp, nullop) and self.bin_op in (ops.logaddexp, ops.add, nullop):
-            new_terms = tuple(v.unscaled_sample(sampled_vars.intersection(v.inputs), sample_inputs) for v in self.terms)
-            return Contraction(self.red_op, self.bin_op, self.reduced_vars, *new_terms)
+        sampled_vars = sampled_vars.intersection(self.inputs)
+        if not sampled_vars:
+            return self
+
+        if self.red_op in (ops.logaddexp, nullop):
+            if self.bin_op in (ops.nullop, ops.logaddexp):
+                # Design choice: we sample over logaddexp reductions, but leave logaddexp
+                # binary choices symbolic.
+                terms = [
+                    term.unscaled_sample(sampled_vars.intersection(term.inputs), sample_inputs)
+                    for term in self.terms]
+                return Contraction(self.red_op, self.bin_op, self.reduced_vars, *terms)
+
+            if self.bin_op is ops.add:
+                # Sample variables greedily in order of the terms in which they appear.
+                for term in self.terms:
+                    greedy_vars = sampled_vars.intersection(term.inputs)
+                    if greedy_vars:
+                        break
+                greedy_terms, terms = [], []
+                for term in self.terms:
+                    (terms if greedy_vars.isdisjoint(term.inputs) else greedy_terms).append(term)
+                if len(greedy_terms) == 1:
+                    term = greedy_terms[0]
+                    terms.append(term.unscaled_sample(greedy_vars, sample_inputs))
+                    result = Contraction(self.red_op, self.bin_op, self.reduced_vars, *terms)
+                elif (len(greedy_terms) == 2 and
+                        isinstance(greedy_terms[0], Tensor) and
+                        isinstance(greedy_terms[1], Gaussian)):
+                    discrete, gaussian = greedy_terms
+                    term = discrete + gaussian.log_normalizer
+                    terms.append(gaussian)
+                    terms.append(-gaussian.log_normalizer)
+                    terms.append(term.unscaled_sample(greedy_vars, sample_inputs))
+                    result = Contraction(self.red_op, self.bin_op, self.reduced_vars, *terms)
+                else:
+                    raise NotImplementedError('Unhandled case: {}'.format(
+                        ', '.join(str(type(t)) for t in greedy_terms)))
+                return result.unscaled_sample(sampled_vars - greedy_vars, sample_inputs)
+
         raise TypeError("Cannot sample through ops ({}, {})".format(self.red_op, self.bin_op))
 
     def align(self, names):
@@ -178,7 +220,8 @@ def eager_contraction_to_binary(red_op, bin_op, reduced_vars, lhs, rhs):
 # Normalizing Contractions
 ##########################################
 
-GROUND_TERMS = (Delta, Gaussian, Number, Tensor)
+ORDERING = {Delta: 1, Number: 2, Tensor: 3, Gaussian: 4}
+GROUND_TERMS = tuple(ORDERING)
 GaussianMixture = Contraction[Union[ops.LogAddExpOp, NullOp], ops.AddOp, frozenset,
                               Tuple[Union[Tensor, Number], Gaussian]]
 
@@ -186,10 +229,9 @@ GaussianMixture = Contraction[Union[ops.LogAddExpOp, NullOp], ops.AddOp, frozens
 @normalize.register(Contraction, AssociativeOp, ops.AddOp, frozenset, GROUND_TERMS, GROUND_TERMS)
 def normalize_contraction_commutative_canonical_order(red_op, bin_op, reduced_vars, *terms):
     # when bin_op is commutative, put terms into a canonical order for pattern matching
-    ordering = {Delta: 1, Number: 2, Tensor: 3, Gaussian: 4}
     new_terms = tuple(
         v for i, v in sorted(enumerate(terms),
-                             key=lambda t: (ordering.get(type(t[1]).__origin__, -1), t[0]))
+                             key=lambda t: (ORDERING.get(type(t[1]).__origin__, -1), t[0]))
     )
     if any(v is not vv for v, vv in zip(terms, new_terms)):
         return Contraction(red_op, bin_op, reduced_vars, *new_terms)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -498,11 +498,13 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         return None  # defer to default implementation
 
     def unscaled_sample(self, sampled_vars, sample_inputs):
-        # Sample only the real variables.
-        sampled_vars = frozenset(k for k, v in self.inputs.items()
-                                 if k in sampled_vars if v.dtype == 'real')
+        sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self
+        if any(self.inputs[k].dtype != 'real' for k in sampled_vars):
+            raise ValueError('Sampling from non-normalized Gaussian mixtures is intentionally '
+                             'not implemented. You probably want to normalize. To work around, '
+                             'add a zero Tensor with given inputs.')
 
         # Partition inputs into sample_inputs + int_inputs + real_inputs.
         sample_inputs = OrderedDict((k, d) for k, d in sample_inputs.items()

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -14,7 +14,7 @@ from funsor.integrate import Integrate
 from funsor.montecarlo import monte_carlo_interpretation
 from funsor.terms import Variable
 from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor, xfail_if_not_implemented
-from funsor.torch import align_tensors, materialize
+from funsor.torch import Tensor, align_tensors, materialize
 
 
 @pytest.mark.parametrize('sample_inputs', [
@@ -256,6 +256,36 @@ def test_gaussian_distribution(event_inputs, batch_inputs):
                          Integrate(p, x * y, p_vars), atol=1e-2)
 
 
+@pytest.mark.parametrize('batch_inputs', [
+    (),
+    (('b', bint(3)),),
+    (('b', bint(3)), ('c', bint(2))),
+], ids=id_from_inputs)
+@pytest.mark.parametrize('event_inputs', [
+    (('e', reals()), ('f', bint(3))),
+    (('e', reals(2)), ('f', bint(2))),
+], ids=id_from_inputs)
+def test_gaussian_mixture_distribution(batch_inputs, event_inputs):
+    num_samples = 100000
+    sample_inputs = OrderedDict(particle=bint(num_samples))
+    be_inputs = OrderedDict(batch_inputs + event_inputs)
+    int_inputs = OrderedDict((k, d) for k, d in be_inputs.items()
+                             if d.dtype != 'real')
+    batch_inputs = OrderedDict(batch_inputs)
+    event_inputs = OrderedDict(event_inputs)
+    sampled_vars = frozenset(['f'])
+    p = random_gaussian(be_inputs) + 0.5 * random_tensor(int_inputs)
+    p_marginal = p.reduce(ops.logaddexp, 'e')
+    assert isinstance(p_marginal, Tensor)
+
+    q = p.sample(sampled_vars, sample_inputs)
+    q_marginal = q.reduce(ops.logaddexp, 'e')
+    q_marginal = materialize(q_marginal).reduce(ops.logaddexp, 'particle')
+    assert isinstance(q_marginal, Tensor)
+    q_marginal = q_marginal.align(tuple(p_marginal.inputs))
+    assert_close(q_marginal, p_marginal, atol=0.1, rtol=None)
+
+
 @pytest.mark.parametrize('moment', [0, 1, 2, 3])
 def test_lognormal_distribution(moment):
     num_samples = 100000
@@ -263,11 +293,11 @@ def test_lognormal_distribution(moment):
     loc = random_tensor(inputs)
     scale = random_tensor(inputs).exp()
 
-    log_measure = dist.LogNormal(loc, scale)
+    log_measure = dist.LogNormal(loc, scale)(value='x')
     probe = Variable('x', reals()) ** moment
     with monte_carlo_interpretation(particle=bint(num_samples)):
         with xfail_if_not_implemented():
-            actual = Integrate(log_measure, probe)
+            actual = Integrate(log_measure, probe, frozenset(['x']))
 
     samples = torch.distributions.LogNormal(loc, scale).sample((num_samples,))
     expected = (samples ** moment).mean(0)


### PR DESCRIPTION
This fixes a subtle statistical inefficiency bug in `Contraction.unscaled_sample()`, especially important for scale mixtures.

Before this PR our strategy for sampling the discrete component of a `Tensor+Gaussian` mixture was to monte carlo sample from the `Tensor` and importance weight from the `Gaussian.log_normalizer`.

After this PR our strategy is to monte carlo sample from the true distribution.

## Tested
- refactoring is exercised by existing tests
- added a mixture sampling test (passes before and after this PR though)