### PR TITLE
Support global variables in sarkka_bilmes_product

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -268,7 +268,7 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozense
     final_chunk = sequential_sum_product(sum_op, prod_op, block_trans, block_time_var, block_step)
     final_sum_vars = frozenset(
         shift_name(name, t) for name in original_names for t in range(1, period))
-    result = final_chunk.reduce(sum_op, final_sum_vars - global_vars)
+    result = final_chunk.reduce(sum_op, final_sum_vars)
     result = result(**{name: name.replace("P" * period, "P") for name in result.inputs})
     return result
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -181,9 +181,8 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     return trans(**{time: 0})
 
 
-def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=None):
+def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozenset()):
 
-    global_vars = frozenset() if global_vars is None else global_vars
     assert isinstance(global_vars, frozenset)
 
     time = time_var.name
@@ -218,15 +217,14 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=No
     for t in range(trans.inputs[time].size - 2, -1, -1):
         result = prod_op(shift_funsor(trans(**{time: t}), duration - t - 1), result)
         sum_vars = frozenset(shift_name(name, duration - t - 1) for name in original_names)
-        result = result.reduce(sum_op, sum_vars - global_vars)
+        result = result.reduce(sum_op, sum_vars)
 
     result = result(**{name: name.replace("P" * duration, "P") for name in result.inputs})
     return result
 
 
-def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=None):
+def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozenset()):
 
-    global_vars = frozenset() if global_vars is None else global_vars
     assert isinstance(global_vars, frozenset)
 
     time = time_var.name

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -181,7 +181,10 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     return trans(**{time: 0})
 
 
-def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
+def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=None):
+
+    global_vars = frozenset() if global_vars is None else global_vars
+    assert isinstance(global_vars, frozenset)
 
     time = time_var.name
 
@@ -194,7 +197,8 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
     def shift_funsor(f, t):
         if t == 0:
             return f
-        return f(**{name: shift_name(name, t) for name in f.inputs if name != time})
+        return f(**{name: shift_name(name, t) for name in f.inputs
+                    if name != time and name not in global_vars})
 
     lags = {get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
@@ -209,17 +213,21 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
 
     result = trans(**{time: duration - 1})
     original_names = frozenset(name for name in trans.inputs
-                               if name != time and not name.startswith("P"))
+                               if name != time and name not in global_vars
+                               and not name.startswith("P"))
     for t in range(trans.inputs[time].size - 2, -1, -1):
         result = prod_op(shift_funsor(trans(**{time: t}), duration - t - 1), result)
         sum_vars = frozenset(shift_name(name, duration - t - 1) for name in original_names)
-        result = result.reduce(sum_op, sum_vars)
+        result = result.reduce(sum_op, sum_vars - global_vars)
 
     result = result(**{name: name.replace("P" * duration, "P") for name in result.inputs})
     return result
 
 
-def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
+def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=None):
+
+    global_vars = frozenset() if global_vars is None else global_vars
+    assert isinstance(global_vars, frozenset)
 
     time = time_var.name
 
@@ -232,7 +240,8 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
     def shift_funsor(f, t):
         if t == 0:
             return f
-        return f(**{name: shift_name(name, t) for name in f.inputs if name != time})
+        return f(**{name: shift_name(name, t) for name in f.inputs
+                    if name != time and name not in global_vars})
 
     lags = {get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
@@ -241,7 +250,8 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
 
     period = int(np.lcm.reduce(list(lags)))
     original_names = frozenset(name for name in trans.inputs
-                               if name != time and not name.startswith("P"))
+                               if name != time and name not in global_vars
+                               and not name.startswith("P"))
     renamed_factors = []
     duration = trans.inputs[time].size
     if duration % period:
@@ -255,12 +265,12 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var):
 
     block_trans = reduce(prod_op, renamed_factors)
     block_step = {shift_name(name, period): name for name in block_trans.inputs
-                  if name != time and get_shift(name) < period}
+                  if name != time and name not in global_vars and get_shift(name) < period}
     block_time_var = Variable(time_var.name, bint(duration // period))
     final_chunk = sequential_sum_product(sum_op, prod_op, block_trans, block_time_var, block_step)
     final_sum_vars = frozenset(
         shift_name(name, t) for name in original_names for t in range(1, period))
-    result = final_chunk.reduce(sum_op, final_sum_vars)
+    result = final_chunk.reduce(sum_op, final_sum_vars - global_vars)
     result = result(**{name: name.replace("P" * period, "P") for name in result.inputs})
     return result
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -251,7 +251,7 @@ def test_sequential_sum_product_bias_2(num_steps, num_sensors, dim):
     assert set(result.inputs) == {"bias", "x_prev", "x_curr"}
 
 
-def _check_sarkka_bilmes(trans, expected_inputs):
+def _check_sarkka_bilmes(trans, expected_inputs, global_vars):
 
     sum_op, prod_op = ops.logaddexp, ops.add
 
@@ -259,10 +259,10 @@ def _check_sarkka_bilmes(trans, expected_inputs):
     duration = trans.inputs["time"].dtype
     time_var = Variable("time", bint(duration))
 
-    expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars)
     assert dict(expected.inputs) == expected_inputs
 
-    actual = sarkka_bilmes_product(sum_op, prod_op, trans, time_var)
+    actual = sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars)
     assert dict(actual.inputs) == expected_inputs
 
     actual = actual.align(tuple(expected.inputs.keys()))
@@ -281,7 +281,7 @@ def test_sarkka_bilmes_example_0(duration):
         "a": bint(3),
     }
 
-    _check_sarkka_bilmes(trans, expected_inputs)
+    _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
 @pytest.mark.parametrize("duration", [2, 3, 4, 5, 6])
@@ -300,7 +300,7 @@ def test_sarkka_bilmes_example_1(duration):
         "Pb": bint(2),
     }
 
-    _check_sarkka_bilmes(trans, expected_inputs)
+    _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
 @pytest.mark.parametrize("duration", [2, 4, 6, 8])
@@ -324,7 +324,7 @@ def test_sarkka_bilmes_example_2(duration):
         "Pc": bint(2),
     }
 
-    _check_sarkka_bilmes(trans, expected_inputs)
+    _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
 @pytest.mark.parametrize("duration", [2, 4, 6, 8])
@@ -344,7 +344,7 @@ def test_sarkka_bilmes_example_3(duration):
         "Pc": bint(2),
     }
 
-    _check_sarkka_bilmes(trans, expected_inputs)
+    _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
 @pytest.mark.parametrize("duration", [3, 6, 9])
@@ -364,4 +364,49 @@ def test_sarkka_bilmes_example_4(duration):
         "Pa": bint(2),
     }
 
-    _check_sarkka_bilmes(trans, expected_inputs)
+    _check_sarkka_bilmes(trans, expected_inputs, frozenset())
+
+
+@pytest.mark.parametrize("duration", [2, 3, 4, 5, 6])
+def test_sarkka_bilmes_example_5(duration):
+
+    trans = random_tensor(OrderedDict({
+        "time": bint(duration),
+        "a": bint(3),
+        "Pa": bint(3),
+        "x": bint(2),
+    }))
+
+    expected_inputs = {
+        "a": bint(3),
+        "Pa": bint(3),
+        "x": bint(2),
+    }
+
+    global_vars = frozenset(["x"])
+
+    _check_sarkka_bilmes(trans, expected_inputs, global_vars)
+
+
+@pytest.mark.parametrize("duration", [3, 6, 9])
+def test_sarkka_bilmes_example_6(duration):
+
+    trans = random_tensor(OrderedDict({
+        "time": bint(duration),
+        "a": bint(2),
+        "Pa": bint(2),
+        "PPPa": bint(2),
+        "x": bint(3),
+    }))
+
+    expected_inputs = {
+        "a": bint(2),
+        "PPa": bint(2),
+        "PPPa": bint(2),
+        "Pa": bint(2),
+        "x": bint(3),
+    }
+
+    global_vars = frozenset(["x"])
+
+    _check_sarkka_bilmes(trans, expected_inputs, global_vars)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -20,7 +20,7 @@ from funsor.sum_product import (
     sum_product
 )
 from funsor.terms import Variable, eager_or_die, moment_matching, reflect
-from funsor.testing import assert_close, random_gaussian, random_tensor, xfail_if_not_implemented
+from funsor.testing import assert_close, random_gaussian, random_tensor
 from funsor.torch import Tensor
 
 
@@ -426,6 +426,7 @@ def test_sarkka_bilmes_example_6(duration):
     (("a", bint(2)), ("b", bint(2)), ("PPb", bint(2))),
     (("a", bint(2)), ("b", bint(2)), ("Pb", bint(2)), ("c", bint(2)), ("PPc", bint(2))),
     (("a", bint(2)), ("Pa", bint(2)), ("PPPa", bint(2))),
+    (("a", bint(2)), ("PPa", bint(2)), ("PPPa", bint(2))),
     # gaussian
     (("a", reals()),),
     (("a", reals()), ("Pa", reals())),
@@ -458,5 +459,10 @@ def test_sarkka_bilmes_generic(time_input, global_inputs, local_inputs):
     else:
         trans = random_tensor(trans_inputs)
 
-    with xfail_if_not_implemented():  # xfail for partial window cases
+    try:
         _check_sarkka_bilmes(trans, expected_inputs, global_vars)
+    except NotImplementedError as e:
+        if 'partial window' in e.args[0]:
+            pytest.xfail(reason=e.args[0])
+        else:
+            raise

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -426,7 +426,7 @@ def test_sarkka_bilmes_example_6(duration):
     (("a", bint(2)), ("b", bint(2)), ("PPb", bint(2))),
     (("a", bint(2)), ("b", bint(2)), ("Pb", bint(2)), ("c", bint(2)), ("PPc", bint(2))),
     (("a", bint(2)), ("Pa", bint(2)), ("PPPa", bint(2))),
-    (("a", bint(2)), ("PPa", bint(2)), ("PPPa", bint(2))),
+    (("a", bint(2)), ("b", bint(2)), ("PPb", bint(2)), ("PPPa", bint(2))),
     # gaussian
     (("a", reals()),),
     (("a", reals()), ("Pa", reals())),
@@ -434,6 +434,7 @@ def test_sarkka_bilmes_example_6(duration):
     (("a", reals()), ("b", reals()), ("PPb", reals())),
     (("a", reals()), ("b", reals()), ("Pb", reals()), ("c", reals()), ("PPc", reals())),
     (("a", reals()), ("Pa", reals()), ("PPPa", reals())),
+    (("a", reals()), ("b", reals()), ("PPb", reals()), ("PPPa", reals())),
     # mv gaussian
     (("a", reals(2)), ("b", reals(2)), ("Pb", reals(2))),
     (("a", reals(2)), ("b", reals(2)), ("PPb", reals(2))),


### PR DESCRIPTION
Addresses #293 

This PR adds a `global_vars` argument to `sarkka_bilmes_product` and `naive_sarkka_bilmes_product` to prevent time-global variables from being eliminated by `sequential_sum_product`.  I've also added a generic parameterized test generalizing the existing example tests with some Gaussian test cases.