### PR TITLE
Implement sound is_affine() test

### DIFF
--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -1,16 +1,96 @@
 from collections import OrderedDict
+from functools import reduce
 
 import opt_einsum
 import torch
+from multipledispatch import dispatch
 
-from funsor.interpreter import gensym
-from funsor.terms import Lambda, Variable, bint
-from funsor.torch import Tensor
+from funsor.cnf import Contraction
+from funsor.interpreter import gensym, interpretation
+from funsor.terms import Binary, Funsor, Lambda, Reduce, Unary, Variable, bint, reflect
+from funsor.torch import Einsum, Tensor
+
+from . import ops
 
 
-# FIXME change this to a sound but incomplete test using pattern matching.
 def is_affine(fn):
-    return True
+    """
+    A sound but incomplete test to determine whether a funsor is affine with
+    respect to all of its real inputs.
+
+    :param Funsor fn: A funsor.
+    :rtype: bool
+    """
+    assert isinstance(fn, Funsor)
+    return _affine_inputs(fn) == _real_inputs(fn)
+
+
+def _real_inputs(fn):
+    return frozenset(k for k, d in fn.inputs.items() if d.dtype == "real")
+
+
+@dispatch(Funsor)
+def _affine_inputs(fn):
+    """
+    Returns a [sound sub]set of real inputs of ``fn``
+    wrt which ``fn`` is known to be affine.
+    """
+    return frozenset()
+
+
+@dispatch(Variable)
+def _affine_inputs(fn):
+    return _real_inputs(fn)
+
+
+@dispatch(Unary)
+def _affine_inputs(fn):
+    if fn.op in (ops.neg, ops.add) or isinstance(fn.op, ops.ReshapeOp):
+        return _affine_inputs(fn.arg)
+    return frozenset()
+
+
+@dispatch(Binary)
+def _affine_inputs(fn):
+    if fn.op in (ops.add, ops.sub):
+        return _affine_inputs(fn.lhs) | _affine_inputs(fn.rhs)
+    if fn.op is ops.truediv:
+        return _affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
+    if isinstance(fn.op, ops.GetitemOp):
+        return _affine_inputs(fn.lhs)
+    if fn.op in (ops.mul, ops.matmul):
+        lhs_affine = _affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
+        rhs_affine = _affine_inputs(fn.rhs) - _real_inputs(fn.lhs)
+        if not lhs_affine:
+            return rhs_affine
+        if not rhs_affine:
+            return lhs_affine
+        # This multilinear case introduces incompleteness, since some vars
+        # could later be reduced, making remaining vars affine.
+        return frozenset()
+    return frozenset()
+
+
+@dispatch(Reduce)
+def _affine_inputs(fn):
+    return _affine_inputs(fn.arg) - fn.reduced_vars
+
+
+@dispatch(Contraction)
+def _affine_inputs(fn):
+    with interpretation(reflect):
+        flat = reduce(fn.bin_op, fn.terms).reduce(fn.red_op, fn.reduced_vars)
+    return _affine_inputs(flat)
+
+
+@dispatch(Einsum)
+def _affine_inputs(fn):
+    result = frozenset()
+    for i, x in enumerate(fn.operands):
+        others = fn.operands[:i] + fn.operands[i+1:]
+        other_inputs = reduce(ops.or_, map(_real_inputs, others), frozenset())
+        result |= _affine_inputs(x) - other_inputs
+    return result
 
 
 def extract_affine(fn):

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -58,21 +58,6 @@ class Contraction(Funsor):
         self.bin_op = bin_op
         self.terms = terms
         self.reduced_vars = reduced_vars
-        self.is_affine = self._is_affine()
-
-    def _is_affine(self):
-        for t in self.terms:
-            if not isinstance(t, (Number, Tensor, Variable, Contraction)):
-                return False
-            if isinstance(t, Contraction):
-                if not ((t.bin_op, self.bin_op) in DISTRIBUTIVE_OPS or (self.bin_op, t.bin_op) in DISTRIBUTIVE_OPS) \
-                        and t.is_affine:
-                    return False
-
-        if self.bin_op is ops.add and self.red_op is not nullop:
-            return sum(1 for k, v in self.inputs.items() if v.dtype == 'real') == \
-                sum(sum(1 for k, v in t.inputs.items() if v.dtype == 'real') for t in self.terms)
-        return True
 
     def unscaled_sample(self, sampled_vars, sample_inputs):
         sampled_vars = sampled_vars.intersection(self.inputs)

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -394,7 +394,7 @@ def eager_normal(loc, scale, value):
 @eager.register(Normal, Tensor, Tensor, (Variable, Contraction))
 def eager_normal(loc, scale, value):
     affine = (loc - value) / scale
-    if not affine.is_affine:
+    if not is_affine(affine):
         return None
 
     real_inputs = OrderedDict((k, v) for k, v in affine.inputs.items() if v.dtype == 'real')

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -90,6 +90,8 @@ def find_domain(op, *domains):
             dtype = 'real'
         elif isinstance(op, ops.ReshapeOp):
             shape = op.shape
+        elif isinstance(op, ops.AssociativeOp):
+            shape = ()
         return Domain(shape, dtype)
 
     lhs, rhs = domains

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -3,12 +3,14 @@ from collections import OrderedDict
 import pytest
 import torch
 
-from funsor.affine import extract_affine
+from funsor.affine import extract_affine, is_affine
 from funsor.cnf import Contraction
 from funsor.domains import bint, reals
 from funsor.terms import Number, Variable
-from funsor.testing import assert_close, check_funsor, random_tensor
+from funsor.testing import assert_close, check_funsor, random_gaussian, random_tensor
 from funsor.torch import Einsum, Tensor
+
+assert random_gaussian  # flake8
 
 SMOKE_TESTS = [
     ('t+x', Contraction),
@@ -39,7 +41,7 @@ def test_smoke(expr, expected_type):
 
     result = eval(expr)
     assert isinstance(result, expected_type)
-    assert result.is_affine
+    assert is_affine(result)
 
 
 SUBS_TESTS = [
@@ -75,7 +77,7 @@ def test_affine_subs(expr, expected_type, expected_inputs):
     result = eval(expr)
     assert isinstance(result, expected_type)
     check_funsor(result, expected_inputs, expected_output)
-    assert result.is_affine
+    assert is_affine(result)
 
 
 @pytest.mark.parametrize('expr', [
@@ -95,6 +97,7 @@ def test_affine_subs(expr, expected_type, expected_inputs):
 ])
 def test_extract_affine(expr):
     x = eval(expr)
+    assert is_affine(x)
     assert isinstance(x, (Contraction, Einsum))
     real_inputs = OrderedDict((k, d) for k, d in x.inputs.items()
                               if d.dtype == 'real')
@@ -116,3 +119,19 @@ def test_extract_affine(expr):
                          for k, (coeff, eqn) in coeffs.items())
     assert isinstance(actual, Tensor)
     assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("expr", [
+    "Variable('x', reals()) ** 2",
+    "Variable('x', reals()) ** 2",
+    "2 ** Variable('x', reals())",
+    "Variable('x', reals()) * Variable('x', reals())",
+    "Variable('x', reals()) * Variable('y', reals())",
+    "Variable('x', reals()) / Variable('y', reals())",
+    "Variable('x', reals()) / Variable('y', reals())",
+    "Variable('x', reals(2,3)) @ Variable('y', reals(3,4))",
+    "random_gaussian(OrderedDict(x=reals()))",
+])
+def test_not_is_affine(expr):
+    x = eval(expr)
+    assert not is_affine(x)

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -131,6 +131,8 @@ def test_extract_affine(expr):
     "Variable('x', reals()) / Variable('y', reals())",
     "Variable('x', reals(2,3)) @ Variable('y', reals(3,4))",
     "random_gaussian(OrderedDict(x=reals()))",
+    "Einsum('abcd,ac->bd',"
+    " (Variable('y', reals(2, 3, 4, 5)), Variable('x', reals(2, 4))))",
 ])
 def test_not_is_affine(expr):
     x = eval(expr)

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -6,7 +6,7 @@ import torch
 from funsor.affine import extract_affine, is_affine
 from funsor.cnf import Contraction
 from funsor.domains import bint, reals
-from funsor.terms import Number, Variable
+from funsor.terms import Number, Unary, Variable
 from funsor.testing import assert_close, check_funsor, random_gaussian, random_tensor
 from funsor.torch import Einsum, Tensor
 
@@ -81,6 +81,8 @@ def test_affine_subs(expr, expected_type, expected_inputs):
 
 
 @pytest.mark.parametrize('expr', [
+    "-Variable('x', reals())",
+    "Variable('x', reals(2)).sum()",
     "Variable('x', reals()) + 0.5",
     "Variable('x', reals(2, 3)) + Variable('y', reals(2, 3))",
     "Variable('x', reals(2)) + Variable('y', reals(2))",
@@ -98,7 +100,7 @@ def test_affine_subs(expr, expected_type, expected_inputs):
 def test_extract_affine(expr):
     x = eval(expr)
     assert is_affine(x)
-    assert isinstance(x, (Contraction, Einsum))
+    assert isinstance(x, (Unary, Contraction, Einsum))
     real_inputs = OrderedDict((k, d) for k, d in x.inputs.items()
                               if d.dtype == 'real')
 
@@ -122,6 +124,10 @@ def test_extract_affine(expr):
 
 
 @pytest.mark.parametrize("expr", [
+    "Variable('x', reals()).log()",
+    "Variable('x', reals()).exp()",
+    "Variable('x', reals()).sigmoid()",
+    "Variable('x', reals(2)).prod()",
     "Variable('x', reals()) ** 2",
     "Variable('x', reals()) ** 2",
     "2 ** Variable('x', reals())",


### PR DESCRIPTION
Addresses #72 

Recall that our affine pattern matching algorithm consists of three steps:
1. (#245) an optimistic (necessarily incomplete) unsound pattern matching step to match possibly affine funsors; 
2. (this PR) a sound but incomplete `is_affine()` test to eliminate non-affine funsors;
3. (#249) an algorithm to substitute in probe funsors and extract affine coefficients from a funsor known to be affine.

This also removes the obsolete `.is_affine` attribute of `Contraction`.

## Tested

- positive cases are exercised by existing tests
- added new positive check and cases to `test_extract_affine()`
- added a new unit test for negative cases