### PR TITLE
Implement eager contract (Tensor,Tensor) via einsum

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -246,7 +246,7 @@ def _eager_contract_tensors(reduced_vars, terms, backend):
     for term in terms:
         inputs.update(term.inputs)
         einsum_inputs.append("".join(symbols[k] for k in term.inputs) +
-                             "".join(symbols[len(term.shape) - i]
+                             "".join(symbols[i - len(term.shape)]
                                      for i, size in enumerate(term.shape)
                                      if size != 1))
 
@@ -263,7 +263,7 @@ def _eager_contract_tensors(reduced_vars, terms, backend):
     event_shape = broadcast_shape(*(term.shape for term in terms))
     einsum_output = ("".join(symbols[k] for k in inputs) +
                      "".join(symbols[dim]
-                             for dim in range(-1, -1 - len(event_shape), -1)
+                             for dim in range(-len(event_shape), 0)
                              if dim in symbols))
     equation = ",".join(einsum_inputs) + "->" + einsum_output
     data = opt_einsum.contract(equation, *operands, backend=backend)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -72,7 +72,7 @@ def partial_sum_product(sum_op, prod_op, factors, eliminate=frozenset(), plates=
         leaf_factors = ordinal_to_factors.pop(leaf)
         leaf_reduce_vars = ordinal_to_vars[leaf]
         for (group_factors, group_vars) in _partition(leaf_factors, leaf_reduce_vars):
-            f = Contraction(sum_op, prod_op, group_vars, group_factors)
+            f = reduce(prod_op, group_factors).reduce(sum_op, group_vars)
             remaining_sum_vars = sum_vars.intersection(f.inputs)
             if not remaining_sum_vars:
                 results.append(f.reduce(prod_op, leaf & eliminate))
@@ -120,7 +120,7 @@ def naive_sequential_sum_product(sum_op, prod_op, trans, time, step):
     while len(factors) > 1:
         y = factors.pop()(**prev_to_drop)
         x = factors.pop()(**curr_to_drop)
-        xy = Contraction(sum_op, prod_op, drop, (x, y))
+        xy = prod_op(x, y).reduce(sum_op, drop)
         factors.append(xy)
     return factors[0]
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -167,7 +167,7 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
         even_duration = duration // 2 * 2
         x = trans(**{time: Slice(time, 0, even_duration, 2, duration)}, **curr_to_drop)
         y = trans(**{time: Slice(time, 1, even_duration, 2, duration)}, **prev_to_drop)
-        contracted = Contraction(sum_op, prod_op, drop, (x, y))
+        contracted = Contraction(sum_op, prod_op, drop, x, y)
         if duration > even_duration:
             extra = trans(**{time: Slice(time, duration - 1, duration)})
             contracted = Cat(time, (contracted, extra))


### PR DESCRIPTION
Addresses #238
Blocked by https://github.com/pyro-ppl/pyro/pull/2065

This implements `Contraction(-,-,-, Tensor, Tensor)` via `einsum`, using either the `torch` or `pyro.ops.einsum.torch_log` backend.

This also starts to use `Contraction()` inside `sequential_sum_product()` so as to make this cheaper op available under the eager interpretation.

## Tested
- refactoring is exercised by existing tests
- added a unit test