### PR TITLE
Add test of pyro-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ install:
 
     # Keep track of Pyro dev branch
     - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
-    - pip install https://github.com/pyro-ppl/pyro-api/archive/pyroapi-tests.zip
+
+    # Keep track of pyro-api master branch
+    - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
 
     - pip install .[test]
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 
     # Keep track of Pyro dev branch
     - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
+    - pip install https://github.com/pyro-ppl/pyro-api/archive/pyroapi-tests.zip
 
     - pip install .[test]
     - pip freeze

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -3,6 +3,7 @@ from numbers import Number
 
 import numpy as np
 from multipledispatch import Dispatcher
+from torch import tensor
 
 _builtin_abs = abs
 _builtin_max = max
@@ -344,6 +345,7 @@ __all__ = [
     'sigmoid',
     'sqrt',
     'sub',
+    'tensor',
     'truediv',
     'xor',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ line_length = 120
 multi_line_output=3
 not_skip = __init__.py
 known_first_party = funsor, test
-known_third_party = opt_einsum, pyro, torch, torchvision
+known_third_party = opt_einsum, pyro, pyroapi, torch, torchvision
 
 [tool:pytest]
 filterwarnings = error

--- a/test/pyroapi/conftest.py
+++ b/test/pyroapi/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def pytest_runtest_call(item):
+    try:
+        item.runtest()
+    except NotImplementedError as e:
+        pytest.xfail(str(e))

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -3,7 +3,7 @@ from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
 
 
-@pytest.fixture(params=["funsor"])
-def backend(request):
-    with pyro_backend(request.param):
+@pytest.yield_fixture
+def backend():
+    with pyro_backend("funsor"):
         yield

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -1,0 +1,9 @@
+import pytest
+from pyroapi import pyro_backend
+from pyroapi.tests import *  # noqa F401
+
+
+@pytest.fixture(params=["funsor"])
+def backend(request):
+    with pyro_backend(request.param):
+        yield


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro-api/issues/2

This adds tests for the generic `pyro-api`. I think we can copy this pattern in numpyro and pyro nearly verbatim.