### PR TITLE
Refactor to reduce size of stack traces for debugging

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -199,20 +199,24 @@ def eager_contraction_generic_recursive(red_op, bin_op, reduced_vars, terms):
 
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Funsor)
 def eager_contraction_to_reduce(red_op, bin_op, reduced_vars, term):
-    return eager.dispatch(Reduce, red_op, term, reduced_vars)
+    args = red_op, term, reduced_vars
+    return eager.dispatch(Reduce, *args)(*args)
 
 
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Funsor, Funsor)
 def eager_contraction_to_binary(red_op, bin_op, reduced_vars, lhs, rhs):
 
     if reduced_vars - (reduced_vars.intersection(lhs.inputs, rhs.inputs)):
-        result = eager.dispatch(Contraction, red_op, bin_op, reduced_vars, (lhs, rhs))
+        args = red_op, bin_op, reduced_vars, (lhs, rhs)
+        result = eager.dispatch(Contraction, *args)(*args)
         if result is not None:
             return result
 
-    result = eager.dispatch(Binary, bin_op, lhs, rhs)
+    args = bin_op, lhs, rhs
+    result = eager.dispatch(Binary, *args)(*args)
     if result is not None and reduced_vars:
-        result = eager.dispatch(Reduce, red_op, result, reduced_vars)
+        args = red_op, result, reduced_vars
+        result = eager.dispatch(Reduce, *args)(*args)
     return result
 
 

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -62,11 +62,13 @@ def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
 def eager_contraction_binary_to_integrate(red_op, bin_op, reduced_vars, lhs, rhs):
 
     if reduced_vars - reduced_vars.intersection(lhs.inputs, rhs.inputs):
-        result = eager.dispatch(Contraction, red_op, bin_op, reduced_vars, (lhs, rhs))
+        args = red_op, bin_op, reduced_vars, (lhs, rhs)
+        result = eager.dispatch(Contraction, *args)(*args)
         if result is not None:
             return result
 
-    result = eager.dispatch(Integrate, lhs.log(), rhs, reduced_vars)
+    args = lhs.log(), rhs, reduced_vars
+    result = eager.dispatch(Integrate, *args)(*args)
     if result is not None:
         return result
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -15,7 +15,7 @@ def monte_carlo(cls, *args):
     cases.
     """
     # TODO Memoize sample statements in a context manager.
-    result = monte_carlo.dispatch(cls, *args)
+    result = monte_carlo.dispatch(cls, *args)(*args)
     if result is None:
         result = eager(cls, *args)
     return result

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -11,9 +11,9 @@ from funsor.terms import Funsor, eager, lazy, normalize
 
 @interpreter.dispatched_interpretation
 def unfold(cls, *args):
-    result = unfold.dispatch(cls, *args)
+    result = unfold.dispatch(cls, *args)(*args)
     if result is None:
-        result = normalize.dispatch(cls, *args)
+        result = normalize.dispatch(cls, *args)(*args)
     if result is None:
         result = lazy(cls, *args)
     return result
@@ -53,7 +53,7 @@ unfold.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[F
 
 @interpreter.dispatched_interpretation
 def optimize(cls, *args):
-    result = optimize.dispatch(cls, *args)
+    result = optimize.dispatch(cls, *args)(*args)
     if result is None:
         result = eager(cls, *args)
     return result
@@ -128,7 +128,7 @@ def apply_optimizer(x):
 
     @interpreter.interpretation(interpreter._INTERPRETATION)
     def nested_optimize_interpreter(cls, *args):
-        result = optimize.dispatch(cls, *args)
+        result = optimize.dispatch(cls, *args)(*args)
         if result is None:
             result = cls(*args)
         return result

--- a/funsor/registry.py
+++ b/funsor/registry.py
@@ -3,11 +3,44 @@ from collections import defaultdict
 from multipledispatch import Dispatcher
 
 
+class PartialDispatcher(Dispatcher):
+    """
+    Wrapper to avoid appearance in stack traces.
+    """
+    def partial_call(self, *args):
+        """
+        Likde :meth:`__call__` but avoids calling ``func()``.
+        """
+        types = tuple(map(type, args))
+        try:
+            func = self._cache[types]
+        except KeyError:
+            func = self.dispatch(*types)
+            if func is None:
+                raise NotImplementedError(
+                    'Could not find signature for %s: <%s>' %
+                    (self.name, ', '.join(cls.__name__ for cls in types)))
+            self._cache[types] = func
+        return func
+
+
+class PartialDefault:
+    def __init__(self, default):
+        self.default = default
+
+    @property
+    def __call__(self):
+        return self.default
+
+    def partial_call(self, *args):
+        return self.default
+
+
 class KeyedRegistry(object):
 
     def __init__(self, default=None):
-        self.default = default
-        self.registry = defaultdict(lambda: Dispatcher('f'))
+        self.default = default if default is None else PartialDefault(default)
+        self.registry = defaultdict(lambda: PartialDispatcher('f'))
 
     def register(self, key, *types):
         key = getattr(key, "__origin__", key)
@@ -26,14 +59,20 @@ class KeyedRegistry(object):
 
         return decorator
 
-    def __call__(self, key, *args, **kwargs):
-        key = getattr(key, "__origin__", key)
-        if self.default is None or key in self.registry:
-            return self.registry[key](*args, **kwargs)
-        return self.default(*args, **kwargs)
-
     def __contains__(self, key):
         return key in self.registry
+
+    def __getitem__(self, key):
+        key = getattr(key, "__origin__", key)
+        if self.default is None:
+            return self.registry[key]
+        return self.registry.get(key, self.default)
+
+    def __call__(self, key, *args):
+        return self[key](*args)
+
+    def dispatch(self, key, *args):
+        return self[key].partial_call(*args)
 
 
 __all__ = [

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -84,7 +84,7 @@ def reflect(cls, *args, **kwargs):
 @dispatched_interpretation
 def normalize(cls, *args):
 
-    result = normalize.dispatch(cls, *args)
+    result = normalize.dispatch(cls, *args)(*args)
     if result is None:
         result = reflect(cls, *args)
 
@@ -96,7 +96,7 @@ def lazy(cls, *args):
     """
     Substitute eagerly but perform ops lazily.
     """
-    result = lazy.dispatch(cls, *args)
+    result = lazy.dispatch(cls, *args)(*args)
     if result is None:
         result = reflect(cls, *args)
     return result
@@ -107,9 +107,9 @@ def eager(cls, *args):
     """
     Eagerly execute ops with known implementations.
     """
-    result = eager.dispatch(cls, *args)
+    result = eager.dispatch(cls, *args)(*args)
     if result is None:
-        result = normalize.dispatch(cls, *args)
+        result = normalize.dispatch(cls, *args)(*args)
     if result is None:
         result = reflect(cls, *args)
     return result
@@ -124,7 +124,7 @@ def eager_or_die(cls, *args):
 
     :raises: :py:class:`NotImplementedError` no pattern is found.
     """
-    result = eager.dispatch(cls, *args)
+    result = eager.dispatch(cls, *args)(*args)
     if result is None:
         if cls in (Subs, Unary, Binary, Reduce):
             raise NotImplementedError("Missing pattern for {}({})".format(
@@ -139,11 +139,11 @@ def sequential(cls, *args):
     Eagerly execute ops with known implementations; additonally execute
     vectorized ops sequentially if no known vectorized implementation exists.
     """
-    result = sequential.dispatch(cls, *args)
+    result = sequential.dispatch(cls, *args)(*args)
     if result is None:
-        result = eager.dispatch(cls, *args)
+        result = eager.dispatch(cls, *args)(*args)
     if result is None:
-        result = normalize.dispatch(cls, *args)
+        result = normalize.dispatch(cls, *args)(*args)
     if result is None:
         result = reflect(cls, *args)
     return result
@@ -155,11 +155,11 @@ def moment_matching(cls, *args):
     A moment matching interpretation of :class:`Reduce` expressions. This falls
     back to :class:`eager` in other cases.
     """
-    result = moment_matching.dispatch(cls, *args)
+    result = moment_matching.dispatch(cls, *args)(*args)
     if result is None:
-        result = eager.dispatch(cls, *args)
+        result = eager.dispatch(cls, *args)(*args)
     if result is None:
-        result = normalize.dispatch(cls, *args)
+        result = normalize.dispatch(cls, *args)(*args)
     if result is None:
         result = reflect(cls, *args)
     return result


### PR DESCRIPTION
This makes a few refactorings to remove cruft from our stack traces and improve debugging experience, inspired by a [blogpost](https://vorpus.org/blog/beautiful-tracebacks-in-trio-v070) of Nathaniel Smith's.

**Cost:** slightly more verbose syntax to call `my_interpretation.dispatch(-)`:
```diff
- eager.dispatch(Binary, lhs, rhs)
+ eager.dispatch(Binary, lhs, rhs)(lhs, rhs)
```
**Benefits:** much cleaner stack traces, for example:

Before this PR:
```
  /Users/fritzobermeyer/github/pyro-ppl/funsor/test/examples/test_bart.py(207)test_bart()
-> elbo = Integrate(q, p - q, frozenset(["gate_rate_t"]))
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(217)__call__()
-> return interpret(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py(92)interpret()
-> return _INTERPRETATION(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(18)monte_carlo()
-> result = monte_carlo.dispatch(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/registry.py(32)__call__()
-> return self.registry[key](*args, **kwargs)
  /Users/fritzobermeyer/miniconda2/envs/pyro3/lib/python3.7/site-packages/multipledispatch/dispatcher.py(278)__call__()
-> return func(*args, **kwargs)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(49)monte_carlo_integrate()
-> return Integrate(sample, integrand, reduced_vars)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(217)__call__()
-> return interpret(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/interpreter.py(92)interpret()
-> return _INTERPRETATION(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(20)monte_carlo()
-> result = eager(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(112)eager()
-> result = normalize.dispatch(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/registry.py(32)__call__()
-> return self.registry[key](*args, **kwargs)
  /Users/fritzobermeyer/miniconda2/envs/pyro3/lib/python3.7/site-packages/multipledispatch/dispatcher.py(278)__call__()
-> return func(*args, **kwargs)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/integrate.py(54)normalize_integrate_contraction()
-> integrand = integrand(**{name: point for name, (point, log_density) in delta.terms
```
After this PR:
```
  /Users/fritzobermeyer/github/pyro-ppl/funsor/test/examples/test_bart.py(207)test_bart()
-> elbo = Integrate(q, p - q, frozenset(["gate_rate_t"]))
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(217)__call__()
-> return interpret(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(18)monte_carlo()
-> result = monte_carlo.dispatch(cls, *args)(*args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(49)monte_carlo_integrate()
-> return Integrate(sample, integrand, reduced_vars)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(217)__call__()
-> return interpret(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/montecarlo.py(20)monte_carlo()
-> result = eager(cls, *args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/terms.py(112)eager()
-> result = normalize.dispatch(cls, *args)(*args)
  /Users/fritzobermeyer/github/pyro-ppl/funsor/funsor/integrate.py(54)normalize_integrate_contraction()
-> integrand = integrand(**{name: point for name, (point, log_density) in delta.terms
```

## Tested
- pure refactoring is exercised by existing tests