### PR TITLE
Add MultivariateNormal pattern for Binary to cover matmul

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -12,7 +12,7 @@ from funsor.cnf import Contraction
 from funsor.domains import bint, reals
 from funsor.gaussian import BlockMatrix, BlockVector, Gaussian
 from funsor.interpreter import interpretation
-from funsor.terms import Funsor, FunsorMeta, Number, Variable, eager, lazy, to_funsor
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, Variable, eager, lazy, to_funsor
 from funsor.torch import Tensor, align_tensors, ignore_jit_warnings, materialize, torch_stack
 
 
@@ -452,9 +452,9 @@ def eager_mvn(loc, scale_tril, value):
 # Create a Gaussian from a ground observation.
 # TODO refactor this logic into Gaussian.eager_subs() and
 #   here return Gaussian(...scale_tril...)(value=loc-value).
-@eager.register(MultivariateNormal, (Variable, Contraction), Tensor, (Variable, Contraction))
-@eager.register(MultivariateNormal, (Variable, Contraction), Tensor, Tensor)
-@eager.register(MultivariateNormal, Tensor, Tensor, (Variable, Contraction))
+@eager.register(MultivariateNormal, (Variable, Contraction, Binary), Tensor, (Variable, Contraction, Binary))
+@eager.register(MultivariateNormal, (Variable, Contraction, Binary), Tensor, Tensor)
+@eager.register(MultivariateNormal, Tensor, Tensor, (Variable, Contraction, Binary))
 def eager_mvn(loc, scale_tril, value):
     assert len(loc.shape) == 1
     assert len(scale_tril.shape) == 2

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -523,6 +523,17 @@ def test_mvn_affine_matmul():
     m = Tensor(torch.randn(2, 3))
     data = dict(x=Tensor(torch.randn(2)), y=Tensor(torch.randn(3)))
     with interpretation(lazy):
+        d = random_mvn((), 3)
+        d = dist.MultivariateNormal(loc=y, scale_tril=d.scale_tril, value=x @ m)
+    _check_mvn_affine(d, data)
+
+
+def test_mvn_affine_matmul_sub():
+    x = Variable('x', reals(2))
+    y = Variable('y', reals(3))
+    m = Tensor(torch.randn(2, 3))
+    data = dict(x=Tensor(torch.randn(2)), y=Tensor(torch.randn(3)))
+    with interpretation(lazy):
         d = dist_to_funsor(random_mvn((), 3))
         d = d(value=x @ m - y)
     _check_mvn_affine(d, data)


### PR DESCRIPTION
Unblocks #246 

This adds a pattern for `Binary` to the `MultivariateNormal` pattern matching code. Note this pattern is more complete but still unsound; soundness will be addressed by `.is_affine` #72

## Tested
- added a unit test