### PR TITLE
Add optional input arguments to to_funsor and to_data

### DIFF
--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -66,8 +66,7 @@ def tensor_to_funsor(tensor, event_inputs=(), event_output=0, dtype="real"):
     dim_to_name_list = DIM_TO_NAME + event_inputs if event_inputs else DIM_TO_NAME
     dim_to_name = OrderedDict(zip(
         range(-len(inputs_shape), 0),
-        zip(dim_to_name_list[len(dim_to_name_list) - len(inputs_shape):],
-            map(bint, inputs_shape))))
+        dim_to_name_list[len(dim_to_name_list) - len(inputs_shape):]))
     return to_funsor(tensor, Domain(dtype=dtype, shape=output_shape), dim_to_name)
 
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -424,10 +424,11 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         # logic very similar to pyro.ops.packed.pack
         # this should not touch memory, only reshape
         # pack the tensor according to the dim => (name, domain) mapping in inputs
-        packed_inputs = OrderedDict(
-            [dim_to_name[dim + len(output.shape) - len(x.shape)] for dim, size in enumerate(x.shape)
-             if size > 1 and dim < len(x.shape) - len(output.shape)]
-        )
+        packed_inputs = OrderedDict()
+        for dim, size in enumerate(x.shape):
+            if size > 1 and dim < len(x.shape) - len(output.shape):
+                name, domain = dim_to_name[dim + len(output.shape) - len(x.shape)]
+                packed_inputs[name] = domain if domain.dtype > 1 else bint(size)
         if any(size > 1 for size in output.shape):
             # pack outputs into a single dimension
             x = x.reshape(x.shape[:-len(output.shape)] + (-1,))

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -425,10 +425,11 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         # this should not touch memory, only reshape
         # pack the tensor according to the dim => (name, domain) mapping in inputs
         packed_inputs = OrderedDict()
-        for dim, size in enumerate(x.shape):
-            if size > 1 and dim < len(x.shape) - len(output.shape):
-                name, domain = dim_to_name[dim + len(output.shape) - len(x.shape)]
-                packed_inputs[name] = domain if domain.dtype > 1 else bint(size)
+        for dim, size in zip(range(len(x.shape) - len(output.shape)), x.shape):
+            if size == 1:
+                continue  # TODO broadcast domain and shape here
+            name, domain = dim_to_name[dim + len(output.shape) - len(x.shape)]
+            packed_inputs[name] = domain if domain.dtype > 1 else bint(size)
         if any(size > 1 for size in output.shape):
             # pack outputs into a single dimension
             x = x.reshape(x.shape[:-len(output.shape)] + (-1,))

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -419,7 +419,7 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         return result
     else:
         assert output is not None  # TODO attempt to infer output
-        assert all(isinstance(k, int) and isinstance(v, str)
+        assert all(isinstance(k, int) and k < 0 and isinstance(v, str)
                    for k, v in dim_to_name.items())
         # logic very similar to pyro.ops.packed.pack
         # this should not touch memory, only reshape
@@ -506,7 +506,7 @@ def tensor_to_data(x, name_to_dim=None):
             raise ValueError(f"cannot convert Tensor to data due to lazy inputs: {set(x.inputs)}")
         return x.data
     else:
-        assert all(isinstance(k, str) and isinstance(v, int) and v <= 0
+        assert all(isinstance(k, str) and isinstance(v, int) and v < 0
                    for k, v in name_to_dim.items())
         # logic very similar to pyro.ops.packed.unpack
         # first collapse input domains into single dimensions

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -419,23 +419,23 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         return result
     else:
         assert output is not None  # TODO attempt to infer output
+        assert all(isinstance(k, int) and isinstance(v[0], str) and isinstance(v[1], Domain)
+                   for k, v in dim_to_name.items())
         # logic very similar to pyro.ops.packed.pack
         # this should not touch memory, only reshape
         # pack the tensor according to the dim => (name, domain) mapping in inputs
         packed_inputs = OrderedDict(
-            [dim_to_name[dim - len(x.shape)] for dim, size in enumerate(x.shape)
+            [dim_to_name[dim + len(output.shape) - len(x.shape)] for dim, size in enumerate(x.shape)
              if size > 1 and dim < len(x.shape) - len(output.shape)]
         )
         if any(size > 1 for size in output.shape):
             # pack outputs into a single dimension
             x = x.reshape(x.shape[:-len(output.shape)] + (-1,))
         x = x.squeeze()
-        if output.shape and all(size == 1 for size in output.shape):
+        if all(size == 1 for size in output.shape):
             # handle special case: all output dims are 1
             x = x.unsqueeze(-1)
         x = x.reshape(x.shape[:-1] + output.shape)
-        # unpack dims into final domain shapes
-        x = x.reshape(sum([d.shape for d in packed_inputs.values()], ()) + output.shape)
         return Tensor(x, packed_inputs, dtype=output.dtype)
 
 
@@ -505,14 +505,14 @@ def align_tensors(*args, **kwargs):
 
 @to_data.register(Tensor)
 def _to_data_tensor(x, name_to_dim=None):
-    if not name_to_dim:
+    if not name_to_dim or not x.inputs:
         if x.inputs:
             raise ValueError(f"cannot convert Tensor to data due to lazy inputs: {set(x.inputs)}")
         return x.data
     else:
         # logic very similar to pyro.ops.packed.unpack
         # first collapse input domains into single dimensions
-        data = x.data.reshape(tuple(d.num_elements for d in x.inputs.values()) + x.output.shape)
+        data = x.data.reshape(tuple(d.dtype for d in x.inputs.values()) + x.output.shape)
         # permute packed dimensions to correct order
         unsorted_dims = [name_to_dim[name] for name in x.inputs]
         dims = sorted(unsorted_dims)
@@ -523,7 +523,7 @@ def _to_data_tensor(x, name_to_dim=None):
         batch_shape = [1] * -min(dims)
         for dim, size in zip(dims, data.shape):
             batch_shape[dim] = size
-        return data.reshape(batch_shape + x.output.shape)
+        return data.reshape(tuple(batch_shape) + x.output.shape)
 
 
 @eager.register(Binary, Op, Tensor, Number)

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -419,17 +419,16 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         return result
     else:
         assert output is not None  # TODO attempt to infer output
-        assert all(isinstance(k, int) and isinstance(v[0], str) and isinstance(v[1], Domain)
+        assert all(isinstance(k, int) and isinstance(v, str)
                    for k, v in dim_to_name.items())
         # logic very similar to pyro.ops.packed.pack
         # this should not touch memory, only reshape
-        # pack the tensor according to the dim => (name, domain) mapping in inputs
+        # pack the tensor according to the dim => name mapping in inputs
         packed_inputs = OrderedDict()
         for dim, size in zip(range(len(x.shape) - len(output.shape)), x.shape):
-            if size == 1:
-                continue  # TODO broadcast domain and shape here
-            name, domain = dim_to_name[dim + len(output.shape) - len(x.shape)]
-            packed_inputs[name] = domain if domain.dtype > 1 else bint(size)
+            name = dim_to_name.get(dim + len(output.shape) - len(x.shape), None)
+            if name is not None:
+                packed_inputs[name] = bint(size)
         shape = tuple(d.size for d in packed_inputs.values()) + output.shape
         if x.shape != shape:
             x = x.reshape(shape)

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -427,7 +427,7 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         packed_inputs = OrderedDict()
         for dim, size in zip(range(len(x.shape) - len(output.shape)), x.shape):
             name = dim_to_name.get(dim + len(output.shape) - len(x.shape), None)
-            if name is not None:
+            if name is not None and size > 1:
                 packed_inputs[name] = bint(size)
         shape = tuple(d.size for d in packed_inputs.values()) + output.shape
         if x.shape != shape:

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -405,18 +405,21 @@ class Tensor(Funsor, metaclass=TensorMeta):
             return "numpy"
 
 
-@dispatch(numeric_array)
-def to_funsor(x):
-    return Tensor(x)
-
-
-@dispatch(numeric_array, Domain)
-def to_funsor(x, output):
-    result = Tensor(x, dtype=output.dtype)
-    if result.output != output:
-        raise ValueError("Invalid shape: expected {}, actual {}"
-                         .format(output.shape, result.output.shape))
-    return result
+# TODO move these registrations to backend-specific files
+@to_funsor.register(torch.Tensor)
+@to_funsor.register(np.ndarray)
+@to_funsor.register(np.generic)
+def tensor_to_funsor(x, output=None, inputs=None):
+    if output is None and inputs is None:
+        return Tensor(x)
+    if output is not None and inputs is None:
+        result = Tensor(x, dtype=output.dtype)
+        if result.output != output:
+            raise ValueError("Invalid shape: expected {}, actual {}"
+                             .format(output.shape, result.output.shape))
+        return result
+    if inputs is not None:
+        raise NotImplementedError("TODO")
 
 
 def align_tensor(new_inputs, x, expand=False):

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -430,14 +430,9 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
                 continue  # TODO broadcast domain and shape here
             name, domain = dim_to_name[dim + len(output.shape) - len(x.shape)]
             packed_inputs[name] = domain if domain.dtype > 1 else bint(size)
-        if any(size > 1 for size in output.shape):
-            # pack outputs into a single dimension
-            x = x.reshape(x.shape[:-len(output.shape)] + (-1,))
-        x = x.squeeze()
-        if all(size == 1 for size in output.shape):
-            # handle special case: all output dims are 1
-            x = x.unsqueeze(-1)
-        x = x.reshape(x.shape[:-1] + output.shape)
+        shape = tuple(d.size for d in packed_inputs.values()) + output.shape
+        if x.shape != shape:
+            x = x.reshape(shape)
         return Tensor(x, packed_inputs, dtype=output.dtype)
 
 
@@ -506,12 +501,14 @@ def align_tensors(*args, **kwargs):
 
 
 @to_data.register(Tensor)
-def _to_data_tensor(x, name_to_dim=None):
+def tensor_to_data(x, name_to_dim=None):
     if not name_to_dim or not x.inputs:
         if x.inputs:
             raise ValueError(f"cannot convert Tensor to data due to lazy inputs: {set(x.inputs)}")
         return x.data
     else:
+        assert all(isinstance(k, str) and isinstance(v, int) and v <= 0
+                   for k, v in name_to_dim.items())
         # logic very similar to pyro.ops.packed.unpack
         # first collapse input domains into single dimensions
         data = x.data.reshape(tuple(d.dtype for d in x.inputs.values()) + x.output.shape)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -757,14 +757,14 @@ interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 
 @singledispatch
-def to_funsor(x, output=None, inputs=None):
+def to_funsor(x, output=None, dim_to_name=None):
     """
     Convert to a :class:`Funsor` .
     Only :class:`Funsor` s and scalars are accepted.
 
     :param x: An object.
     :param funsor.domains.Domain output: An optional output hint.
-    :param OrderedDict inputs: An optional inputs hint.
+    :param OrderedDict dim_to_name: An optional inputs hint.
     :return: A Funsor equivalent to ``x``.
     :rtype: Funsor
     :raises: ValueError
@@ -773,23 +773,23 @@ def to_funsor(x, output=None, inputs=None):
 
 
 @to_funsor.register(Funsor)
-def funsor_to_funsor(x, output=None, inputs=None):
+def funsor_to_funsor(x, output=None, dim_to_name=None):
     if output is not None and x.output != output:
         raise ValueError("Output mismatch: {} vs {}".format(x.output, output))
-    if inputs is not None and x.inputs != inputs:
-        raise ValueError("Inputs mismatch: {} vs {}".format(x.inputs, inputs))
+    if dim_to_name is not None and list(x.inputs.keys()) != [v[0] for v in dim_to_name.values()]:
+        raise ValueError("Inputs mismatch: {} vs {}".format(x.inputs, dim_to_name))
     return x
 
 
 @singledispatch
-def to_data(x, inputs=None):
+def to_data(x, name_to_dim=None):
     """
     Extract a python object from a :class:`Funsor`.
 
     Raises a ``ValueError`` if free variables remain or if the funsor is lazy.
 
     :param x: An object, possibly a :class:`Funsor`.
-    :param OrderedDict inputs: An optional inputs hint.
+    :param OrderedDict name_to_dim: An optional inputs hint.
     :return: A non-funsor equivalent to ``x``.
     :raises: ValueError if any free variables remain.
     :raises: PatternMissingError if funsor is not fully evaluated.
@@ -798,8 +798,8 @@ def to_data(x, inputs=None):
 
 
 @to_data.register(Funsor)
-def _to_data_funsor(x, inputs=None):
-    if inputs is None and x.inputs:
+def _to_data_funsor(x, name_to_dim=None):
+    if name_to_dim is None and x.inputs:
         raise ValueError(f"cannot convert {type(x)} to data due to lazy inputs: {set(x.inputs)}")
     raise PatternMissingError(r"cannot convert to a non-Funsor: {repr(x)}")
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -764,7 +764,7 @@ def to_funsor(x, output=None, dim_to_name=None):
 
     :param x: An object.
     :param funsor.domains.Domain output: An optional output hint.
-    :param OrderedDict dim_to_name: An optional inputs hint.
+    :param OrderedDict dim_to_name: An optional mapping from negative batch dimensions to name strings.
     :return: A Funsor equivalent to ``x``.
     :rtype: Funsor
     :raises: ValueError
@@ -776,7 +776,7 @@ def to_funsor(x, output=None, dim_to_name=None):
 def funsor_to_funsor(x, output=None, dim_to_name=None):
     if output is not None and x.output != output:
         raise ValueError("Output mismatch: {} vs {}".format(x.output, output))
-    if dim_to_name is not None and list(x.inputs.keys()) != [v[0] for v in dim_to_name.values()]:
+    if dim_to_name is not None and list(x.inputs.keys()) != list(dim_to_name.values()):
         raise ValueError("Inputs mismatch: {} vs {}".format(x.inputs, dim_to_name))
     return x
 


### PR DESCRIPTION
## Overview

Based on our design discussion on Monday, this PR is a first step toward replacing much of Pyro's internals with Funsor and supporting enumeration in NumPyro.  It adds a `dim_to_name` mapping argument to `to_funsor` and a `name_to_dim` mapping argument to `to_data` which provide sufficient information for uniquely converting PyTorch tensors and distributions to Funsors with free variables and vice versa.  

The changes in this PR only support `Tensor`s.  In followup PRs, I will implement versions of `to_funsor` and `to_data` that apply to `Distribution`s.

This code is ready for review, but before changing the design too much I'd like to have first versions of the plate/enum-aware wrappers (discussed below) implemented as well (update: https://github.com/pyro-ppl/pyro/pull/2307)

## Design

`dim_to_name` is a dictionary that maps batch dimensions to (name, domain) pairs.  `name_to_dim` is a dictionary that maps input names to batch dimensions.  

This extra information (beyond an ordered list of names) is necessary for unique conversion because in Pyro we often have empty batch dimensions in our unpacked tensor shapes that do not mean anything, and eventually in Funsor we will support non-vector `bint` domains.

These arguments are optional, and `to_funsor` and `to_data` behave the same as before when they are not provided.

## Rationale 

The primary use case for this new functionality is upstream in Pyro and NumPyro, where we would like to convert distributions and lazy sample values to and from funsors with shapes consistent with the global plate and enumeration dimension state.  This code could plausibly live in Pyro, but I've put it here since it is intended to support an implementation of `EnumMessenger` and tensor variable elimination in NumPyro.

I am implementing wrappers of these two functions in Pyro that construct `name_to_dim`/`dim_to_name` automatically using the information in `MarkovMessenger`, and I do not expect that Pyro users would ever construct these manually or even know that they exist.

This design is very similar to the `dim_to_symbol` and `symbol_to_dim` arguments used in `pyro.ops.packed.pack` and `pyro.ops.packed.unpack`, but generalized to support event dimensions.  As a consequence of this similarity, we should easily be able to replace `pyro.ops.packed` with Funsor.

## Other changes

This design is also very similar to the conversion functions `funsor_to_tensor` and `tensor_to_funsor` in `pyro/ops/convert.py`, which use a particular convention for constructing instances of `dim_to_name` and `name_to_dim`.  I have modified the implementations of these functions to use `to_data` and `to_funsor` to reflect this similarity and to reuse their tests, and eventually I expect that much of `funsor.pyro.convert` will be deprecated in favor of the plate/enum-aware wrappers being implemented in Pyro.

I have also switched `to_funsor` to use `functools.singledispatch` rather than `multipledispatch`, which may provide a small performance boost and also avoids introducing a `multipledispatch` dependency in the event that we move this code out of Funsor.

## Tested
- New design exercised by existing tests in `test/pyro/test_convert.py`
- Ground `to_funsor` exercised by existing tests