### PR TITLE
Add docstrings for funsor.pyro.hmm classes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,6 +196,6 @@ intersphinx_mapping = {
 
 # @jpchen's hack to get rtd builder to install latest pytorch
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')
+    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')
     # pyro needs to be installed after torch so pyro doesnt install the bloated torch-1.0 wheel
     os.system('pip install pyro-ppl')


### PR DESCRIPTION
Addresses #201 

I've simply copied the corresponding docstrings from pyro.distributions.hmm, and added links back to those and description of differences.