### PR TITLE
Add zeros, ones, randn to funsor.compat.ops

### DIFF
--- a/funsor/compat/ops.py
+++ b/funsor/compat/ops.py
@@ -1,0 +1,3 @@
+from torch import ones, randn, tensor, zeros
+
+from .ops import *  # noqa F401

--- a/funsor/compat/ops.py
+++ b/funsor/compat/ops.py
@@ -1,3 +1,3 @@
-from torch import ones, randn, tensor, zeros
+from torch import ones, randn, tensor, zeros  # noqa F401
 
 from .ops import *  # noqa F401

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -3,7 +3,6 @@ from numbers import Number
 
 import numpy as np
 from multipledispatch import Dispatcher
-from torch import tensor
 
 _builtin_abs = abs
 _builtin_max = max
@@ -345,7 +344,6 @@ __all__ = [
     'sigmoid',
     'sqrt',
     'sub',
-    'tensor',
     'truediv',
     'xor',
 ]


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro-api/pull/5

This creates a new `funsor.compat.ops` with zeros, ones, and randn. I've also moved `tensor` here and out of the core `funsor.ops`. After this PR I will update pyroapi.dispatch.