### PR TITLE
Add ops.sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 install:
     - pip install -U pip
-    - pip install torch==1.3.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
     # Keep track of Pyro dev branch
     - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -77,6 +77,10 @@ class LogAddExpOp(AssociativeOp):
     pass
 
 
+class SampleOp(LogAddExpOp):
+    pass
+
+
 class SubOp(Op):
     pass
 
@@ -255,10 +259,13 @@ def max(x, y):
     return _builtin_max(x, y)
 
 
-@LogAddExpOp
-def logaddexp(x, y):
+def _logaddexp(x, y):
     shift = max(x, y)
     return log(exp(x - shift) + exp(y - shift)) + shift
+
+
+logaddexp = LogAddExpOp(_logaddexp)
+sample = SampleOp(_logaddexp)
 
 
 @SubOp
@@ -291,6 +298,7 @@ DISTRIBUTIVE_OPS = frozenset([
     (min, mul),
     (max, add),
     (min, add),
+    (sample, add),
 ])
 
 
@@ -397,6 +405,7 @@ __all__ = [
     'Op',
     'PRODUCT_INVERSES',
     'ReciprocalOp',
+    'SampleOp',
     'SubOp',
     'ReshapeOp',
     'UNITS',
@@ -430,6 +439,7 @@ __all__ = [
     'pow',
     'safediv',
     'safesub',
+    'sample',
     'sigmoid',
     'sqrt',
     'sub',

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -260,6 +260,10 @@ def max(x, y):
 
 
 def _logaddexp(x, y):
+    if hasattr(x, "__logaddexp__"):
+        return x.__logaddexp__(y)
+    if hasattr(y, "__rlogaddexp__"):
+        return y.__logaddexp__(x)
     shift = max(x, y)
     return log(exp(x - shift) + exp(y - shift)) + shift
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -630,6 +630,12 @@ class Funsor(object, metaclass=FunsorMeta):
     def __rsub__(self, other):
         return Binary(ops.sub, to_funsor(other), self)
 
+    def __logaddexp__(self, other):
+        return Binary(ops.logaddexp, self, to_funsor(other))
+
+    def __rlogaddexp__(self, other):
+        return Binary(ops.logaddexp, self, to_funsor(other))
+
     def __mul__(self, other):
         return Binary(ops.mul, self, to_funsor(other))
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -634,7 +634,7 @@ class Funsor(object, metaclass=FunsorMeta):
         return Binary(ops.logaddexp, self, to_funsor(other))
 
     def __rlogaddexp__(self, other):
-        return Binary(ops.logaddexp, self, to_funsor(other))
+        return Binary(ops.logaddexp, to_funsor(other), self)
 
     def __mul__(self, other):
         return Binary(ops.mul, self, to_funsor(other))

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -252,7 +252,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             reduced_vars = reduced_vars & self_vars
             if reduced_vars == self_vars and not self.output.shape:
                 # Reduce all dims at once.
-                if op is ops.logaddexp:
+                if isinstance(op, ops.LogAddExpOp):
                     # work around missing torch.Tensor.logsumexp()
                     data = self.data.reshape(-1).logsumexp(0)
                     return Tensor(data, dtype=self.dtype)
@@ -1112,6 +1112,7 @@ REDUCE_OP_TO_TORCH = {
     ops.and_: torch.all,
     ops.or_: torch.any,
     ops.logaddexp: torch.logsumexp,
+    ops.sample: torch.logsumexp,
     ops.min: torch.min,
     ops.max: torch.max,
 }

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -247,8 +247,8 @@ def test_reduce_all(op):
     x = Variable('x', bint(2))
     y = Variable('y', bint(3))
     z = Variable('z', bint(4))
-    if op is ops.logaddexp:
-        pytest.skip()
+    if isinstance(op, ops.LogAddExpOp):
+        pytest.skip()  # not defined for integers
 
     with interpretation(sequential):
         f = x * y + z
@@ -281,8 +281,8 @@ def test_reduce_subset(op, reduced_vars):
     f = x * y + z
     dtype = f.dtype
     check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Domain((), dtype))
-    if op is ops.logaddexp:
-        pytest.skip()
+    if isinstance(op, ops.LogAddExpOp):
+        pytest.skip()  # not defined for integers
 
     with interpretation(sequential):
         actual = f.reduce(op, reduced_vars)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -526,7 +526,16 @@ def test_lambda_getitem():
     assert Lambda(i, y) is x
 
 
-REDUCE_OPS = [ops.add, ops.mul, ops.and_, ops.or_, ops.logaddexp, ops.min, ops.max]
+REDUCE_OPS = [
+    ops.add,
+    ops.mul,
+    ops.and_,
+    ops.or_,
+    ops.logaddexp,
+    ops.sample,
+    ops.min,
+    ops.max,
+]
 
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b'), ('b', 'a', 'c')])
@@ -538,7 +547,7 @@ def test_reduce_all(dims, op):
     data = torch.rand(shape) + 0.5
     if op in [ops.and_, ops.or_]:
         data = data.byte()
-    if op is ops.logaddexp:
+    if isinstance(op, ops.LogAddExpOp):
         # work around missing torch.Tensor.logsumexp()
         expected_data = data.reshape(-1).logsumexp(0)
     else:
@@ -576,7 +585,7 @@ def test_reduce_subset(dims, reduced_vars, op):
         assert actual is x
     else:
         if reduced_vars == frozenset(dims):
-            if op is ops.logaddexp:
+            if isinstance(op, ops.LogAddExpOp):
                 # work around missing torch.Tensor.logsumexp()
                 data = data.reshape(-1).logsumexp(0)
             else:


### PR DESCRIPTION
Addresses #304 
Pair coded with @eb8680 

This pulls the `ops.sample` changes out of #305 

@eb8680 I hope this does not conflict with any of your work. I'll leave the remaining `Argreduce` and adoint changes to you, and then port Pyro's https://github.com/pyro-ppl/pyro/pull/2285 to Funsor.

## Tested
- added `ops.sample` to some Tensor tests