### PR TITLE
Fix numpy expand and make numpy backend jittable

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -51,8 +51,8 @@ def eager_cat_homogeneous(name, part_name, *parts):
             raise NotImplementedError("TODO")
         discretes.append(discrete)
         info_vec, precision = align_gaussian(inputs, gaussian)
-        info_vecs.append(ops.expand(info_vec, shape + info_vec.shape[-1:]))
-        precisions.append(ops.expand(precision, shape + precision.shape[-2:]))
+        info_vecs.append(ops.expand(info_vec, shape + (-1,)))
+        precisions.append(ops.expand(precision, shape + (-1, -1)))
     if part_name != name:
         del inputs[part_name]
         del int_inputs[part_name]

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -326,7 +326,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
         #   Then g is an unbiased estimator of f in value and all derivatives.
         #   In the special case f = detach(f), we can simplify to
         #       g = delta(x=x0) |f|.
-        if flat_logits.requires_grad:
+        if hasattr(flat_logits, "requires_grad") and flat_logits.requires_grad:
             # Apply a dice factor to preserve differentiability.
             index = [ops.new_arange(self.data, n).reshape((n,) + (1,) * (len(flat_logits.shape) - i - 2))
                      for i, n in enumerate(flat_logits.shape[:-1])]
@@ -337,7 +337,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
                                   (log_prob - log_prob.detach()), sb_inputs))
         else:
             # This is the special case f = detach(f).
-            results.append(Tensor(flat_logits.logsumexp(-1), batch_inputs))
+            results.append(Tensor(ops.logsumexp(flat_logits, -1), batch_inputs))
 
         return reduce(ops.add, results)
 

--- a/funsor/torch.py
+++ b/funsor/torch.py
@@ -141,6 +141,8 @@ def _diagonal(x, dim1, dim2):
 
 @ops.cat.register(int, [torch.Tensor])
 def _cat(dim, *x):
+    if len(x) == 1:
+        return x[0]
     return torch.cat(x, dim=dim)
 
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -965,3 +965,11 @@ def test_cat_simple(output, backend):
         ('k', bint(6)),
     ])
     assert xy.output == output
+
+
+@pytest.mark.parametrize("expand_shape", [(4, 3, 2), (4, -1, 2), (4, 3, -1), (4, -1, -1)])
+@pytest.mark.parametrize("backend", ["torch", "numpy"])
+def test_ops_expand(expand_shape, backend):
+    x = randn((3, 2), backend)
+    actual = ops.expand(x, expand_shape)
+    assert actual.shape == (4, 3, 2)


### PR DESCRIPTION
Following fixes are detected while I did profiling GaussianHMM in #315.
- Support `-1` in expand shape for numpy backend using @fritzo 's suggestion
- `UnshapedArray` is replaced by `jax.core.Tracer`. A device array `x` will become `Tracer` under jit/vmap/pmap. This tracer has an attribute `x.aval`, which is UnshapedArray.
- Make `eager_cat_homogeneous` backend agnostic

Follow-up PR:
- enhance the speed of Gaussian