### PR TITLE
Add PatternMissingError and use it for more informative failures in SVI

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -338,7 +338,13 @@ def dispatched_interpretation(fn):
     return fn
 
 
+class PatternMissingError(NotImplementedError):
+    def __str__(self):
+        return f"{super().__str__()}\nThis is most likely due to a missing pattern."
+
+
 __all__ = [
+    'PatternMissingError',
     'dispatched_interpretation',
     'interpret',
     'interpretation',

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -382,7 +382,7 @@ class SVI(object):
             with block(hide_fn=lambda msg: msg["type"] != "param"):
                 loss = self.loss(self.model, self.guide, *args, **kwargs)
         # Differentiate the loss.
-        loss.data.backward()
+        funsor.to_data(loss).backward()
         # Grab all the parameters from the trace.
         params = [site["value"].data.unconstrained()
                   for site in param_capture.values()]
@@ -545,7 +545,7 @@ class Jit(object):
                 result = replay(self.fn, guide_trace=self._param_trace)(*args)
                 assert not result.inputs
                 assert result.output == funsor.reals()
-                return result.data
+                return funsor.to_data(result)
 
             with validation_enabled(False), warnings.catch_warnings():
                 if self.ignore_jit_warnings:

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -206,8 +206,7 @@ def to_funsor(x, output):
 @to_data.register(Array)
 def _to_data_array(x):
     if x.inputs:
-        raise ValueError("cannot convert Array to a data due to lazy inputs: {}"
-                         .format(set(x.inputs)))
+        raise ValueError(f"cannot convert Array to data due to lazy inputs: {set(x.inputs)}")
     return x.data
 
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -13,7 +13,7 @@ from multipledispatch.variadic import Variadic, isvariadic
 import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.domains import Domain, bint, find_domain, reals
-from funsor.interpreter import dispatched_interpretation, interpret
+from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.util import getargspec, lazy_property, pretty, quote
 
@@ -774,14 +774,17 @@ def to_data(x):
 
     :param x: An object, possibly a :class:`Funsor`.
     :return: A non-funsor equivalent to ``x``.
-    :raises: ValueError
+    :raises: ValueError if any free variables remain.
+    :raises: PatternMissingError if funsor is not fully evaluated.
     """
     return x
 
 
 @to_data.register(Funsor)
 def _to_data_funsor(x):
-    raise ValueError("cannot convert to a non-Funsor: {}".format(repr(x)))
+    if x.inputs:
+        raise ValueError(f"cannot convert {type(x)} to data due to lazy inputs: {set(x.inputs)}")
+    raise PatternMissingError(r"cannot convert to a non-Funsor: {repr(x)}")
 
 
 class Variable(Funsor):

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -397,8 +397,7 @@ def to_funsor(x, output):
 @to_data.register(Tensor)
 def _to_data_tensor(x):
     if x.inputs:
-        raise ValueError("cannot convert Tensor to a data due to lazy inputs: {}"
-                         .format(set(x.inputs)))
+        raise ValueError(f"cannot convert Tensor to data due to lazy inputs: {set(x.inputs)}")
     return x.data
 
 


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro-api/pull/5

Most failures of SVI tests (including the current test_mean_field_elbo in pyroapi) fail due to missing patterns. This Pr makes such patterns raise a NotImplementedError, actually a more informative subclass PatternMissingError

## Tested
- ran pyroapi tests and got xfailures as expected