### PR TITLE
Implement a MarkovProduct funsor

### DIFF
--- a/docs/source/funsors.rst
+++ b/docs/source/funsors.rst
@@ -57,9 +57,9 @@ Affine
     :show-inheritance:
     :member-order: bysource
 
-Contract
---------
-.. automodule:: funsor.contract
+Contraction
+-----------
+.. automodule:: funsor.cnf
     :members:
     :undoc-members:
     :show-inheritance:

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,6 +1,7 @@
 from funsor.domains import Domain, bint, find_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
+from funsor.sum_product import MarkovProduct
 from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.torch import Tensor, arange
 from funsor.util import pretty, quote
@@ -35,6 +36,7 @@ __all__ = [
     'Independent',
     'Integrate',
     'Lambda',
+    'MarkovProduct',
     'Number',
     'Slice',
     'Stack',

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -84,4 +84,10 @@ class FunsorDistribution(dist.TorchDistribution):
         return value
 
     def expand(self, batch_shape, _instance=None):
-        raise NotImplementedError("TODO")
+        new = self._get_checked_instance(type(self), _instance)
+        batch_shape = torch.Size(batch_shape)
+        funsor_dist = self.funsor_dist + tensor_to_funsor(torch.zeros(batch_shape))
+        FunsorDistribution.__init__(
+            new, funsor_dist, batch_shape, self.event_shape, self.dtype, validate_args=False)
+        new.validate_args = self.__dict__.get('_validate_args')
+        return new

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -49,8 +49,7 @@ class FunsorDistribution(dist.TorchDistribution):
         if self._validate_args:
             self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
-        value = tensor_to_funsor(value, ("time",), event_output=self.event_dim - 1,
-                                 dtype=self.dtype)
+        value = tensor_to_funsor(value, event_output=self.event_dim, dtype=self.dtype)
         log_prob = self.funsor_dist(value=value)
         log_prob = funsor_to_tensor(log_prob, ndims=ndims)
         return log_prob

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -87,7 +87,7 @@ class FunsorDistribution(dist.TorchDistribution):
         new = self._get_checked_instance(type(self), _instance)
         batch_shape = torch.Size(batch_shape)
         funsor_dist = self.funsor_dist + tensor_to_funsor(torch.zeros(batch_shape))
-        FunsorDistribution.__init__(
-            new, funsor_dist, batch_shape, self.event_shape, self.dtype, validate_args=False)
+        super(type(self), new).__init__(
+            funsor_dist, batch_shape, self.event_shape, self.dtype, validate_args=False)
         new.validate_args = self.__dict__.get('_validate_args')
         return new

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -7,10 +7,8 @@ from torch.distributions import constraints
 from funsor.cnf import Contraction
 from funsor.delta import Delta
 from funsor.domains import bint
-from funsor.interpreter import interpretation, reinterpret
-from funsor.optimizer import apply_optimizer
 from funsor.pyro.convert import DIM_TO_NAME, funsor_to_tensor, tensor_to_funsor
-from funsor.terms import Funsor, lazy
+from funsor.terms import Funsor
 
 
 class FunsorDistribution(dist.TorchDistribution):
@@ -51,10 +49,9 @@ class FunsorDistribution(dist.TorchDistribution):
         if self._validate_args:
             self._validate_sample(value)
         ndims = max(len(self.batch_shape), value.dim() - self.event_dim)
-        value = tensor_to_funsor(value, event_output=self.event_dim, dtype=self.dtype)
-        with interpretation(lazy):
-            log_prob = apply_optimizer(self.funsor_dist(value=value))
-        log_prob = reinterpret(log_prob)
+        value = tensor_to_funsor(value, ("time",), event_output=self.event_dim - 1,
+                                 dtype=self.dtype)
+        log_prob = self.funsor_dist(value=value)
         log_prob = funsor_to_tensor(log_prob, ndims=ndims)
         return log_prob
 

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -186,15 +186,6 @@ class GaussianHMM(FunsorDistribution):
         super(GaussianHMM, self).__init__(
             funsor_dist, batch_shape, event_shape, dtype, validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(GaussianHMM, _instance)
-        batch_shape = torch.Size(batch_shape)
-        funsor_dist = self.funsor_dist + tensor_to_funsor(torch.zeros(batch_shape))
-        super(GaussianHMM, new).__init__(
-            funsor_dist, batch_shape, self.event_shape, self.dtype, validate_args=False)
-        new.validate_args = self.__dict__.get('_validate_args')
-        return new
-
 
 class GaussianMRF(FunsorDistribution):
     has_rsample = True
@@ -240,15 +231,6 @@ class GaussianMRF(FunsorDistribution):
 
         dtype = "real"
         super(GaussianMRF, self).__init__(funsor_dist, batch_shape, event_shape, dtype, validate_args)
-
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(GaussianMRF, _instance)
-        batch_shape = torch.Size(batch_shape)
-        funsor_dist = self.funsor_dist + tensor_to_funsor(torch.zeros(batch_shape))
-        super(GaussianMRF, new).__init__(
-            funsor_dist, batch_shape, self.event_shape, self.dtype, validate_args=False)
-        new.validate_args = self.__dict__.get('_validate_args')
-        return new
 
 
 class SwitchingLinearHMM(FunsorDistribution):

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -58,7 +58,7 @@ def align_tensor(new_inputs, x, expand=False):
     :param funsor.terms.Funsor x: A :class:`Tensor` or
         :class:`~funsor.terms.Number` .
     :param bool expand: If False (default), set result size to 1 for any input
-        of ``x`` not in ``new_inputs``; if True expand to ``new_inputs` size.
+        of ``x`` not in ``new_inputs``; if True expand to ``new_inputs`` size.
     :return: a number or :class:`torch.Tensor` that can be broadcast to other
         tensors with inputs ``new_inputs``.
     :rtype: tuple

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -13,7 +13,8 @@ from funsor.integrate import Integrate
 from funsor.interpreter import interpretation
 from funsor.montecarlo import monte_carlo
 from funsor.pyro.convert import AffineNormal
-from funsor.terms import Binary, Independent, Number, Reduce, Slice, Stack, Subs, Variable, reflect
+from funsor.sum_product import MarkovProduct
+from funsor.terms import Binary, Independent, Stack, Subs, Variable, reflect
 from funsor.testing import xfail_param
 from funsor.torch import Function, Tensor
 
@@ -61,7 +62,7 @@ def test_bart(analytic_kl):
            frozenset(),
            (Tensor(
              torch.tensor([[-0.6077086925506592, -1.1546266078948975, -0.7021151781082153, -0.5303535461425781, -0.6365622282028198, -1.2423288822174072, -0.9941254258155823, -0.6287292242050171], [-0.6987162828445435, -1.0875964164733887, -0.7337473630905151, -0.4713417589664459, -0.6674002408981323, -1.2478348016738892, -0.8939017057418823, -0.5238542556762695]], dtype=torch.float32),  # noqa
-             (('time_b3',
+             (('time_b4',
                bint(2),),
               ('_event_1_b2',
                bint(8),),),
@@ -69,114 +70,59 @@ def test_bart(analytic_kl):
             Gaussian(
              torch.tensor([[[-0.3536059558391571], [-0.21779225766658783], [0.2840439975261688], [0.4531521499156952], [-0.1220812276005745], [-0.05519985035061836], [0.10932210087776184], [0.6656699776649475]], [[-0.39107921719551086], [-0.20241987705230713], [0.2170514464378357], [0.4500560462474823], [0.27945515513420105], [-0.0490039587020874], [-0.06399798393249512], [0.846565842628479]]], dtype=torch.float32),  # noqa
              torch.tensor([[[[1.984686255455017]], [[0.6699360013008118]], [[1.6215802431106567]], [[2.372016668319702]], [[1.77385413646698]], [[0.526767373085022]], [[0.8722561597824097]], [[2.1879124641418457]]], [[[1.6996612548828125]], [[0.7535632252693176]], [[1.4946647882461548]], [[2.642792224884033]], [[1.7301604747772217]], [[0.5203893780708313]], [[1.055436372756958]], [[2.8370864391326904]]]], dtype=torch.float32),  # noqa
-             (('time_b3',
+             (('time_b4',
                bint(2),),
               ('_event_1_b2',
                bint(8),),
               ('value_b1',
                reals(),),)),)),
-          'gate_rate_b4',
+          'gate_rate_b3',
           '_event_1_b2',
           'value_b1'),
          'gate_rate_t',
-         'time_b3',
-         'gate_rate_b4')
-        p_prior = Reduce(ops.logaddexp,
-         Binary(ops.add,
-          Subs(
-           Reduce(ops.logaddexp,
-            Binary(ops.add,
+         'time_b4',
+         'gate_rate_b3')
+        p_prior = Contraction(ops.logaddexp, ops.add,
+         frozenset({'state(time=1)_b11', 'state_b10'}),
+         (MarkovProduct(ops.logaddexp, ops.add,
+           Contraction(ops.nullop, ops.add,
+            frozenset(),
+            (Tensor(
+              torch.tensor(2.7672932147979736, dtype=torch.float32),
+              (),
+              'real'),
+             Gaussian(
+              torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
+              torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
+              (('state_b7',
+                reals(2,),),
+               ('state(time=1)_b8',
+                reals(2,),),)),
              Subs(
-              Binary(ops.add,
-               Binary(ops.add,
-                Tensor(
-                 torch.tensor(2.7672932147979736, dtype=torch.float32),
-                 (),
-                 'real'),
-                Subs(
-                 Subs(
-                  Gaussian(
-                   torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
-                   torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
-                   (('state_b13',
-                     reals(2,),),
-                    ('state(time=1)_b7',
-                     reals(2,),),)),
-                  ()),
-                 ())),
-               Subs(
-                AffineNormal(
-                 Tensor(
-                  torch.tensor([[0.03488487750291824, 0.07356668263673782, 0.19946961104869843, 0.5386509299278259, -0.708323061466217, 0.24411526322364807, -0.20855577290058136, -0.2421337217092514], [0.41762110590934753, 0.5272183418273926, -0.49835553765296936, -0.0363837406039238, -0.0005282597267068923, 0.2704298794269562, -0.155222088098526, -0.44802337884902954]], dtype=torch.float32),  # noqa
-                  (),
-                  'real'),
-                 Tensor(
-                  torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
-                  (('time_b8',
-                    bint(2),),),
-                  'real'),
-                 Tensor(
-                  torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
-                  (('time_b8',
-                    bint(2),),),
-                  'real'),
-                 Variable('state(time=1)_b7', reals(2,)),
-                 Variable('gate_rate_b6', reals(8,))),
-                (('gate_rate_b6',
-                  Binary(ops.GetitemOp(0),
-                   Variable('gate_rate_t', reals(2, 8)),
-                   Variable('time_b8', bint(2))),),))),
-              (('state(time=1)_b7',
-                Variable('_drop_0_b11', reals(2,)),),
-               ('time_b8',
-                Slice('time_b12', 0, 2, 2, 2),),)),
-             Subs(
-              Binary(ops.add,
-               Binary(ops.add,
-                Tensor(
-                 torch.tensor(2.7672932147979736, dtype=torch.float32),
-                 (),
-                 'real'),
-                Subs(
-                 Subs(
-                  Gaussian(
-                   torch.tensor([-0.0, -0.0, 0.0, 0.0], dtype=torch.float32),
-                   torch.tensor([[98.01002502441406, 0.0, -99.0000228881836, -0.0], [0.0, 98.01002502441406, -0.0, -99.0000228881836], [-99.0000228881836, -0.0, 100.0000228881836, 0.0], [-0.0, -99.0000228881836, 0.0, 100.0000228881836]], dtype=torch.float32),  # noqa
-                   (('state_b9',
-                     reals(2,),),
-                    ('state(time=1)_b14',
-                     reals(2,),),)),
-                  ()),
-                 ())),
-               Subs(
-                AffineNormal(
-                 Tensor(
-                  torch.tensor([[0.03488487750291824, 0.07356668263673782, 0.19946961104869843, 0.5386509299278259, -0.708323061466217, 0.24411526322364807, -0.20855577290058136, -0.2421337217092514], [0.41762110590934753, 0.5272183418273926, -0.49835553765296936, -0.0363837406039238, -0.0005282597267068923, 0.2704298794269562, -0.155222088098526, -0.44802337884902954]], dtype=torch.float32),  # noqa
-                  (),
-                  'real'),
-                 Tensor(
-                  torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
-                  (('time_b10',
-                    bint(2),),),
-                  'real'),
-                 Tensor(
-                  torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
-                  (('time_b10',
-                    bint(2),),),
-                  'real'),
-                 Variable('state(time=1)_b14', reals(2,)),
-                 Variable('gate_rate_b6', reals(8,))),
-                (('gate_rate_b6',
-                  Binary(ops.GetitemOp(0),
-                   Variable('gate_rate_t', reals(2, 8)),
-                   Variable('time_b10', bint(2))),),))),
-              (('state_b9',
-                Variable('_drop_0_b11', reals(2,)),),
-               ('time_b10',
-                Slice('time_b12', 1, 2, 2, 2),),))),
-            frozenset({'_drop_0_b11'})),
-           (('time_b12',
-             Number(0, 1),),)),
+              AffineNormal(
+               Tensor(
+                torch.tensor([[0.03488487750291824, 0.07356668263673782, 0.19946961104869843, 0.5386509299278259, -0.708323061466217, 0.24411526322364807, -0.20855577290058136, -0.2421337217092514], [0.41762110590934753, 0.5272183418273926, -0.49835553765296936, -0.0363837406039238, -0.0005282597267068923, 0.2704298794269562, -0.155222088098526, -0.44802337884902954]], dtype=torch.float32),  # noqa
+                (),
+                'real'),
+               Tensor(
+                torch.tensor([[-0.003566693514585495, -0.2848514914512634, 0.037103548645973206, 0.12648648023605347, -0.18501518666744232, -0.20899859070777893, 0.04121830314397812, 0.0054807960987091064], [0.0021788496524095535, -0.18700894713401794, 0.08187370002269745, 0.13554862141609192, -0.10477752983570099, -0.20848378539085388, -0.01393645629286766, 0.011670656502246857]], dtype=torch.float32),  # noqa
+                (('time_b9',
+                  bint(2),),),
+                'real'),
+               Tensor(
+                torch.tensor([[0.5974780917167664, 0.864071786403656, 1.0236268043518066, 0.7147538065910339, 0.7423890233039856, 0.9462157487869263, 1.2132389545440674, 1.0596832036972046], [0.5787821412086487, 0.9178534150123596, 0.9074794054031372, 0.6600189208984375, 0.8473222255706787, 0.8426999449729919, 1.194266438484192, 1.0471148490905762]], dtype=torch.float32),  # noqa
+                (('time_b9',
+                  bint(2),),),
+                'real'),
+               Variable('state(time=1)_b8', reals(2,)),
+               Variable('gate_rate_b6', reals(8,))),
+              (('gate_rate_b6',
+                Binary(ops.GetitemOp(0),
+                 Variable('gate_rate_t', reals(2, 8)),
+                 Variable('time_b9', bint(2))),),)),)),
+           Variable('time_b9', bint(2)),
+           frozenset({('state_b7', 'state(time=1)_b8')}),
+           frozenset({('state(time=1)_b8', 'state(time=1)_b11'), ('state_b7', 'state_b10')})),  # noqa
           Subs(
            dist.MultivariateNormal(
             Tensor(
@@ -189,69 +135,66 @@ def test_bart(analytic_kl):
              'real'),
             Variable('value_b5', reals(2,))),
            (('value_b5',
-             Variable('state_b13', reals(2,)),),))),
-         frozenset({'state(time=1)_b14', 'state_b13'}))
-        p_likelihood = Reduce(ops.add,
-         Reduce(ops.logaddexp,
-          Binary(ops.add,
-           dist.Categorical(
-            Binary(ops.GetitemOp(0),
+             Variable('state_b10', reals(2,)),),)),))
+        p_likelihood = Contraction(ops.add, ops.nullop,
+         frozenset({'time_b17', 'destin_b16', 'origin_b15'}),
+         (Contraction(ops.logaddexp, ops.add,
+           frozenset({'gated_b14'}),
+           (dist.Categorical(
              Binary(ops.GetitemOp(0),
-              Subs(
-               Function(unpack_gate_rate_0,
-                reals(2, 2, 2),
-                (Variable('gate_rate_b15', reals(8,)),)),
-               (('gate_rate_b15',
-                 Binary(ops.GetitemOp(0),
-                  Variable('gate_rate_t', reals(2, 8)),
-                  Variable('time_b18', bint(2))),),)),
-              Variable('origin_b20', bint(2))),
-             Variable('destin_b19', bint(2))),
-            Variable('gated_b17', bint(2))),
-           Stack(
-            'gated_b17',
-            (dist.Poisson(
               Binary(ops.GetitemOp(0),
+               Subs(
+                Function(unpack_gate_rate_0,
+                 reals(2, 2, 2),
+                 (Variable('gate_rate_b12', reals(8,)),)),
+                (('gate_rate_b12',
+                  Binary(ops.GetitemOp(0),
+                   Variable('gate_rate_t', reals(2, 8)),
+                   Variable('time_b17', bint(2))),),)),
+               Variable('origin_b15', bint(2))),
+              Variable('destin_b16', bint(2))),
+             Variable('gated_b14', bint(2))),
+            Stack('gated_b14',
+             (dist.Poisson(
                Binary(ops.GetitemOp(0),
-                Subs(
-                 Function(unpack_gate_rate_1,
-                  reals(2, 2),
-                  (Variable('gate_rate_b16', reals(8,)),)),
-                 (('gate_rate_b16',
-                   Binary(ops.GetitemOp(0),
-                    Variable('gate_rate_t', reals(2, 8)),
-                    Variable('time_b18', bint(2))),),)),
-                Variable('origin_b20', bint(2))),
-               Variable('destin_b19', bint(2))),
-              Tensor(
-               torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
-               (('time_b18',
-                 bint(2),),
-                ('origin_b20',
-                 bint(2),),
-                ('destin_b19',
-                 bint(2),),),
-               'real')),
-             dist.Delta(
-              Tensor(
-               torch.tensor(0.0, dtype=torch.float32),
-               (),
-               'real'),
-              Tensor(
-               torch.tensor(0.0, dtype=torch.float32),
-               (),
-               'real'),
-              Tensor(
-               torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
-               (('time_b18',
-                 bint(2),),
-                ('origin_b20',
-                 bint(2),),
-                ('destin_b19',
-                 bint(2),),),
-               'real')),))),
-          frozenset({'gated_b17'})),
-         frozenset({'time_b18', 'origin_b20', 'destin_b19'}))
+                Binary(ops.GetitemOp(0),
+                 Subs(
+                  Function(unpack_gate_rate_1,
+                   reals(2, 2),
+                   (Variable('gate_rate_b13', reals(8,)),)),
+                  (('gate_rate_b13',
+                    Binary(ops.GetitemOp(0),
+                     Variable('gate_rate_t', reals(2, 8)),
+                     Variable('time_b17', bint(2))),),)),
+                 Variable('origin_b15', bint(2))),
+                Variable('destin_b16', bint(2))),
+               Tensor(
+                torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
+                (('time_b17',
+                  bint(2),),
+                 ('origin_b15',
+                  bint(2),),
+                 ('destin_b16',
+                  bint(2),),),
+                'real')),
+              dist.Delta(
+               Tensor(
+                torch.tensor(0.0, dtype=torch.float32),
+                (),
+                'real'),
+               Tensor(
+                torch.tensor(0.0, dtype=torch.float32),
+                (),
+                'real'),
+               Tensor(
+                torch.tensor([[[1.0, 1.0], [5.0, 0.0]], [[0.0, 6.0], [19.0, 3.0]]], dtype=torch.float32),  # noqa
+                (('time_b17',
+                  bint(2),),
+                 ('origin_b15',
+                  bint(2),),
+                 ('destin_b16',
+                  bint(2),),),
+                'real')),)),)),))
 
     if analytic_kl:
         exact_part = funsor.Integrate(q, p_prior - q, frozenset(["gate_rate_t"]))

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -1,4 +1,3 @@
-import warnings
 
 import pyro.distributions as dist
 import pytest
@@ -177,11 +176,7 @@ def test_gaussian_hmm_log_prob(init_shape, trans_mat_shape, trans_mvn_shape,
     data = obs_dist.expand(shape).sample()
     assert data.shape == actual_dist.shape()
 
-    # https://github.com/pyro-ppl/funsor/issues/184
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
     actual_log_prob = actual_dist.log_prob(data)
-
     expected_log_prob = expected_dist.log_prob(data)
     assert_close(actual_log_prob, expected_log_prob, atol=1e-5, rtol=1e-5)
     check_expand(actual_dist, data)
@@ -411,11 +406,7 @@ def test_gaussian_hmm_log_prob_null_dynamics(init_shape, trans_mat_shape, trans_
     data = obs_dist.expand(shape).sample()
     assert data.shape == actual_dist.shape()
 
-    # https://github.com/pyro-ppl/funsor/issues/184
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
     actual_log_prob = actual_dist.log_prob(data)
-
     expected_log_prob = expected_dist.log_prob(data)
 
     assert_close(actual_log_prob, expected_log_prob, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Addresses #228 

This adds `MarkovProduct` as a lazy `sequential_sum_product()`. Changes include:
- Refactor `sequential_sum_product()` to input `time` as a `Variable` rather than string
  (for the same reason as #233 ).
- Refactor `GaussianHMM` and `GaussianMRF` to use `MarkovProduct`. Note that `DiscreteHMM` cannot be converted until we allow `bint()` domains with nontrivial shape.
- Fixed some docs.

## Tested
- added `MarkovProduct` cases to test_sum_product.py
- `GaussianHMM` and `GaussianMRF` refactoring is covered by test/pyro/test_hmm.py
- updated test/examples/test_bart.py to use `MarkovProduct`
- ran `make docs` locally