### PR TITLE
Add tensor_ops.py

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -5,8 +5,8 @@ from funsor.domains import Domain, bint, find_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.sum_product import MarkovProduct
-from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.tensor_ops import Tensor, arange
+from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.util import pretty, quote
 
 from . import (

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -6,7 +6,7 @@ from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.sum_product import MarkovProduct
 from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
-from funsor.torch import Tensor, arange
+from funsor.tensor_ops import Tensor, arange
 from funsor.util import pretty, quote
 
 from . import (

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -11,7 +11,6 @@ import opt_einsum
 from multipledispatch.variadic import Variadic
 from pyro.distributions.util import broadcast_shape
 
-import funsor
 import funsor.ops as ops
 from funsor.affine import affine_inputs
 from funsor.delta import Delta
@@ -34,6 +33,7 @@ from funsor.terms import (
     reflect,
     to_funsor
 )
+from funsor.torch import Tensor as TorchTensor
 from funsor.util import quote
 
 
@@ -144,7 +144,7 @@ class Contraction(Funsor):
 
 
 GaussianMixture = Contraction[Union[ops.LogAddExpOp, NullOp], ops.AddOp, frozenset,
-                              Tuple[Union[funsor.torch.Tensor, Number], Gaussian]]
+                              Tuple[Union[TorchTensor, Number], Gaussian]]
 
 
 @quote.register(Contraction)
@@ -228,14 +228,14 @@ def eager_contraction_to_binary(red_op, bin_op, reduced_vars, lhs, rhs):
     return result
 
 
-@eager.register(Contraction, ops.AddOp, ops.MulOp, frozenset, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Contraction, ops.AddOp, ops.MulOp, frozenset, TorchTensor, TorchTensor)
 def eager_contraction_tensor(red_op, bin_op, reduced_vars, *terms):
     if not all(term.dtype == "real" for term in terms):
         raise NotImplementedError('TODO')
     return _eager_contract_tensors(reduced_vars, terms, backend="torch")
 
 
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, TorchTensor, TorchTensor)
 def eager_contraction_tensor(red_op, bin_op, reduced_vars, *terms):
     if not all(term.dtype == "real" for term in terms):
         raise NotImplementedError('TODO')
@@ -298,7 +298,7 @@ def _(fn):
 # Normalizing Contractions
 ##########################################
 
-ORDERING = {Delta: 1, Number: 2, funsor.torch.Tensor: 3, Gaussian: 4}
+ORDERING = {Delta: 1, Number: 2, TorchTensor: 3, Gaussian: 4}
 GROUND_TERMS = tuple(ORDERING)
 
 

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -14,8 +14,9 @@ from funsor.affine import is_affine
 from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym, interpretation
+from funsor.tensor_ops import align_tensors, materialize
 from funsor.terms import Funsor, FunsorMeta, Number, Variable, eager, lazy, to_funsor
-from funsor.torch import Tensor, align_tensors, ignore_jit_warnings, materialize, torch_stack
+from funsor.torch import Tensor, ignore_jit_warnings, torch_stack
 
 
 def numbers_to_tensors(*args):
@@ -269,7 +270,7 @@ def eager_categorical(probs, value):
 
 @eager.register(Categorical, Tensor, Variable)
 def eager_categorical(probs, value):
-    value = materialize(value)
+    value = materialize(probs.data, value)
     return Categorical.eager_log_prob(probs=probs, value=value)
 
 

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -17,7 +17,7 @@ from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym, interpretation
 from funsor.tensor_ops import Tensor, align_tensors, is_tensor, materialize
 from funsor.terms import Funsor, FunsorMeta, Number, Variable, eager, lazy, to_funsor
-from funsor.torch import ignore_jit_warnings, torch_stack
+from funsor.torch import Tensor as TorchTensor, ignore_jit_warnings, torch_stack
 
 
 def numbers_to_tensors(*args):
@@ -122,7 +122,7 @@ class BernoulliProbs(Distribution):
         super(BernoulliProbs, self).__init__(probs, value)
 
 
-@eager.register(BernoulliProbs, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(BernoulliProbs, TorchTensor, TorchTensor)
 def eager_bernoulli(probs, value):
     return BernoulliProbs.eager_log_prob(probs=probs, value=value)
 
@@ -148,7 +148,7 @@ class BernoulliLogits(Distribution):
         super(BernoulliLogits, self).__init__(logits, value)
 
 
-@eager.register(BernoulliLogits, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(BernoulliLogits, TorchTensor, TorchTensor)
 def eager_bernoulli_logits(logits, value):
     return BernoulliLogits.eager_log_prob(logits=logits, value=value)
 
@@ -191,7 +191,7 @@ class Beta(Distribution):
         super(Beta, self).__init__(concentration1, concentration0, value)
 
 
-@eager.register(Beta, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Beta, TorchTensor, TorchTensor, TorchTensor)
 def eager_beta(concentration1, concentration0, value):
     return Beta.eager_log_prob(concentration1=concentration1,
                                concentration0=concentration0,
@@ -227,7 +227,7 @@ class Binomial(Distribution):
         super(Binomial, self).__init__(total_count, probs, value)
 
 
-@eager.register(Binomial, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Binomial, TorchTensor, TorchTensor, TorchTensor)
 def eager_binomial(total_count, probs, value):
     return Binomial.eager_log_prob(total_count=total_count, probs=probs, value=value)
 
@@ -259,17 +259,17 @@ class Categorical(Distribution):
         super(Categorical, self).__init__(probs, value)
 
 
-@eager.register(Categorical, Funsor, funsor.torch.Tensor)
+@eager.register(Categorical, Funsor, TorchTensor)
 def eager_categorical(probs, value):
     return probs[value].log()
 
 
-@eager.register(Categorical, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Categorical, TorchTensor, TorchTensor)
 def eager_categorical(probs, value):
     return Categorical.eager_log_prob(probs=probs, value=value)
 
 
-@eager.register(Categorical, funsor.torch.Tensor, Variable)
+@eager.register(Categorical, TorchTensor, Variable)
 def eager_categorical(probs, value):
     value = materialize(probs.data, value)
     return Categorical.eager_log_prob(probs=probs, value=value)
@@ -297,7 +297,7 @@ class Delta(Distribution):
         return super(Delta, self).__init__(v, log_density, value)
 
 
-@eager.register(Delta, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Delta, TorchTensor, TorchTensor, TorchTensor)
 def eager_delta(v, log_density, value):
     # This handles event_dim specially, and hence cannot use the
     # generic Delta.eager_log_prob() method.
@@ -343,7 +343,7 @@ class Dirichlet(Distribution):
         super(Dirichlet, self).__init__(concentration, value)
 
 
-@eager.register(Dirichlet, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Dirichlet, TorchTensor, TorchTensor)
 def eager_dirichlet(concentration, value):
     return Dirichlet.eager_log_prob(concentration=concentration, value=value)
 
@@ -372,7 +372,7 @@ class DirichletMultinomial(Distribution):
         super(DirichletMultinomial, self).__init__(concentration, total_count, value)
 
 
-@eager.register(DirichletMultinomial, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(DirichletMultinomial, TorchTensor, TorchTensor, TorchTensor)
 def eager_dirichlet_multinomial(concentration, total_count, value):
     return DirichletMultinomial.eager_log_prob(
         concentration=concentration, total_count=total_count, value=value)
@@ -417,7 +417,7 @@ class Multinomial(Distribution):
         super(Multinomial, self).__init__(total_count, probs, value)
 
 
-@eager.register(Multinomial, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Multinomial, TorchTensor, TorchTensor, TorchTensor)
 def eager_multinomial(total_count, probs, value):
     # Multinomial.log_prob() supports inhomogeneous total_count only by
     # avoiding passing total_count to the constructor.
@@ -450,12 +450,12 @@ class Normal(Distribution):
         super(Normal, self).__init__(loc, scale, value)
 
 
-@eager.register(Normal, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Normal, TorchTensor, TorchTensor, TorchTensor)
 def eager_normal(loc, scale, value):
     return Normal.eager_log_prob(loc=loc, scale=scale, value=value)
 
 
-@eager.register(Normal, Funsor, funsor.torch.Tensor, Funsor)
+@eager.register(Normal, Funsor, TorchTensor, Funsor)
 def eager_normal(loc, scale, value):
     assert loc.output == reals()
     assert scale.output == reals()
@@ -499,12 +499,12 @@ class MultivariateNormal(Distribution):
         super(MultivariateNormal, self).__init__(loc, scale_tril, value)
 
 
-@eager.register(MultivariateNormal, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(MultivariateNormal, TorchTensor, TorchTensor, TorchTensor)
 def eager_mvn(loc, scale_tril, value):
     return MultivariateNormal.eager_log_prob(loc=loc, scale_tril=scale_tril, value=value)
 
 
-@eager.register(MultivariateNormal, Funsor, funsor.torch.Tensor, Funsor)
+@eager.register(MultivariateNormal, Funsor, TorchTensor, Funsor)
 def eager_mvn(loc, scale_tril, value):
     assert len(loc.shape) == 1
     assert len(scale_tril.shape) == 2
@@ -543,7 +543,7 @@ class Poisson(Distribution):
         super().__init__(rate, value)
 
 
-@eager.register(Poisson, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Poisson, TorchTensor, TorchTensor)
 def eager_poisson(rate, value):
     return Poisson.eager_log_prob(rate=rate, value=value)
 
@@ -571,7 +571,7 @@ class Gamma(Distribution):
         super().__init__(concentration, rate, value)
 
 
-@eager.register(Gamma, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(Gamma, TorchTensor, TorchTensor, TorchTensor)
 def eager_gamma(concentration, rate, value):
     return Gamma.eager_log_prob(concentration=concentration, rate=rate, value=value)
 
@@ -599,7 +599,7 @@ class VonMises(Distribution):
         super().__init__(loc, concentration, value)
 
 
-@eager.register(VonMises, funsor.torch.Tensor, funsor.torch.Tensor, funsor.torch.Tensor)
+@eager.register(VonMises, TorchTensor, TorchTensor, TorchTensor)
 def eager_vonmises(loc, concentration, value):
     return VonMises.eager_log_prob(loc=loc, concentration=concentration, value=value)
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -324,14 +324,14 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         # Constants and Affine funsors are eagerly substituted;
         # everything else is lazily substituted.
         lazy_subs = tuple((k, v) for k, v in subs
-                          if not isinstance(v, (Number, Variable, Slice)) and not is_tensor(v)
+                          if not (isinstance(v, (Number, Variable, Slice)) or is_tensor(v))
                           and not (is_affine(v) and affine_inputs(v)))
         var_subs = tuple((k, v) for k, v in subs if isinstance(v, Variable))
         int_subs = tuple((k, v) for k, v in subs
-                         if isinstance(v, (Number, Slice)) or is_tensor(v)
+                         if (isinstance(v, (Number, Slice)) or is_tensor(v))
                          if v.dtype != 'real')
         real_subs = tuple((k, v) for k, v in subs
-                          if isinstance(v, Number) or is_tensor(v)
+                          if (isinstance(v, Number) or is_tensor(v))
                           if v.dtype == 'real')
         affine_subs = tuple((k, v) for k, v in subs
                             if is_affine(v) and affine_inputs(v) and not isinstance(v, Variable))

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -438,7 +438,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         affine = OrderedDict()
         for k, v in subs:
             const, coeffs = extract_affine(v)
-            if is_tensor(const) and all(is_tensor(coeffs) for coeff, _ in coeffs.values()):
+            if is_tensor(const) and all(is_tensor(coeff) for coeff, _ in coeffs.values()):
                 affine[k] = const, coeffs
             else:
                 remaining_subs += (k, v),

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -7,10 +7,8 @@ from functools import reduce
 
 import numpy as np
 import torch
-from multipledispatch import dispatch
 from pyro.distributions.util import broadcast_shape
 
-import funsor
 import funsor.ops as ops
 from funsor.affine import affine_inputs, extract_affine, is_affine
 from funsor.delta import Delta

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -10,7 +10,6 @@ import torch
 from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic
 
-import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.delta import Delta
@@ -19,6 +18,7 @@ from funsor.gaussian import Gaussian, align_gaussian
 from funsor.ops import AssociativeOp
 from funsor.tensor_ops import Tensor, align_tensor
 from funsor.terms import Funsor, Independent, Number, Reduce, Unary, eager, moment_matching, normalize
+from funsor.torch import Tensor as TorchTensor
 
 
 @dispatch(str, str, Variadic[(Gaussian, GaussianMixture)])

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -10,14 +10,15 @@ import torch
 from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic
 
+import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.delta import Delta
 from funsor.domains import bint
 from funsor.gaussian import Gaussian, align_gaussian
 from funsor.ops import AssociativeOp
+from funsor.tensor_ops import Tensor, align_tensor
 from funsor.terms import Funsor, Independent, Number, Reduce, Unary, eager, moment_matching, normalize
-from funsor.torch import Tensor, align_tensor
 
 
 @dispatch(str, str, Variadic[(Gaussian, GaussianMixture)])
@@ -81,7 +82,7 @@ def moment_matching_contract_default(*args):
     return None
 
 
-@moment_matching.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, (Number, Tensor), Gaussian)
+@moment_matching.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, (Number, funsor.torch.Tensor), Gaussian)
 def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gaussian):
 
     approx_vars = frozenset(k for k in reduced_vars if k in gaussian.inputs
@@ -144,8 +145,10 @@ def eager_reduce_exp(op, arg, reduced_vars):
 
 
 @eager.register(Independent,
-                (Contraction[ops.NullOp, ops.AddOp, frozenset, Tuple[Delta, Union[Number, Tensor], Gaussian]],
-                 Contraction[ops.NullOp, ops.AddOp, frozenset, Tuple[Delta, Union[Number, Tensor, Gaussian]]]),
+                (Contraction[ops.NullOp, ops.AddOp, frozenset,
+                             Tuple[Delta, Union[Number, funsor.torch.Tensor], Gaussian]],
+                 Contraction[ops.NullOp, ops.AddOp, frozenset,
+                             Tuple[Delta, Union[Number, funsor.torch.Tensor, Gaussian]]]),
                 str, str, str)
 def eager_independent_joint(joint, reals_var, bint_var, diag_var):
     if diag_var not in joint.terms[0].fresh:

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -82,7 +82,7 @@ def moment_matching_contract_default(*args):
     return None
 
 
-@moment_matching.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, (Number, funsor.torch.Tensor), Gaussian)
+@moment_matching.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, (Number, TorchTensor), Gaussian)
 def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gaussian):
 
     approx_vars = frozenset(k for k in reduced_vars if k in gaussian.inputs
@@ -146,9 +146,9 @@ def eager_reduce_exp(op, arg, reduced_vars):
 
 @eager.register(Independent,
                 (Contraction[ops.NullOp, ops.AddOp, frozenset,
-                             Tuple[Delta, Union[Number, funsor.torch.Tensor], Gaussian]],
+                             Tuple[Delta, Union[Number, TorchTensor], Gaussian]],
                  Contraction[ops.NullOp, ops.AddOp, frozenset,
-                             Tuple[Delta, Union[Number, funsor.torch.Tensor, Gaussian]]]),
+                             Tuple[Delta, Union[Number, TorchTensor, Gaussian]]]),
                 str, str, str)
 def eager_independent_joint(joint, reals_var, bint_var, diag_var):
     if diag_var not in joint.terms[0].fresh:

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -41,7 +41,7 @@ class Distribution(object):
     def log_prob(self, value):
         result = self.funsor_dist(value=value)
         if self.sample_inputs:
-            result = result + funsor.torch.Tensor(
+            result = result + funsor.Tensor(
                 torch.zeros(*(size.dtype for size in self.sample_inputs.values())),
                 self.sample_inputs
             )
@@ -179,7 +179,7 @@ CondIndepStackFrame = namedtuple("CondIndepStackFrame", ["name", "size", "dim"])
 
 # This implementation of vectorized PlateMessenger broadcasts and
 # records a cond_indep_stack which is later used to convert
-# torch.Tensors to funsor.torch.Tensors.
+# torch.Tensors to TorchTensors.
 class PlateMessenger(Messenger):
     def __init__(self, fn, name, size, dim):
         assert dim < 0
@@ -212,7 +212,7 @@ def tensor_to_funsor(value, cond_indep_stack, output):
             frame = cond_indep_stack[dim - len(batch_shape)]
             assert size == frame.size, (size, frame)
             inputs[frame.name] = funsor.bint(int(size))
-    value = funsor.torch.Tensor(data, inputs, output.dtype)
+    value = funsor.Tensor(data, inputs, output.dtype)
     assert value.output == output
     return value
 
@@ -570,7 +570,7 @@ class Jit(object):
                 self._compiled = torch.jit.trace(compiled, params_and_args, check_trace=False)
 
         data = self._compiled(*params_and_args)
-        return funsor.torch.Tensor(data)
+        return funsor.Tensor(data)
 
 
 # This is a jit wrapper for ELBO implementations.

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -179,7 +179,7 @@ CondIndepStackFrame = namedtuple("CondIndepStackFrame", ["name", "size", "dim"])
 
 # This implementation of vectorized PlateMessenger broadcasts and
 # records a cond_indep_stack which is later used to convert
-# torch.Tensors to TorchTensors.
+# torch.Tensors to funsor.torch.Tensors.
 class PlateMessenger(Messenger):
     def __init__(self, fn, name, size, dim):
         assert dim < 0

--- a/funsor/numpy.py
+++ b/funsor/numpy.py
@@ -7,9 +7,9 @@ import numpy as np
 from multipledispatch import dispatch
 
 import funsor.ops as ops
-from funsor.domains import Domain, bint, find_domain
-from funsor.tensor_ops import align_tensor, align_tensors, materialize
-from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, substitute, to_data, to_funsor
+from funsor.domains import Domain, find_domain
+from funsor.tensor_ops import align_tensors, materialize
+from funsor.terms import Binary, Funsor, FunsorMeta, Number, eager, to_data, to_funsor
 
 
 class ArrayMeta(FunsorMeta):

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -373,8 +373,7 @@ def transpose(x, dim0, dim1):
 
 @Op
 def permute(x, dims):
-    if isinstance(x, Number):
-        return x
+    raise NotImplementedError
 
 
 __all__ = [

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -373,16 +373,8 @@ def transpose(x, dim0, dim1):
 
 @Op
 def permute(x, dims):
-    raise NotImplementedError
-
-
-@Op
-def TensorOp(x, inputs, dtype):
-    raise NotImplementedError
-
-
-def Tensor(x, inputs=None, dtype="real"):
-    return TensorOp(x, inputs, dtype)
+    if isinstance(x, Number):
+        return x
 
 
 __all__ = [

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -32,9 +32,8 @@ from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.ops import cholesky
-from funsor.tensor_ops import align_tensors
+from funsor.tensor_ops import Tensor, align_tensors
 from funsor.terms import Funsor, Independent, Variable, eager
-from funsor.torch import Tensor
 
 # Conversion functions use fixed names for Pyro batch dims, but
 # accept an event_inputs tuple for custom event dim names.

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -32,8 +32,9 @@ from funsor.domains import bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.ops import cholesky
+from funsor.tensor_ops import align_tensors
 from funsor.terms import Funsor, Independent, Variable, eager
-from funsor.torch import Tensor, align_tensors
+from funsor.torch import Tensor
 
 # Conversion functions use fixed names for Pyro batch dims, but
 # accept an event_inputs tuple for custom event dim names.

--- a/funsor/tensor_ops.py
+++ b/funsor/tensor_ops.py
@@ -1,0 +1,149 @@
+from collections import OrderedDict
+
+import numpy as np
+import torch
+from multipledispatch import dispatch
+
+import funsor
+import funsor.ops as ops
+from funsor.domains import bint
+from funsor.terms import Funsor, Number, substitute
+
+
+def align_tensor(new_inputs, x, expand=False):
+    r"""
+    Permute and add dims to a tensor to match desired ``new_inputs``.
+
+    :param OrderedDict new_inputs: A target set of inputs.
+    :param funsor.terms.Funsor x: A :class:`Tensor`, :class:`Array`, or
+        :class:`~funsor.terms.Number` .
+    :param bool expand: If False (default), set result size to 1 for any input
+        of ``x`` not in ``new_inputs``; if True expand to ``new_inputs`` size.
+    :return: a number or :class:`torch.Tensor` that can be broadcast to other
+        tensors with inputs ``new_inputs``.
+    :rtype: int or float or torch.Tensor or numpy.ndarray
+    """
+    assert isinstance(new_inputs, OrderedDict)
+    assert isinstance(x, (Number, funsor.torch.Tensor, funsor.numpy.Array))
+    assert all(isinstance(d.dtype, int) for d in x.inputs.values())
+
+    data = x.data
+    if isinstance(x, Number):
+        return data
+
+    old_inputs = x.inputs
+    if old_inputs == new_inputs:
+        return data
+
+    # Permute squashed input dims.
+    x_keys = tuple(old_inputs)
+    data = ops.permute(data, tuple(x_keys.index(k) for k in new_inputs if k in old_inputs) +
+                       tuple(range(len(old_inputs), len(data.shape))))
+
+    # Unsquash multivariate input dims by filling in ones.
+    data = data.reshape(tuple(old_inputs[k].dtype if k in old_inputs else 1 for k in new_inputs) +
+                        x.output.shape)
+
+    # Optionally expand new dims.
+    if expand:
+        data = ops.expand(data, tuple(d.dtype for d in new_inputs.values()) + x.output.shape)
+    return data
+
+
+def align_tensors(*args, **kwargs):
+    r"""
+    Permute multiple tensors before applying a broadcasted op.
+
+    This is mainly useful for implementing eager funsor operations.
+
+    :param funsor.terms.Funsor \*args: Multiple :class:`Tensor` s or :class:`Array` s and
+        :class:`~funsor.terms.Number` s.
+    :param bool expand: Whether to expand input tensors. Defaults to False.
+    :return: a pair ``(inputs, tensors)`` where tensors are all
+        :class:`torch.Tensor` s that can be broadcast together to a single data
+        with given ``inputs``.
+    :rtype: tuple
+    """
+    expand = kwargs.pop('expand', False)
+    assert not kwargs
+    inputs = OrderedDict()
+    for x in args:
+        inputs.update(x.inputs)
+    tensors = [align_tensor(inputs, x, expand=expand) for x in args]
+    return inputs, tensors
+
+
+def arange(prototype, name, *args, **kwargs):
+    """
+    Helper to create a named :func:`torch.arange` funsor.
+    In some cases this can be replaced by a symbolic
+    :class:`~funsor.terms.Slice` .
+
+    :param prototype: either a torch.Tensor or a numpy.array
+    :param str name: A variable name.
+    :param int start:
+    :param int stop:
+    :param int step: Three args following :py:class:`slice` semantics.
+    :param int dtype: An optional bounded integer type of this slice.
+    :rtype: Tensor
+    """
+    start = 0
+    step = 1
+    dtype = None
+    if len(args) == 1:
+        stop = args[0]
+        dtype = kwargs.pop("dtype", stop)
+    elif len(args) == 2:
+        start, stop = args
+        dtype = kwargs.pop("dtype", stop)
+    elif len(args) == 3:
+        start, stop, step = args
+        dtype = kwargs.pop("dtype", stop)
+    elif len(args) == 4:
+        start, stop, step, dtype = args
+    else:
+        raise ValueError
+    if step <= 0:
+        raise ValueError
+    stop = min(dtype, max(start, stop))
+    data = ops.new_arange(prototype, start, stop, step)
+    inputs = OrderedDict([(name, bint(len(data)))])
+    return Tensor(data, inputs, dtype=dtype)
+
+
+def materialize(prototype, x):
+    """
+    Attempt to convert a Funsor to a :class:`~funsor.terms.Number` or
+    :class:`Tensor` by substituting :func:`arange` s into its free variables.
+
+    :param prototype: either a torch.Tensor or a numpy.array
+    :arg Funsor x: A funsor.
+    :rtype: Funsor
+    """
+    assert isinstance(x, Funsor)
+    if isinstance(x, (Number, funsor.torch.Tensor, funsor.numpy.Array)):
+        return x
+    subs = []
+    for name, domain in x.inputs.items():
+        if isinstance(domain.dtype, int):
+            subs.append((name, arange(prototype, name, domain.dtype)))
+    subs = tuple(subs)
+    return substitute(x, subs)
+
+
+@dispatch(torch.Tensor, (type(None), tuple, OrderedDict), (int, str))
+def _Tensor(x, inputs, dtype):
+    return funsor.torch.Tensor(x, inputs, dtype)
+
+
+@dispatch(np.ndarray, (type(None), tuple, OrderedDict), (int, str))
+def _Tensor(x, inputs, dtype):
+    return funsor.numpy.Array(x, inputs, dtype)
+
+
+def Tensor(x, inputs=None, dtype="real"):
+    return _Tensor(x, inputs, dtype)
+
+
+def is_tensor(x):
+    return isinstance(x, (funsor.torch.Tensor, funsor.numpy.Array))

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -28,7 +28,6 @@ from funsor.terms import (
     Unary,
     Variable,
     eager,
-    substitute,
     to_data,
     to_funsor
 )

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -16,6 +16,7 @@ from funsor.einsum import BACKEND_ADJOINT_OPS, einsum, naive_einsum, naive_plate
 from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer
 from funsor.sum_product import MarkovProduct, naive_sequential_sum_product, sequential_sum_product, sum_product
+from funsor.tensor_ops import is_tensor
 from funsor.terms import Variable, reflect
 from funsor.testing import (
     assert_close,
@@ -71,7 +72,7 @@ def test_einsum_adjoint(einsum_impl, equation, backend):
         expected = tv._pyro_backward_result
         if inp:
             actual = actual.align(tuple(inp))
-        assert isinstance(actual, funsor.Tensor)
+        assert is_tensor(actual)
         assert expected.shape == actual.data.shape
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
@@ -115,7 +116,7 @@ def test_plated_einsum_adjoint(einsum_impl, equation, plates, backend):
         expected = tv._pyro_backward_result
         if inp:
             actual = actual.align(tuple(inp))
-        assert isinstance(actual, funsor.Tensor)
+        assert is_tensor(actual)
         assert expected.shape == actual.data.shape
         assert torch.allclose(expected, actual.data, atol=1e-7)
 
@@ -153,7 +154,7 @@ def test_optimized_plated_einsum_adjoint(equation, plates, backend):
         expected = tv._pyro_backward_result
         if inp:
             actual = actual.align(tuple(inp))
-        assert isinstance(actual, funsor.Tensor)
+        assert is_tensor(actual)
         assert expected.shape == actual.data.shape
         assert torch.allclose(expected, actual.data, atol=1e-7)
 

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -8,7 +8,6 @@ import torch
 from pyro.ops.contract import einsum as pyro_einsum
 from pyro.ops.einsum.adjoint import require_backward as pyro_require_backward
 
-import funsor
 import funsor.ops as ops
 from funsor.adjoint import AdjointTape
 from funsor.domains import bint, reals

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 from pyro.ops.contract import einsum as pyro_einsum
 
-import funsor
 from funsor.distributions import Categorical
 from funsor.domains import bint
 from funsor.einsum import naive_einsum, naive_plated_einsum

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -14,9 +14,9 @@ from funsor.domains import bint
 from funsor.einsum import naive_einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
+from funsor.tensor_ops import Tensor, is_tensor
 from funsor.terms import Variable, reflect
 from funsor.testing import assert_close, make_einsum_example
-from funsor.torch import Tensor
 
 EINSUM_EXAMPLES = [
     "a,b->",
@@ -47,7 +47,7 @@ def test_einsum(equation, backend):
     actual_optimized = reinterpret(optimized_ast)  # eager by default
     actual = naive_einsum(equation, *funsor_operands, backend=backend)
 
-    assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
+    assert is_tensor(actual) and len(outputs) == 1
     if len(outputs[0]) > 0:
         actual = actual.align(tuple(outputs[0]))
         actual_optimized = actual_optimized.align(tuple(outputs[0]))

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -499,10 +499,10 @@ def test_integrate_variable(int_inputs, real_inputs):
 
     sampled_log_measure = log_measure.sample(reduced_vars, OrderedDict(particle=bint(100000)))
     approx = Integrate(sampled_log_measure, integrand, reduced_vars | {'particle'})
-    assert isinstance(approx, Tensor)
+    assert is_tensor(approx)
 
     exact = Integrate(log_measure, integrand, reduced_vars)
-    assert isinstance(exact, Tensor)
+    assert is_tensor(exact)
     assert_close(approx, exact, atol=0.1, rtol=0.1)
 
 
@@ -530,10 +530,10 @@ def test_integrate_gaussian(int_inputs, real_inputs):
 
     sampled_log_measure = log_measure.sample(reduced_vars, OrderedDict(particle=bint(10000)))
     approx = Integrate(sampled_log_measure, integrand, reduced_vars | {'particle'})
-    assert isinstance(approx, Tensor)
+    assert is_tensor(approx)
 
     exact = Integrate(log_measure, integrand, reduced_vars)
-    assert isinstance(exact, Tensor)
+    assert is_tensor(exact)
     assert_close(approx, exact, atol=0.1, rtol=0.1)
 
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -14,9 +14,10 @@ from funsor.cnf import Contraction, GaussianMixture
 from funsor.domains import bint, reals
 from funsor.gaussian import BlockMatrix, BlockVector, Gaussian
 from funsor.integrate import Integrate
+from funsor.tensor_ops import Tensor, is_tensor
 from funsor.terms import Number, Variable
 from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor
-from funsor.torch import Einsum, Tensor
+from funsor.torch import Einsum, Tensor as TorchTensor
 from funsor.numpy import Array
 
 assert Einsum  # flake8
@@ -147,24 +148,22 @@ def test_block_matrix_batched(batch_shape, sparse):
     ('g2(i=i0)', Gaussian),
     ('g1(i=i0) + g2(i=i0)', Gaussian),
     ('g1(i=i0) + g2', Gaussian),
-    ('g1(x=x0)', (Tensor, Array)),
-    ('g2(y=y0)', (Tensor, Array)),
+    ('g1(x=x0)', (TorchTensor, Array)),
+    ('g2(y=y0)', (TorchTensor, Array)),
     ('(g1 + g2)(i=i0)', Gaussian),
-    ('(g1 + g2)(x=x0, y=y0)', (Tensor, Array)),
-    ('(g2 + g1)(x=x0, y=y0)', (Tensor, Array)),
-    ('g1.reduce(ops.logaddexp, "x")', (Tensor, Array)),
+    ('(g1 + g2)(x=x0, y=y0)', (TorchTensor, Array)),
+    ('(g2 + g1)(x=x0, y=y0)', (TorchTensor, Array)),
+    ('g1.reduce(ops.logaddexp, "x")', (TorchTensor, Array)),
     ('(g1 + g2).reduce(ops.logaddexp, "x")', Contraction),
     ('(g1 + g2).reduce(ops.logaddexp, "y")', Contraction),
-    ('(g1 + g2).reduce(ops.logaddexp, frozenset(["x", "y"]))', (Tensor, Array)),
+    ('(g1 + g2).reduce(ops.logaddexp, frozenset(["x", "y"]))', (TorchTensor, Array)),
 ])
 @pytest.mark.parametrize("backend", ["torch", "numpy"])
 def test_smoke(expr, expected_type, backend):
     if backend == "torch":
         tensor = torch.tensor
-        Tensor_ = Tensor
     else:
         tensor = np.array
-        Tensor_ = Array
 
     g1 = Gaussian(
         info_vec=tensor([[0.0, 0.1, 0.2],
@@ -188,19 +187,19 @@ def test_smoke(expr, expected_type, backend):
         inputs=OrderedDict([('i', bint(2)), ('y', reals(2))]))
     assert isinstance(g2, Gaussian)
 
-    shift = Tensor_(tensor([-1., 1.]), OrderedDict([('i', bint(2))]))
-    assert isinstance(shift, Tensor_)
+    shift = Tensor(tensor([-1., 1.]), OrderedDict([('i', bint(2))]))
+    assert is_tensor(shift)
 
     i0 = Number(1, 2)
     assert isinstance(i0, Number)
 
-    x0 = Tensor_(tensor([0.5, 0.6, 0.7]))
-    assert isinstance(x0, Tensor_)
+    x0 = Tensor(tensor([0.5, 0.6, 0.7]))
+    assert is_tensor(x0)
 
-    y0 = Tensor_(tensor([[0.2, 0.3],
-                         [0.8, 0.9]]),
-                 inputs=OrderedDict([('i', bint(2))]))
-    assert isinstance(y0, Tensor_)
+    y0 = Tensor(tensor([[0.2, 0.3],
+                        [0.8, 0.9]]),
+                inputs=OrderedDict([('i', bint(2))]))
+    assert is_tensor(y0)
 
     result = eval(expr)
     assert isinstance(result, expected_type)

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -10,7 +10,8 @@ import funsor
 from funsor import Number, Variable, bint, reals
 from funsor.domains import Domain
 from funsor.interpreter import _USE_TCO, interpretation
-from funsor.numpy import Array, align_arrays
+from funsor.numpy import Array
+from funsor.tensor_ops import align_tensors
 from funsor.terms import lazy
 from funsor.testing import assert_equiv, check_funsor, random_array
 
@@ -179,9 +180,9 @@ def test_advanced_indexing_lazy(output_shape):
         k = u + v
 
     expected_data = np.empty((2, 3) + output_shape)
-    i_data = funsor.numpy.materialize(i).data.astype(np.int64)
-    j_data = funsor.numpy.materialize(j).data.astype(np.int64)
-    k_data = funsor.numpy.materialize(k).data.astype(np.int64)
+    i_data = funsor.tensor_ops.materialize(x.data, i).data.astype(np.int64)
+    j_data = funsor.tensor_ops.materialize(x.data, j).data.astype(np.int64)
+    k_data = funsor.tensor_ops.materialize(x.data, k).data.astype(np.int64)
     for u in range(2):
         for v in range(3):
             expected_data[u, v] = x.data[i_data[u], j_data[v], k_data[u, v]]
@@ -280,8 +281,8 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
     shape2 = tuple(sizes[d] for d in dims2)
     inputs1 = OrderedDict((d, bint(sizes[d])) for d in dims1)
     inputs2 = OrderedDict((d, bint(sizes[d])) for d in dims2)
-    data1 = np.array(np.random.rand(*shape1)) + 0.5
-    data2 = np.array(np.random.rand(*shape2)) + 0.5
+    data1 = np.array(np.random.rand(*shape1) + 0.5)
+    data2 = np.array(np.random.rand(*shape2) + 0.5)
     dtype = 'real'
     if symbol in BOOLEAN_OPS:
         dtype = 2
@@ -289,7 +290,7 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
         data2 = data2.astype(bool)
     x1 = Array(data1, inputs1, dtype)
     x2 = Array(data2, inputs2, dtype)
-    inputs, aligned = align_arrays(x1, x2)
+    inputs, aligned = align_tensors(x1, x2)
     expected_data = binary_eval(symbol, aligned[0], aligned[1])
 
     actual = binary_eval(symbol, x1, x2)

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -13,9 +13,9 @@ from funsor.domains import bint
 from funsor.einsum import einsum, naive_contract_einsum, naive_einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
+from funsor.tensor_ops import Tensor
 from funsor.terms import Variable, normalize, reflect
 from funsor.testing import assert_close, make_chain_einsum, make_einsum_example, make_hmm_einsum, make_plated_hmm_einsum
-from funsor.torch import Tensor
 
 OPTIMIZED_EINSUM_EXAMPLES = [
     make_chain_einsum(t) for t in range(2, 50, 10)
@@ -41,7 +41,7 @@ def test_optimized_einsum(equation, backend, einsum_impl):
     optimized_ast = apply_optimizer(naive_ast)
     actual = reinterpret(optimized_ast)  # eager by default
 
-    assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
+    assert isinstance(actual, funsor.torch.Tensor) and len(outputs) == 1
     if len(outputs[0]) > 0:
         actual = actual.align(tuple(outputs[0]))
 
@@ -120,7 +120,7 @@ def test_optimized_plated_einsum(equation, plates, backend):
         actual_naive = naive_plated_einsum(equation, *funsor_operands, plates=plates, backend=backend)
         assert_close(actual, actual_naive)
 
-    assert isinstance(actual, funsor.Tensor) and len(outputs) == 1
+    assert isinstance(actual, funsor.torch.Tensor) and len(outputs) == 1
     if len(outputs[0]) > 0:
         actual = actual.align(tuple(outputs[0]))
 

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -15,7 +15,7 @@ from funsor.delta import Delta
 from funsor.domains import bint, reals
 from funsor.integrate import Integrate
 from funsor.montecarlo import monte_carlo_interpretation
-from funsor.tensor_ops import Tensor, align_tensors, is_tensor, materialize
+from funsor.tensor_ops import align_tensors, is_tensor, materialize
 from funsor.terms import Variable
 from funsor.testing import assert_close, id_from_inputs, random_gaussian, random_tensor, xfail_if_not_implemented
 


### PR DESCRIPTION
The file will contain several utilities such as: `align_tensor`, `align_tensors`, `arange`, `materialize`. In addition, a function Tensor will be constructed to fall back to torch.Tensor or numpy.Array.

Other changes in this PR:
+ use `tensor_ops.is_tensor` to check if a variable is a tensor
+ change `from funsor.torch import Tensor` to `from funsor.torch import TorchTensor`; we will use `from funsor.tensor_ops import Tensor` throughout.

TODO:
- [x] find bugs and make all tests pass