### PR TITLE
Add adjoint methods to support backwards marginal through MarkovProduct

### DIFF
--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -259,7 +259,7 @@ def _scatter(src, res, subs):
     for k, v in res.inputs.items():
         if k not in src.inputs and isinstance(subs[k], Number):
             src_inputs[k] = bint(1)
-            src_data = src_data.unsqueeze(-1)
+            src_data = src_data.unsqueeze(-1 - len(src.output.shape))
     src = Tensor(src_data, src_inputs, src.output.dtype).align(tuple(res.inputs.keys()))
 
     data = res.data

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -41,10 +41,12 @@ class AdjointTape(object):
         self._old_interpretation = None
 
     def __call__(self, cls, *args):
-        with interpretation(self._old_interpretation):
-            result = cls(*args)
-        if issubclass(cls, (Reduce, Contraction, Binary, Tensor, Subs, Cat)):  # TODO make generic
+        if cls in adjoint_ops:  # atomic op, don't trace internals
+            with interpretation(self._old_interpretation):
+                result = cls(*args)
             self.tape.append((result, cls, args))
+        else:
+            result = self._old_interpretation(cls, *args)
         return result
 
     def __enter__(self):

--- a/funsor/registry.py
+++ b/funsor/registry.py
@@ -32,6 +32,9 @@ class KeyedRegistry(object):
             return self.registry[key](*args, **kwargs)
         return self.default(*args, **kwargs)
 
+    def __contains__(self, key):
+        return key in self.registry
+
 
 __all__ = [
     'KeyedRegistry',

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -188,7 +188,7 @@ def test_optimized_plated_einsum_adjoint(equation, plates, backend):
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
 
-@pytest.mark.parametrize('num_steps', [2 ** k for k in [1, 2, 3, 4]])  # list(range(3, 13)))
+@pytest.mark.parametrize('num_steps', list(range(3, 13)))
 @pytest.mark.parametrize('sum_op,prod_op,state_domain', [
     (ops.add, ops.mul, bint(2)),
     (ops.add, ops.mul, bint(3)),
@@ -203,7 +203,7 @@ def test_optimized_plated_einsum_adjoint(equation, plates, backend):
 @pytest.mark.parametrize('impl', [
     sequential_sum_product,
     naive_sequential_sum_product,
-    MarkovProduct,  # reason="something missing?"),
+    xfail_param(MarkovProduct, reason="something missing?"),
 ])
 def test_sequential_sum_product_adjoint_discrete(impl, sum_op, prod_op, batch_inputs, state_domain, num_steps):
     # test mostly copied from test_sum_product.py

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -175,7 +175,7 @@ def test_optimized_plated_einsum_adjoint(equation, plates, backend):
 @pytest.mark.parametrize('impl', [
     sequential_sum_product,
     naive_sequential_sum_product,
-    xfail_param(MarkovProduct, reason="something missing?"),
+    MarkovProduct,
 ])
 def test_sequential_sum_product_adjoint_discrete(impl, sum_op, prod_op, batch_inputs, state_domain, num_steps):
     # test mostly copied from test_sum_product.py


### PR DESCRIPTION
Addresses #228 

This PR adds adjoint machinery necessary for computing backward marginals through `sequential_sum_product`.  In particular, it adds general adjoint methods for `Subs` of `Tensor` and for `Cat`, completing support for the operations appearing in `sequential_sum_product` and unblocking the adjoint experiments.  The adjoint for `Subs` of `Tensor` is implemented in such a way that generalizing it to integer variable substitution in `Gaussian`s should be very straightforward, and I'll do that in a followup PR.

I've also simplified `adjoint` slightly by removing the multiplicities that were being tracked previously and removing the one suspect test that required their presence.

Remaining tasks:
- [x] In theory `adjoint` should work for eager `MarkovProduct` evaluation as well, but even though it simply calls `sequential_sum_product` internally, the test cases that call `MarkovProduct` are failing.  I'm not sure what's happening there, but would like to include a fix in this PR. (Update: fixed)

Tested:
- Added test comparing serial and parallel sequential sum product adjoints