### PR TITLE
Accept more types to .reduce(), .sample(), Integrate()

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -65,7 +65,7 @@ def main(args):
         p = p.reduce(ops.add, {'x', 'y'})
 
         # Construct an elbo. This is where sampling happens.
-        elbo = funsor.Integrate(q, p - q, frozenset(['z']))
+        elbo = funsor.Integrate(q, p - q, 'z')
         elbo = elbo.reduce(ops.add, 'batch') * subsample_scale
         loss = -elbo
         return loss

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -5,13 +5,39 @@ import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.delta import Delta
 from funsor.gaussian import Gaussian, _mv, _trace_mm, _vv, align_gaussian, cholesky_inverse
-from funsor.terms import Funsor, Number, Subs, Unary, Variable, eager, normalize, substitute, to_funsor
+from funsor.terms import (
+    Funsor,
+    FunsorMeta,
+    Number,
+    Subs,
+    Unary,
+    Variable,
+    _convert_reduced_vars,
+    eager,
+    normalize,
+    substitute,
+    to_funsor
+)
 from funsor.torch import Tensor
 
 
-class Integrate(Funsor):
+class IntegrateMeta(FunsorMeta):
+    """
+    Wrapper to convert reduced_vars arg to a frozenset of str.
+    """
+    def __call__(cls, log_measure, integrand, reduced_vars):
+        reduced_vars = _convert_reduced_vars(reduced_vars)
+        return super().__call__(log_measure, integrand, reduced_vars)
+
+
+class Integrate(Funsor, metaclass=IntegrateMeta):
     """
     Funsor representing an integral wrt a log density funsor.
+
+    :param Funsor log_measure: A log density funsor treated as a measure.
+    :param Funsor integrand: An integrand funsor.
+    :param reduced_vars: An input name or set of names to reduce.
+    :type reduced_vars: str, Variable, or set or frozenset thereof.
     """
     def __init__(self, log_measure, integrand, reduced_vars):
         assert isinstance(log_measure, Funsor)

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -197,14 +197,14 @@ def test_bart(analytic_kl):
                 'real')),)),)),))
 
     if analytic_kl:
-        exact_part = funsor.Integrate(q, p_prior - q, frozenset(["gate_rate_t"]))
+        exact_part = funsor.Integrate(q, p_prior - q, "gate_rate_t")
         with interpretation(monte_carlo):
-            approx_part = funsor.Integrate(q, p_likelihood, frozenset(["gate_rate_t"]))
+            approx_part = funsor.Integrate(q, p_likelihood, "gate_rate_t")
         elbo = exact_part + approx_part
     else:
         p = p_prior + p_likelihood
         with interpretation(monte_carlo):
-            elbo = Integrate(q, p - q, frozenset(["gate_rate_t"]))
+            elbo = Integrate(q, p - q, "gate_rate_t")
 
     assert isinstance(elbo, Tensor), elbo.pretty()
     assert call_count == 1

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -490,6 +490,6 @@ def test_mc_plate_gaussian():
     integrand = Gaussian(torch.randn((100, 1)) + 3., torch.ones((100, 1, 1)),
                          (('data', bint(100)), ('loc', reals())))
 
-    res = Integrate(log_measure.sample(frozenset({'loc'})), integrand, frozenset({'loc'}))
-    res = res.reduce(ops.mul, frozenset({'data'}))
+    res = Integrate(log_measure.sample('loc'), integrand, 'loc')
+    res = res.reduce(ops.mul, 'data')
     assert not torch.isinf(res).any()

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -2,12 +2,13 @@ from collections import OrderedDict
 
 import pytest
 
+from funsor import ops
 from funsor.domains import bint
 from funsor.integrate import Integrate
 from funsor.interpreter import interpretation
 from funsor.montecarlo import monte_carlo
-from funsor.terms import eager, lazy, moment_matching, normalize, reflect
-from funsor.testing import random_tensor
+from funsor.terms import Variable, eager, lazy, moment_matching, normalize, reflect
+from funsor.testing import assert_close, random_tensor
 
 
 @pytest.mark.parametrize('interp', [
@@ -16,4 +17,17 @@ def test_integrate(interp):
     log_measure = random_tensor(OrderedDict([('i', bint(2)), ('j', bint(3))]))
     integrand = random_tensor(OrderedDict([('j', bint(3)), ('k', bint(4))]))
     with interpretation(interp):
-        Integrate(log_measure, integrand, frozenset(['i', 'j', 'k']))
+        Integrate(log_measure, integrand, {'i', 'j', 'k'})
+
+
+def test_syntactic_sugar():
+    i = Variable("i", bint(3))
+    log_measure = random_tensor(OrderedDict(i=bint(3)))
+    integrand = random_tensor(OrderedDict(i=bint(3)))
+    expected = (log_measure.exp() * integrand).reduce(ops.add, "i")
+    assert_close(Integrate(log_measure, integrand, "i"), expected)
+    assert_close(Integrate(log_measure, integrand, {"i"}), expected)
+    assert_close(Integrate(log_measure, integrand, frozenset(["i"])), expected)
+    assert_close(Integrate(log_measure, integrand, i), expected)
+    assert_close(Integrate(log_measure, integrand, {i}), expected)
+    assert_close(Integrate(log_measure, integrand, frozenset([i])), expected)

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -305,16 +305,16 @@ def test_reduce_moment_matching_moments():
     with interpretation(moment_matching):
         approx = gaussian.reduce(ops.logaddexp, 'j')
     with monte_carlo_interpretation(s=bint(100000)):
-        actual = Integrate(approx, Number(1.), frozenset(['x']))
-        expected = Integrate(gaussian, Number(1.), frozenset(['j', 'x']))
+        actual = Integrate(approx, Number(1.), 'x')
+        expected = Integrate(gaussian, Number(1.), {'j', 'x'})
         assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
-        actual = Integrate(approx, x, frozenset(['x']))
-        expected = Integrate(gaussian, x, frozenset(['j', 'x']))
+        actual = Integrate(approx, x, 'x')
+        expected = Integrate(gaussian, x, {'j', 'x'})
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
-        actual = Integrate(approx, x * x, frozenset(['x']))
-        expected = Integrate(gaussian, x * x, frozenset(['j', 'x']))
+        actual = Integrate(approx, x * x, 'x')
+        expected = Integrate(gaussian, x * x, {'j', 'x'})
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -302,12 +302,16 @@ def test_reduce_subset(op, reduced_vars):
 
 
 def test_reduce_syntactic_sugar():
+    i = Variable("i", bint(3))
     x = Stack("i", (Number(1), Number(2), Number(3)))
     expected = Number(1 + 2 + 3)
     assert x.reduce(ops.add) is expected
     assert x.reduce(ops.add, "i") is expected
     assert x.reduce(ops.add, {"i"}) is expected
     assert x.reduce(ops.add, frozenset(["i"])) is expected
+    assert x.reduce(ops.add, i) is expected
+    assert x.reduce(ops.add, {i}) is expected
+    assert x.reduce(ops.add, frozenset([i])) is expected
 
 
 def test_slice():


### PR DESCRIPTION
Addresses #211 #233 

This adds a `_convert_reduced_vars()` helper used in `.reduce()`, `.sample()`, and `Integrate()` to convert strings, Variables, and sets and frozensets thereof to frozensets of strings. This refactoring will also be useful in #233 .

## Tested
- refactoring is exercised by existing tests
- added unit tests for `.reduce()`, `Integrate()`
- rewrote many examples and tests to use the new sugared syntax