### PR TITLE
Refactor towards Gaussian._eager_subs_affine()

### DIFF
--- a/docs/source/affine.rst
+++ b/docs/source/affine.rst
@@ -1,0 +1,6 @@
+Affine Pattern Matching
+-----------------------
+.. automodule:: funsor.affine
+    :members:
+    :show-inheritance:
+    :member-order: bysource

--- a/docs/source/funsors.rst
+++ b/docs/source/funsors.rst
@@ -51,14 +51,6 @@ Joint
     :show-inheritance:
     :member-order: bysource
 
-Affine
---------
-.. automodule:: funsor.affine
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :member-order: bysource
-
 Contraction
 -----------
 .. automodule:: funsor.cnf

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Funsor is a tensor-like library for functions and distributions
    optimizer
    adjoint
    sum_product
+   affine
    testing
 
 .. toctree::

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -134,6 +134,7 @@ def extract_affine(fn):
     """
     # Determine constant part by evaluating fn at zero.
     inputs = affine_inputs(fn)
+    inputs = OrderedDict((k, v) for k, v in fn.inputs.items() if k in inputs)
     zeros = {k: Tensor(torch.zeros(v.shape)) for k, v in inputs.items()}
     const = fn(**zeros)
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -4,9 +4,8 @@ from functools import reduce, singledispatch
 import opt_einsum
 import torch
 
-from funsor.cnf import Contraction
-from funsor.interpreter import gensym, interpretation
-from funsor.terms import Binary, Funsor, Lambda, Reduce, Unary, Variable, bint, reflect
+from funsor.interpreter import gensym
+from funsor.terms import Binary, Funsor, Lambda, Reduce, Unary, Variable, bint
 from funsor.torch import Einsum, Tensor
 
 from . import ops
@@ -20,46 +19,61 @@ def is_affine(fn):
     :param Funsor fn: A funsor.
     :rtype: bool
     """
-    assert isinstance(fn, Funsor)
-    return _affine_inputs(fn) == _real_inputs(fn)
+    return affine_inputs(fn) == _real_inputs(fn)
 
 
 def _real_inputs(fn):
     return frozenset(k for k, d in fn.inputs.items() if d.dtype == "real")
 
 
-@singledispatch
-def _affine_inputs(fn):
+def affine_inputs(fn):
     """
     Returns a [sound sub]set of real inputs of ``fn``
     wrt which ``fn`` is known to be affine.
+
+    :param Funsor fn: A funsor.
+    :return: A set of input names wrt which ``fn`` is affine.
+    :rtype: frozenset
     """
+    result = getattr(fn, '_affine_inputs', None)
+    if result is None:
+        result = fn._affine_inputs = _affine_inputs(fn)
+    return result
+
+
+@singledispatch
+def _affine_inputs(fn):
+    assert isinstance(fn, Funsor)
     return frozenset()
 
 
-@_affine_inputs.register(Variable)
+# Make registration public.
+affine_inputs.register = _affine_inputs.register
+
+
+@affine_inputs.register(Variable)
 def _(fn):
     return _real_inputs(fn)
 
 
-@_affine_inputs.register(Unary)
+@affine_inputs.register(Unary)
 def _(fn):
     if fn.op in (ops.neg, ops.add) or isinstance(fn.op, ops.ReshapeOp):
-        return _affine_inputs(fn.arg)
+        return affine_inputs(fn.arg)
     return frozenset()
 
 
-@_affine_inputs.register(Binary)
+@affine_inputs.register(Binary)
 def _(fn):
     if fn.op in (ops.add, ops.sub):
-        return _affine_inputs(fn.lhs) | _affine_inputs(fn.rhs)
+        return affine_inputs(fn.lhs) | affine_inputs(fn.rhs)
     if fn.op is ops.truediv:
-        return _affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
+        return affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
     if isinstance(fn.op, ops.GetitemOp):
-        return _affine_inputs(fn.lhs)
+        return affine_inputs(fn.lhs)
     if fn.op in (ops.mul, ops.matmul):
-        lhs_affine = _affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
-        rhs_affine = _affine_inputs(fn.rhs) - _real_inputs(fn.lhs)
+        lhs_affine = affine_inputs(fn.lhs) - _real_inputs(fn.rhs)
+        rhs_affine = affine_inputs(fn.rhs) - _real_inputs(fn.lhs)
         if not lhs_affine:
             return rhs_affine
         if not rhs_affine:
@@ -70,26 +84,19 @@ def _(fn):
     return frozenset()
 
 
-@_affine_inputs.register(Reduce)
+@affine_inputs.register(Reduce)
 def _(fn):
-    return _affine_inputs(fn.arg) - fn.reduced_vars
+    return affine_inputs(fn.arg) - fn.reduced_vars
 
 
-@_affine_inputs.register(Contraction)
-def _(fn):
-    with interpretation(reflect):
-        flat = reduce(fn.bin_op, fn.terms).reduce(fn.red_op, fn.reduced_vars)
-    return _affine_inputs(flat)
-
-
-@_affine_inputs.register(Einsum)
+@affine_inputs.register(Einsum)
 def _(fn):
     # This is simply a multiary version of the above Binary(ops.mul, ...) case.
     results = []
     for i, x in enumerate(fn.operands):
         others = fn.operands[:i] + fn.operands[i+1:]
         other_inputs = reduce(ops.or_, map(_real_inputs, others), frozenset())
-        results.append(_affine_inputs(x) - other_inputs)
+        results.append(affine_inputs(x) - other_inputs)
     # This multilinear case introduces incompleteness, since some vars
     # could later be reduced, making remaining vars affine.
     if sum(map(bool, results)) == 1:
@@ -101,35 +108,39 @@ def _(fn):
 
 def extract_affine(fn):
     """
-    Extracts an affine representation of a funsor, which is exact for affine
-    funsors and approximate otherwise. For affine funsors this satisfies::
+    Extracts an affine representation of a funsor, satisfying::
 
         x = ...
         const, coeffs = extract_affine(x)
         y = sum(Einsum(eqn, (coeff, Variable(var, coeff.output)))
                 for var, (coeff, eqn) in coeffs.items())
         assert_close(y, x)
+        assert frozenset(coeffs) == affine_inputs(x)
+
+    The ``coeffs`` will have one key per input wrt which ``fn`` is known to be
+    affine (via :func:`affine_inputs` ), and ``const`` and ``coeffs.values``
+    will all be constant wrt these inputs.
 
     The affine approximation is computed by ev evaluating ``fn`` at
     zero and each basis vector. To improve performance, users may want to run
     under the :func:`~funsor.memoize.memoize` interpretation.
 
-    :param Funsor fn: A funsor assumed to be affine wrt the (add,mul) semiring.
-       The affine assumption is not checked.
+    :param Funsor fn: A funsor that is affine wrt the (add,mul) semiring in
+        some subset of its inputs.
     :return: A pair ``(const, coeffs)`` where const is a funsor with no real
         inputs and ``coeffs`` is an OrderedDict mapping input name to a
         ``(coefficient, eqn)`` pair in einsum form.
     :rtype: tuple
     """
     # Determine constant part by evaluating fn at zero.
-    real_inputs = OrderedDict((k, v) for k, v in fn.inputs.items() if v.dtype == 'real')
-    zeros = {k: Tensor(torch.zeros(v.shape)) for k, v in real_inputs.items()}
+    inputs = affine_inputs(fn)
+    zeros = {k: Tensor(torch.zeros(v.shape)) for k, v in inputs.items()}
     const = fn(**zeros)
 
     # Determine linear coefficients by evaluating fn on basis vectors.
     name = gensym('probe')
     coeffs = OrderedDict()
-    for k, v in real_inputs.items():
+    for k, v in inputs.items():
         dim = v.num_elements
         var = Variable(name, bint(dim))
         subs = zeros.copy()
@@ -141,3 +152,10 @@ def extract_affine(fn):
         eqn = f'{inputs1},{inputs2}->{output}'
         coeffs[k] = coeff, eqn
     return const, coeffs
+
+
+__all__ = [
+    "affine_inputs",
+    "extract_affine",
+    "is_affine",
+]

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -353,9 +353,9 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
             return self._eager_subs_int(int_subs, real_subs + affine_subs + lazy_subs)
         if real_subs:
             return self._eager_subs_real(real_subs, affine_subs + lazy_subs)
-        # TODO
-        # if affine_subs:
-        #     return self._eager_subs_affine(affine_subs, lazy_subs)
+        if affine_subs:
+            # TODO: return self._eager_subs_affine(affine_subs, lazy_subs)
+            lazy_subs = affine_subs + lazy_subs
         return reflect(Subs, self, lazy_subs)
 
     def _eager_subs_var(self, subs, remaining_subs):


### PR DESCRIPTION
Addresses #72 

This is step 1/3 in implementing affine recognition for Gaussian funsors, and is a pure refactoring PR. This does not actually implement `._eager_affine_subs()`, and I will implement that in step 2/3 and remove the old MultivariateNormal pattern in step 3/3. This PR:
- exposes the old `_affine_inputs()` function as a public `affine_inputs()` function
- adds momoziation to `affine_inputs()`
- moves the `affine_inputs` pattern for Contraction to cnf.py to allow a new dependency chain
  `cnf.py -> gaussian.py -> affine.py` where affine is used inside gaussian
- refactors `extract_affine()` so that it is always correct but produces an affine representation only wrt those inputs that are actually affine. This is both less dangerous and the behavior we will want in `Gaussian._eager_affine()`
- refactors `Gaussian.eager_subs()` into multiple functions.

## Tested
- pure refactoring is covered by existing tests