### PR TITLE
Dispatch to either torch.cholesky() or torch.sqrt()

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -38,6 +38,16 @@ def _trace_mm(x, y):
     return (x * y).sum([-1, -2])
 
 
+def cholesky(u):
+    """
+    Like :func:`torch.cholesky` but uses sqrt for scalar matrices.
+    Works around https://github.com/pytorch/pytorch/issues/24403 often.
+    """
+    if u.size(-1) == 1:
+        return u.sqrt()
+    return u.cholesky()
+
+
 def cholesky_solve(b, u):
     """
     Like :func:`torch.cholesky_solve` but supports gradients.
@@ -300,7 +310,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
     @lazy_property
     def _precision_chol(self):
-        return self.precision.cholesky()
+        return cholesky(self.precision)
 
     @lazy_property
     def log_normalizer(self):
@@ -461,7 +471,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
                 prec_aa = self.precision[..., a.unsqueeze(-1), a]
                 prec_ba = self.precision[..., b.unsqueeze(-1), a]
                 prec_bb = self.precision[..., b.unsqueeze(-1), b]
-                prec_b = prec_bb.cholesky()
+                prec_b = cholesky(prec_bb)
                 prec_a = prec_ba.triangular_solve(prec_b, upper=False).solution
                 prec_at = prec_a.transpose(-1, -2)
                 precision = prec_aa - prec_at.matmul(prec_a)

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -11,7 +11,7 @@ import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.delta import Delta
 from funsor.domains import bint
-from funsor.gaussian import Gaussian, align_gaussian, cholesky_solve, cholesky_inverse
+from funsor.gaussian import Gaussian, align_gaussian, cholesky, cholesky_inverse, cholesky_solve
 from funsor.ops import AssociativeOp
 from funsor.terms import Funsor, Independent, Number, Reduce, Unary, eager, moment_matching, normalize
 from funsor.torch import Tensor, align_tensor
@@ -115,7 +115,7 @@ def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gauss
         mask = (total.data == 0).to(total.data.dtype).unsqueeze(-1).unsqueeze(-1)
         new_cov.data += mask * torch.eye(new_cov.data.size(-1))
 
-        new_precision = Tensor(cholesky_inverse(new_cov.data.cholesky()), new_cov.inputs)
+        new_precision = Tensor(cholesky_inverse(cholesky(new_cov.data)), new_cov.inputs)
         new_info_vec = new_precision.data.matmul(new_loc.data.unsqueeze(-1)).squeeze(-1)
         new_inputs = new_loc.inputs.copy()
         new_inputs.update((k, d) for k, d in gaussian.inputs.items() if d.dtype == 'real')

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -26,7 +26,7 @@ from funsor.cnf import Contraction
 from funsor.delta import Delta
 from funsor.distributions import BernoulliLogits, MultivariateNormal, Normal
 from funsor.domains import bint, reals
-from funsor.gaussian import Gaussian, align_tensors, cholesky_solve
+from funsor.gaussian import Gaussian, align_tensors, cholesky_solve, cholesky
 from funsor.interpreter import gensym
 from funsor.terms import Funsor, Independent, Variable, eager
 from funsor.torch import Tensor
@@ -171,7 +171,7 @@ def funsor_to_mvn(gaussian, ndims, event_inputs=()):
     assert isinstance(gaussian, Gaussian)
 
     precision = gaussian.precision
-    loc = gaussian.info_vec.unsqueeze(-1).cholesky_solve(precision.cholesky()).squeeze(-1)
+    loc = cholesky_solve(gaussian.info_vec.unsqueeze(-1), cholesky(precision)).squeeze(-1)
 
     int_inputs = OrderedDict((k, d) for k, d in gaussian.inputs.items() if d.dtype != "real")
     loc = Tensor(loc, int_inputs)


### PR DESCRIPTION
This implements a custom `cholesky()` function that dispatches to either `torch.cholesky()` for nontrivial matrices or `torch.sqrt()` for 1x1 matrices. In practice `funsor.Gaussian` is often used for large batches of diagonal gaussians.

This PR has the important side effect of working around a MAGMA bug https://github.com/pytorch/pytorch/issues/24403 

## Tested
- refactoring is exercised by existing tests
- tested with BART example on CUDA (which fails before this PR, due to a MAGMA bug)