### PR TITLE
fix broken docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ multipledispatch
 numpy>=1.7
 opt_einsum>=2.3.2
 unification
-pytest
+pytest>=4.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ multipledispatch
 numpy>=1.7
 opt_einsum>=2.3.2
 unification
+pytest


### PR DESCRIPTION
docs are broken which makes it difficult to look up method type signatures.  it's because `funsor/testing.py` is in `funsor/` and not `test/`.  is there a reason for this? in pyro the same functions live in `tests/common.py`.  for now i did the less invasive thing of adding pytest to the rtd requirements but it seems that the only place testing.py is used is in `test/`