### PR TITLE
Implement affine pattern recognition for Gaussian substitution

### DIFF
--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -6,7 +6,7 @@ import torch
 from pyro.distributions.util import broadcast_shape
 
 import funsor.ops as ops
-from funsor.affine import extract_affine, is_affine
+from funsor.affine import affine_inputs, extract_affine, is_affine
 from funsor.delta import Delta
 from funsor.domains import reals
 from funsor.ops import AddOp, NegOp, SubOp
@@ -341,14 +341,14 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         # everything else is lazily substituted.
         lazy_subs = tuple((k, v) for k, v in subs
                           if not isinstance(v, (Number, Tensor, Variable, Slice))
-                          and not is_affine(v))
+                          and not (is_affine(v) and affine_inputs(v)))
         var_subs = tuple((k, v) for k, v in subs if isinstance(v, Variable))
         int_subs = tuple((k, v) for k, v in subs if isinstance(v, (Number, Tensor, Slice))
                          if v.dtype != 'real')
         real_subs = tuple((k, v) for k, v in subs if isinstance(v, (Number, Tensor))
                           if v.dtype == 'real')
         affine_subs = tuple((k, v) for k, v in subs
-                            if is_affine(v) and not isinstance(v, Variable))
+                            if is_affine(v) and affine_inputs(v) and not isinstance(v, Variable))
         if var_subs:
             return self._eager_subs_var(var_subs, int_subs + real_subs + affine_subs + lazy_subs)
         if int_subs:

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -485,8 +485,8 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         for old_k, (const, coeffs) in affine.items():
             del new_real_inputs[old_k]
             for new_k, (coeff, eqn) in coeffs.items():
-                new_dim = len(eqn.split('->')[0].split(',')[1])
-                new_real_inputs[new_k] = reals(*coeff.shape[:new_dim])
+                new_shape = coeff.shape[:len(eqn.split('->')[0].split(',')[1])]
+                new_real_inputs[new_k] = reals(*new_shape)
         old_offsets, old_dim = _compute_offsets(old_real_inputs)
         new_offsets, new_dim = _compute_offsets(new_real_inputs)
         new_inputs = new_int_inputs.copy()

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -80,7 +80,8 @@ def test_block_vector_batched(batch_shape):
     assert_close(actual.as_tensor(), expected)
 
 
-def test_block_matrix():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_block_matrix(sparse):
     shape = (10, 10)
     expected = torch.zeros(shape)
     actual = BlockMatrix(shape)
@@ -88,11 +89,12 @@ def test_block_matrix():
     expected[1, 1] = torch.randn(())
     actual[1, 1] = expected[1, 1]
 
-    expected[1, 3:5] = torch.randn(2)
-    actual[1, 3:5] = expected[1, 3:5]
+    if not sparse:
+        expected[1, 3:5] = torch.randn(2)
+        actual[1, 3:5] = expected[1, 3:5]
 
-    expected[3:5, 1] = torch.randn(2)
-    actual[3:5, 1] = expected[3:5, 1]
+        expected[3:5, 1] = torch.randn(2)
+        actual[3:5, 1] = expected[3:5, 1]
 
     expected[3:5, 3:5] = torch.randn(2, 2)
     actual[3:5, 3:5] = expected[3:5, 3:5]
@@ -100,8 +102,9 @@ def test_block_matrix():
     assert_close(actual.as_tensor(), expected)
 
 
+@pytest.mark.parametrize('sparse', [False, True])
 @pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)])
-def test_block_matrix_batched(batch_shape):
+def test_block_matrix_batched(batch_shape, sparse):
     shape = batch_shape + (10, 10)
     expected = torch.zeros(shape)
     actual = BlockMatrix(shape)
@@ -109,11 +112,12 @@ def test_block_matrix_batched(batch_shape):
     expected[..., 1, 1] = torch.randn(batch_shape)
     actual[..., 1, 1] = expected[..., 1, 1]
 
-    expected[..., 1, 3:5] = torch.randn(batch_shape + (2,))
-    actual[..., 1, 3:5] = expected[..., 1, 3:5]
+    if not sparse:
+        expected[..., 1, 3:5] = torch.randn(batch_shape + (2,))
+        actual[..., 1, 3:5] = expected[..., 1, 3:5]
 
-    expected[..., 3:5, 1] = torch.randn(batch_shape + (2,))
-    actual[..., 3:5, 1] = expected[..., 3:5, 1]
+        expected[..., 3:5, 1] = torch.randn(batch_shape + (2,))
+        actual[..., 3:5, 1] = expected[..., 3:5, 1]
 
     expected[..., 3:5, 3:5] = torch.randn(batch_shape + (2, 2))
     actual[..., 3:5, 3:5] = expected[..., 3:5, 3:5]

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -12,7 +12,9 @@ from funsor.gaussian import BlockMatrix, BlockVector, Gaussian, cholesky_inverse
 from funsor.integrate import Integrate
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor
-from funsor.torch import Tensor
+from funsor.torch import Einsum, Tensor
+
+assert Einsum  # flake8
 
 
 @pytest.mark.parametrize("size", [1, 2, 3], ids=str)
@@ -310,6 +312,7 @@ def test_eager_subs_variable():
     (('x', 'Variable("u", reals()) * 2 + 1'),
      ('y', 'Variable("u", reals()) * Tensor(torch.ones(4))'),
      ('z', 'Variable("u", reals()) * Tensor(torch.ones(2, 3))')),
+    (('y', 'Einsum("abc,bc->a", (Tensor(torch.randn(4, 3, 5)), Variable("v", reals(3, 5))))'),),
 ])
 @pytest.mark.parametrize('g_ints', ["", "i", "j", "ij"])
 @pytest.mark.parametrize('subs_ints', ["", "i", "j", "ji"])


### PR DESCRIPTION
Addresses #72 
Follows #284 

This is step 2/3 in implementing affine recognition for Gaussian funsors. This PR:
- implements `Gaussian._eager_subs_affine()`.
- refactors `_find_gaps()` to `_find_intervals()` for nonuniform block slicing in `BlockVector` and `BlockMatrix`.

## Tested
- added a unit test w/ a variety of substitutions and batch shapes
- strengthened tests for `BlockMatrix`