### PR TITLE
Support numpy docs for getargspec

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -152,6 +152,7 @@ def reinterpret_funsor(x):
 @recursion_reinterpret.register(types.BuiltinFunctionType)
 @recursion_reinterpret.register(numpy.ndarray)
 @recursion_reinterpret.register(torch.Tensor)
+@recursion_reinterpret.register(numpy.ufunc)
 @recursion_reinterpret.register(torch.nn.Module)
 @recursion_reinterpret.register(Domain)
 @recursion_reinterpret.register(Op)

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -23,19 +23,19 @@ def getargspec(fn):
     """
     Similar to Python 2's :py:func:`inspect.getargspec` but:
     - In Python 3 uses ``getfullargspec`` to avoid ``DeprecationWarning``.
-    - For builtin functions like ``torch.matmul``, falls back to attmpting
-      to parse the function docstring, assuming torch-style.
+    - For builtin functions like ``torch.matmul`` or ``numpy.matmul, falls back to attempting
+      to parse the function docstring, assuming torch-style or numpy-style.
     """
     assert callable(fn)
     try:
         args, vargs, kwargs, defaults, _, _, _ = inspect.getfullargspec(fn)
     except TypeError:
         # Fall back to attmpting to parse a PyTorch-style docstring.
-        match = re.match(r"\s{}\(([^)]*)\)".format(fn.__name__), fn.__doc__)
+        match = re.match(r"\s*{}\(([^)]*)\)".format(fn.__name__), fn.__doc__)
         if match is None:
             raise
-        parts = match.group(1).split(", ")
-        args = [a.split("=")[0] for a in parts]
+        parts = re.sub(r"[[\]]", "", match.group(1)).split(", ")
+        args = [a.split("=")[0] for a in parts if a not in ["/", "*"]]
         if not all(re.match(r"^[^\d\W]\w*\Z", arg) for arg in args):
             raise
         vargs = None

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -756,12 +756,7 @@ def test_function_nested_lazy(backend):
     assert_close(actual_argmax, expected_argmax)
 
 
-@pytest.mark.parametrize("backend", [
-    "torch",
-    pytest.param("numpy", marks=pytest.mark.xfail(
-        reason="funsor.util.getargspec regex pattern needs to rewrite to support numpy docstring."
-               " Issue #207"))
-])
+@pytest.mark.parametrize("backend", ["torch", "numpy"])
 def test_function_of_numeric_array(backend):
     _numeric_matmul = torch.matmul if backend == "torch" else np.matmul
     x = randn((4, 3), backend)


### PR DESCRIPTION
pytorch docs and numpy docs have different patterns. This PR tries to resolve that issue in `funsor.util.getargspec`.

### pytorch
```
\nmatmul(input, other, out=None)
```

### numpy
```
matmul(x1, x2, /, out=None, *, casting='same_kind', order='K', dtype=None, subok=True[, signature, extobj])
```