### PR TITLE
Implement generalized sequential sum-product operation

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -198,6 +198,9 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
 
     lags = {get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
+    if not lags:
+        return naive_sequential_sum_product(sum_op, prod_op, trans, time_var, {})
+
     period = int(np.lcm.reduce(list(lags)))
 
     duration = trans.inputs[time].size
@@ -233,6 +236,9 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
 
     lags = {get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
+    if not lags:
+        return sequential_sum_product(sum_op, prod_op, trans, time_var, {})
+
     period = int(np.lcm.reduce(list(lags)))
     original_names = frozenset(name for name in trans.inputs
                                if name != time and not name.startswith("P"))

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -1,8 +1,12 @@
+import re
 from collections import OrderedDict, defaultdict
 from functools import reduce
 
+import numpy as np
+
 import funsor.ops as ops
 from funsor.cnf import Contraction
+from funsor.domains import bint
 from funsor.ops import UNITS, AssociativeOp
 from funsor.terms import Cat, Funsor, FunsorMeta, Number, Slice, Subs, Variable, eager, substitute, to_funsor
 from funsor.util import quote
@@ -174,6 +178,86 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
         trans = contracted
         duration = (duration + 1) // 2
     return trans(**{time: 0})
+
+
+def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
+
+    time = time_var.name
+
+    def get_shift(name):
+        return len(re.search("^P*", name).group(0))
+
+    def shift_name(name, t):
+        return t * "P" + name
+
+    def shift_funsor(f, t):
+        if t == 0:
+            return f
+        return f(**{name: shift_name(name, t) for name in f.inputs if name != time})
+
+    lags = {get_shift(name) for name in trans.inputs if name != time}
+    lags.discard(0)
+    period = int(np.lcm.reduce(list(lags)))
+
+    duration = trans.inputs[time].size
+    if duration % period:
+        raise NotImplementedError("TODO handle partial windows")
+
+    result = trans(**{time: duration - 1})
+    original_names = frozenset(name for name in trans.inputs
+                               if name != time and not name.startswith("P"))
+    for t in range(trans.inputs[time].size - 2, -1, -1):
+        print("RESULT INPUTS 1: {}".format(sorted(set(result.inputs))))
+        result = prod_op(shift_funsor(trans(**{time: t}), duration - t - 1), result)
+        print("RESULT INPUTS 2: {}".format(sorted(set(result.inputs))))
+        sum_vars = frozenset(shift_name(name, duration - t - 1) for name in original_names)
+        print("SUM VARS: {}".format(sorted(sum_vars)))
+        result = result.reduce(sum_op, sum_vars)
+
+    result = result(**{name: name.replace("P" * duration, "P") for name in result.inputs})
+    return result
+
+
+def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
+
+    time = time_var.name
+
+    def get_shift(name):
+        return len(re.search("^P*", name).group(0))
+
+    def shift_name(name, t):
+        return t * "P" + name
+
+    def shift_funsor(f, t):
+        if t == 0:
+            return f
+        return f(**{name: shift_name(name, t) for name in f.inputs if name != time})
+
+    lags = {get_shift(name) for name in trans.inputs if name != time}
+    lags.discard(0)
+    period = int(np.lcm.reduce(list(lags)))
+    original_names = frozenset(name for name in trans.inputs
+                               if name != time and not name.startswith("P"))
+    renamed_factors = []
+    duration = trans.inputs[time].size
+    if duration % period:
+        raise NotImplementedError("TODO handle partial windows")
+
+    for t in range(period):
+        slice_t = Slice(time, t, duration - period + t + 1, period, duration)
+        factor = shift_funsor(trans, period - t - 1)
+        factor = factor(**{time: slice_t})
+        renamed_factors.append(factor)
+
+    block_trans = reduce(prod_op, renamed_factors)
+    block_step = {shift_name(name, period): name for name in block_trans.inputs if name != time}
+    block_time_var = Variable(time_var.name, bint(duration // period))
+    final_chunk = sequential_sum_product(sum_op, prod_op, block_trans, block_time_var, block_step)
+    final_sum_vars = frozenset(
+        shift_name(name, t) for name in original_names for t in range(1, period))
+    result = final_chunk.reduce(sum_op, final_sum_vars)
+    result = result(**{name: name.replace("P" * period, "P") for name in result.inputs})
+    return result
 
 
 class MarkovProductMeta(FunsorMeta):

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -11,8 +11,10 @@ from funsor.optimizer import apply_optimizer
 from funsor.sum_product import (
     MarkovProduct,
     _partition,
+    naive_sarkka_bilmes_product,
     naive_sequential_sum_product,
     partial_sum_product,
+    sarkka_bilmes_product,
     sequential_sum_product,
     sum_product
 )
@@ -247,3 +249,38 @@ def test_sequential_sum_product_bias_2(num_steps, num_sensors, dim):
 
     result = sequential_sum_product(ops.logaddexp, ops.add, factor, time, {"x_prev": "x_curr"})
     assert set(result.inputs) == {"bias", "x_prev", "x_curr"}
+
+
+@pytest.mark.parametrize("duration", [2, 4, 6, 8])
+def test_sarkka_bilmes_example(duration):
+
+    sum_op, prod_op = ops.logaddexp, ops.add
+
+    time_var = Variable("time", bint(duration))
+
+    trans = random_tensor(OrderedDict({
+        "time": bint(duration),
+        "a": bint(4),
+        "b": bint(3),
+        "Pb": bint(3),
+        "c": bint(2),
+        "PPc": bint(2),
+    }))
+
+    expected_inputs = {
+        "a": bint(4),
+        "b": bint(3),
+        "Pb": bint(3),
+        "c": bint(2),
+        "PPc": bint(2),
+        "Pc": bint(2),
+    }
+
+    print("\n")
+    expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    assert dict(expected.inputs) == expected_inputs
+
+    actual = sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    assert dict(actual.inputs) == expected_inputs
+
+    assert_close(actual, expected)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -251,8 +251,39 @@ def test_sequential_sum_product_bias_2(num_steps, num_sensors, dim):
     assert set(result.inputs) == {"bias", "x_prev", "x_curr"}
 
 
+@pytest.mark.parametrize("duration", [2, 3, 4, 5, 6])
+def test_sarkka_bilmes_example_1(duration):
+
+    sum_op, prod_op = ops.logaddexp, ops.add
+
+    time_var = Variable("time", bint(duration))
+
+    trans = random_tensor(OrderedDict({
+        "time": bint(duration),
+        "a": bint(3),
+        "b": bint(2),
+        "Pb": bint(2),
+    }))
+
+    expected_inputs = {
+        "a": bint(3),
+        "b": bint(2),
+        "Pb": bint(2),
+    }
+
+    print("\n")
+    expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    assert dict(expected.inputs) == expected_inputs
+
+    actual = sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    assert dict(actual.inputs) == expected_inputs
+
+    actual = actual.align(tuple(expected.inputs.keys()))
+    assert_close(actual, expected)
+
+
 @pytest.mark.parametrize("duration", [2, 4, 6, 8])
-def test_sarkka_bilmes_example(duration):
+def test_sarkka_bilmes_example_2(duration):
 
     sum_op, prod_op = ops.logaddexp, ops.add
 
@@ -283,4 +314,5 @@ def test_sarkka_bilmes_example(duration):
     actual = sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
     assert dict(actual.inputs) == expected_inputs
 
+    actual = actual.align(tuple(expected.inputs.keys()))
     assert_close(actual, expected)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -367,7 +367,7 @@ def test_matmul(inputs1, inputs2, output_shape1, output_shape2):
     block = {'a': 1, 'b': 2, 'c': 3}
     actual_block = actual(**block)
     expected_block = Tensor(x1(**block).data @ x2(**block).data)
-    assert_close(actual_block, expected_block)
+    assert_close(actual_block, expected_block, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.parametrize('scalar', [0.5])


### PR DESCRIPTION
pair-coded with @fritzo 

Tasks:
- [x] Fix bug in `sequential_sum_product` when `step` contains overlapping variables
- [x] Add more tests

For followup PRs:
- Handle partial windows
- Update interface to follow the subscripting design in #167 
- Change name?