### PR TITLE
Refactor Integrate patterns

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -13,7 +13,7 @@ from funsor.delta import Delta
 from funsor.domains import bint
 from funsor.gaussian import Gaussian, align_gaussian, cholesky_solve, cholesky_inverse
 from funsor.ops import AssociativeOp
-from funsor.terms import Funsor, Independent, Number, Reduce, Unary, eager, moment_matching, normalize
+from funsor.terms import Independent, Number, eager, moment_matching
 from funsor.torch import Tensor, align_tensor
 
 
@@ -130,16 +130,6 @@ def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gauss
 ####################################################
 # Patterns for normalizing
 ####################################################
-
-
-@eager.register(Reduce, ops.AddOp, Unary[ops.ExpOp, Funsor], frozenset)
-def eager_reduce_exp(op, arg, reduced_vars):
-    # x.exp().reduce(ops.add) == x.reduce(ops.logaddexp).exp()
-    log_result = arg.arg.reduce(ops.logaddexp, reduced_vars)
-    if log_result is not normalize(Reduce, ops.logaddexp, arg.arg, reduced_vars):
-        return log_result.exp()
-    return None
-
 
 @eager.register(Independent,
                 (Contraction[ops.NullOp, ops.AddOp, frozenset, Tuple[Delta, Union[Number, Tensor], Gaussian]],

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from contextlib2 import contextmanager
 
-from funsor.integrate import Integrate
+from funsor.integrate import Integrate, integrator
 from funsor.interpreter import dispatched_interpretation, interpretation
 from funsor.terms import Funsor, eager
 
@@ -41,10 +41,16 @@ def monte_carlo_interpretation(**sample_inputs):
 
 
 @monte_carlo.register(Integrate, Funsor, Funsor, frozenset)
+@integrator
 def monte_carlo_integrate(log_measure, integrand, reduced_vars):
+    if not (reduced_vars.issubset(log_measure.inputs) and
+            reduced_vars.issubset(integrand.inputs)):
+        return None  # normalize
+
     sample = log_measure.sample(reduced_vars, monte_carlo.sample_inputs)
     if sample is log_measure:
         return None  # cannot progress
+
     reduced_vars |= frozenset(monte_carlo.sample_inputs).intersection(sample.inputs)
     return Integrate(sample, integrand, reduced_vars)
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -470,8 +470,8 @@ def test_integrate_gaussian(int_inputs, real_inputs):
     inputs = int_inputs.copy()
     inputs.update(real_inputs)
 
-    log_measure = random_gaussian(inputs)
-    integrand = random_gaussian(inputs)
+    log_measure = random_gaussian(inputs) + random_tensor(int_inputs)
+    integrand = random_gaussian(inputs) + random_tensor(int_inputs)
     reduced_vars = frozenset(real_inputs)
 
     sampled_log_measure = log_measure.sample(reduced_vars, OrderedDict(particle=bint(10000)))
@@ -479,7 +479,7 @@ def test_integrate_gaussian(int_inputs, real_inputs):
     assert isinstance(approx, Tensor)
 
     exact = Integrate(log_measure, integrand, reduced_vars)
-    assert isinstance(exact, Tensor)
+    assert isinstance(exact, Tensor), exact.pretty()
     assert_close(approx, exact, atol=0.1, rtol=0.1)
 
 

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -299,21 +299,25 @@ def test_reduce_moment_matching_shape(interp):
 
 def test_reduce_moment_matching_moments():
     x = Variable('x', reals(2))
+    discrete = random_tensor(OrderedDict([('i', bint(2)), ('j', bint(3))]))
     gaussian = random_gaussian(OrderedDict(
         [('i', bint(2)), ('j', bint(3)), ('x', reals(2))]))
+    gaussian -= gaussian.log_normalizer
+    joint = discrete + gaussian
+
     with interpretation(moment_matching):
-        approx = gaussian.reduce(ops.logaddexp, 'j')
+        approx = joint.reduce(ops.logaddexp, 'j')
     with monte_carlo_interpretation(s=bint(100000)):
         actual = Integrate(approx, Number(1.), frozenset(['x']))
-        expected = Integrate(gaussian, Number(1.), frozenset(['j', 'x']))
+        expected = Integrate(joint, Number(1.), frozenset(['j', 'x']))
         assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
         actual = Integrate(approx, x, frozenset(['x']))
-        expected = Integrate(gaussian, x, frozenset(['j', 'x']))
+        expected = Integrate(joint, x, frozenset(['j', 'x']))
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
         actual = Integrate(approx, x * x, frozenset(['x']))
-        expected = Integrate(gaussian, x * x, frozenset(['j', 'x']))
+        expected = Integrate(joint, x * x, frozenset(['j', 'x']))
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 
@@ -323,6 +327,7 @@ def test_reduce_moment_matching_finite():
         [('i', bint(6)), ('j', bint(5)), ('k', bint(3))]))
     gaussian = random_gaussian(OrderedDict(
         [('k', bint(3)), ('l', bint(2)), ('y', reals()), ('z', reals(2))]))
+    gaussian -= gaussian.log_normalizer
 
     discrete.data[1:, :] = -float('inf')
     discrete.data[:, 1:] = -float('inf')

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -297,7 +297,6 @@ def test_reduce_moment_matching_shape(interp):
                  joint.reduce(ops.logaddexp, real_vars | reduced_vars))
 
 
-@pytest.mark.xfail(reason="missing pattern")
 def test_reduce_moment_matching_moments():
     x = Variable('x', reals(2))
     gaussian = random_gaussian(OrderedDict(


### PR DESCRIPTION
Addresses #228 

This is an experimental refactoring of `Integrate` patterns to make logic more straight-forward.

After this PR `Integrate()` restricts approximation to only `log_measure` and no subterms. To achieve this I have remove the `integrate <--> binary` patterns and exp/log logic introduced in #157.

## Tested
- [ ] fix `test_reduce_moment_matching_moments` which started xfailing in #157 