### PR TITLE
Add generic unscaled_sample method to Distribution

### DIFF
--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -216,6 +216,7 @@ _wrapped_pyro_dists = [
     (dist.Normal, ()),
     (dist.MultivariateNormal, ('loc', 'scale_tril')),
     (dist.Delta, ()),
+    (fakes.NonreparameterizedBeta, ()),
     (fakes.NonreparameterizedGamma, ()),
     (fakes.NonreparameterizedNormal, ()),
     (fakes.NonreparameterizedDirichlet, ()),

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -113,7 +113,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         inputs_, tensors = align_tensors(*params.values())
         inputs = OrderedDict(sample_inputs.items())
         inputs.update(inputs_)
-        sample_shape = tuple(v.dtype for v in sample_inputs.values())
+        sample_shape = tuple(v.size for v in sample_inputs.values())
 
         raw_dist = self.dist_class(**dict(zip(self._ast_fields[:-1], tensors)))
         if getattr(raw_dist, "has_rsample", False):

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -110,12 +110,16 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         assert all(isinstance(v, (Number, Tensor)) for v in params.values())
         assert isinstance(value, Variable) and value.name in sampled_vars
         inputs_, tensors = align_tensors(*params.values())
-        raw_sample = self.dist_class(
-            **dict(zip(self._ast_fields[:-1], tensors))
-        ).sample(tuple(v.dtype for v in sample_inputs.values()))
+        raw_dist = self.dist_class(**dict(zip(self._ast_fields[:-1], tensors)))
+        raw_sample = raw_dist.sample(tuple(v.dtype for v in sample_inputs.values()))
+        raw_score_function = raw_dist.score_parts(raw_sample).score_function
         inputs = OrderedDict((k, v) for k, v in sample_inputs.items())
         inputs.update(inputs_)
-        return funsor.delta.Delta(value.name, Tensor(raw_sample, inputs, value.output.dtype))
+        result = funsor.delta.Delta(value.name, Tensor(raw_sample, inputs, value.output.dtype))
+        if not dist.util.is_identically_zero(raw_score_function):
+            dice_factor = Tensor(raw_score_function - raw_score_function.detach(), inputs, reals())
+            result = dice_factor + result
+        return result
 
     def __getattribute__(self, attr):
         if attr in type(self)._ast_fields and attr != 'name':

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -111,7 +111,10 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         assert isinstance(value, Variable) and value.name in sampled_vars
         inputs_, tensors = align_tensors(*params.values())
         raw_dist = self.dist_class(**dict(zip(self._ast_fields[:-1], tensors)))
-        raw_sample = raw_dist.sample(tuple(v.dtype for v in sample_inputs.values()))
+        if raw_dist.has_rsample:
+            raw_sample = raw_dist.rsample(tuple(v.dtype for v in sample_inputs.values()))
+        else:
+            raw_sample = raw_dist.sample(tuple(v.dtype for v in sample_inputs.values()))
         raw_score_function = raw_dist.score_parts(raw_sample).score_function
         inputs = OrderedDict((k, v) for k, v in sample_inputs.items())
         inputs.update(inputs_)

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 
 import makefun
 import pyro.distributions as dist
+import pyro.distributions.testing.fakes as fakes
 from pyro.distributions.torch_distribution import MaskedDistribution
 import torch
 import torch.distributions.constraints as constraints
@@ -111,7 +112,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         assert isinstance(value, Variable) and value.name in sampled_vars
         inputs_, tensors = align_tensors(*params.values())
         raw_dist = self.dist_class(**dict(zip(self._ast_fields[:-1], tensors)))
-        if raw_dist.has_rsample:
+        if getattr(raw_dist, "has_rsample", False):
             raw_sample = raw_dist.rsample(tuple(v.dtype for v in sample_inputs.values()))
         else:
             raw_sample = raw_dist.sample(tuple(v.dtype for v in sample_inputs.values()))
@@ -215,6 +216,9 @@ _wrapped_pyro_dists = [
     (dist.Normal, ()),
     (dist.MultivariateNormal, ('loc', 'scale_tril')),
     (dist.Delta, ()),
+    (fakes.NonreparameterizedGamma, ()),
+    (fakes.NonreparameterizedNormal, ()),
+    (fakes.NonreparameterizedDirichlet, ()),
 ]
 
 for pyro_dist_class, param_names in _wrapped_pyro_dists:

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -117,8 +117,9 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         inputs.update(inputs_)
         result = funsor.delta.Delta(value.name, Tensor(raw_sample, inputs, value.output.dtype))
         if not dist.util.is_identically_zero(raw_score_function):
+            # scaling of dice_factor by num samples should already be handled by Funsor.sample
             dice_factor = Tensor(raw_score_function - raw_score_function.detach(), inputs, reals())
-            result = dice_factor + result
+            result += dice_factor
         return result
 
     def __getattribute__(self, attr):

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -313,7 +313,7 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
     pyro_dist_class = funsor_dist.dist_class
     params = [to_data(getattr(funsor_dist, param_name), name_to_dim=name_to_dim)
               for param_name in funsor_dist._ast_fields if param_name != 'value']
-    pyro_dist = pyro_dist_class(*params)
+    pyro_dist = pyro_dist_class(**dict(zip(funsor_dist._ast_fields[:-1], params)))
     funsor_event_shape = funsor_dist.value.output.shape
     pyro_dist = pyro_dist.to_event(max(len(funsor_event_shape) - len(pyro_dist.event_shape), 0))
     if pyro_dist.event_shape != funsor_event_shape:

--- a/funsor/distributions.py
+++ b/funsor/distributions.py
@@ -118,7 +118,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         result = funsor.delta.Delta(value.name, Tensor(raw_sample, inputs, value.output.dtype))
         if not dist.util.is_identically_zero(raw_score_function):
             # scaling of dice_factor by num samples should already be handled by Funsor.sample
-            dice_factor = Tensor(raw_score_function - raw_score_function.detach(), inputs, reals())
+            dice_factor = Tensor(raw_score_function - raw_score_function.detach(), inputs)
             result += dice_factor
         return result
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -734,3 +734,33 @@ def test_bernoullilogits_sample(batch_shape, sample_inputs):
     funsor_dist = dist.Bernoulli(logits=logits)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
+
+
+@pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_beta_sample(batch_shape, sample_inputs):
+    sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    concentration1 = Tensor(torch.randn(batch_shape).exp(), inputs)
+    concentration0 = Tensor(torch.randn(batch_shape).exp(), inputs)
+    funsor_dist = dist.Beta(concentration1, concentration0)
+
+    _check_sample(funsor_dist, sample_inputs, inputs)
+
+
+@pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_binomial_sample(batch_shape, sample_inputs):
+    sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    max_count = 10
+    total_count_data = random_tensor(inputs, bint(max_count)).data.float()
+    total_count = Tensor(total_count_data, inputs)
+    probs = Tensor(torch.rand(batch_shape), inputs)
+    funsor_dist = dist.Binomial(total_count, probs)
+
+    _check_sample(funsor_dist, sample_inputs, inputs)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -792,3 +792,16 @@ def test_binomial_sample(batch_shape, sample_inputs):
     funsor_dist = dist.Binomial(total_count, probs)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
+
+
+@pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_poisson_sample(batch_shape, sample_inputs):
+    sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    rate = Tensor(torch.rand(batch_shape), inputs)
+    funsor_dist = dist.Poisson(rate)
+
+    _check_sample(funsor_dist, sample_inputs, inputs)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -687,9 +687,10 @@ def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2, rtol=1e-2):
             frozenset(['value'])
         ).reduce(ops.add, frozenset(sample_inputs))
         grad_targets = [v.data for v in list(funsor_dist.params.values())[:-1]]
-        actual_grads = torch.autograd.grad(actual_variance.reduce(ops.add).data, grad_targets, allow_unused=True)
+        actual_grads = torch.autograd.grad(actual_variance.reduce(ops.add).sum().data, grad_targets, allow_unused=True)
         expected_variance = Tensor(funsor_dist.dist_class(*tensors).variance, inputs)
-        expected_grads = torch.autograd.grad(expected_variance.reduce(ops.add).data, grad_targets, allow_unused=True)
+        expected_grads = torch.autograd.grad(
+            expected_variance.reduce(ops.add).sum().data, grad_targets, allow_unused=True)
 
         assert_close(actual_variance, expected_variance, atol=atol, rtol=rtol)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -723,7 +723,6 @@ def test_dirichlet_sample(batch_shape, sample_inputs, event_shape):
     _check_sample(funsor_dist, sample_inputs, inputs)
 
 
-@pytest.mark.xfail(reason="incorrect output somehow?")
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_bernoullilogits_sample(batch_shape, sample_inputs):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -658,7 +658,7 @@ def test_von_mises_probs_density(batch_shape, syntax):
     assert_close(actual, expected)
 
 
-def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-1, rtol=None,
+def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2, rtol=None,
                   num_samples=100000, statistic="mean", skip_grad=False):
     """utility that compares a Monte Carlo estimate of a distribution mean with the true mean"""
     samples_per_dim = int(num_samples ** (1./max(1, len(sample_inputs))))
@@ -729,7 +729,8 @@ def test_gamma_sample(batch_shape, sample_inputs, reparametrized):
     rate = Tensor(torch.rand(batch_shape), inputs)
     funsor_dist = (dist.Gamma if reparametrized else dist.NonreparameterizedGamma)(concentration, rate)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000,
+                  atol=5e-2 if reparametrized else 1e-1)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])
@@ -745,7 +746,7 @@ def test_normal_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
     with interpretation(lazy if with_lazy else eager):
         funsor_dist = (dist.Normal if reparametrized else dist.NonreparameterizedNormal)(loc, scale)
 
-    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
+    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000, atol=1e-2 if reparametrized else 1e-1)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])
@@ -761,7 +762,7 @@ def test_mvn_sample(with_lazy, batch_shape, sample_inputs, event_shape):
     with interpretation(lazy if with_lazy else eager):
         funsor_dist = dist.MultivariateNormal(loc, scale_tril)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
 
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
@@ -775,7 +776,7 @@ def test_dirichlet_sample(batch_shape, sample_inputs, event_shape, reparametrize
     concentration = Tensor(torch.randn(batch_shape + event_shape).exp(), inputs)
     funsor_dist = (dist.Dirichlet if reparametrized else dist.NonreparameterizedDirichlet)(concentration)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2 if reparametrized else 1e-1)
 
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
@@ -816,7 +817,8 @@ def test_beta_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
         funsor_dist = (dist.Beta if reparametrized else dist.NonreparameterizedBeta)(
             concentration1, concentration0)
 
-    _check_sample(funsor_dist, sample_inputs, inputs, statistic="variance", num_samples=100000)
+    _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2 if reparametrized else 1e-1,
+                  statistic="variance", num_samples=100000)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -703,14 +703,15 @@ def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2, rtol=1e-2):
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_gamma_sample(batch_shape, sample_inputs):
+@pytest.mark.parametrize('reparametrized', [True, False])
+def test_gamma_sample(batch_shape, sample_inputs, reparametrized):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
     concentration = Tensor(torch.rand(batch_shape), inputs)
     rate = Tensor(torch.rand(batch_shape), inputs)
-    funsor_dist = dist.Gamma(concentration, rate)
+    funsor_dist = (dist.Gamma if reparametrized else dist.NonreparameterizedGamma)(concentration, rate)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
 
@@ -718,7 +719,8 @@ def test_gamma_sample(batch_shape, sample_inputs):
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_normal_sample(with_lazy, batch_shape, sample_inputs):
+@pytest.mark.parametrize('reparametrized', [True, False])
+def test_normal_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -726,7 +728,7 @@ def test_normal_sample(with_lazy, batch_shape, sample_inputs):
     loc = Tensor(torch.randn(batch_shape), inputs)
     scale = Tensor(torch.rand(batch_shape), inputs)
     with interpretation(lazy if with_lazy else eager):
-        funsor_dist = dist.Normal(loc, scale)
+        funsor_dist = (dist.Normal if reparametrized else dist.NonreparameterizedNormal)(loc, scale)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
 
@@ -751,13 +753,14 @@ def test_mvn_sample(with_lazy, batch_shape, sample_inputs, event_shape):
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
-def test_dirichlet_sample(batch_shape, sample_inputs, event_shape):
+@pytest.mark.parametrize('reparametrized', [True, False])
+def test_dirichlet_sample(batch_shape, sample_inputs, event_shape, reparametrized):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
 
     concentration = Tensor(torch.randn(batch_shape + event_shape).exp(), inputs)
-    funsor_dist = dist.Dirichlet(concentration)
+    funsor_dist = (dist.Dirichlet if reparametrized else dist.NonreparameterizedDirichlet)(concentration)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
 
@@ -791,7 +794,8 @@ def test_bernoulliprobs_sample(batch_shape, sample_inputs):
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
-def test_beta_sample(with_lazy, batch_shape, sample_inputs):
+@pytest.mark.parametrize('reparametrized', [True, False])
+def test_beta_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
@@ -799,7 +803,8 @@ def test_beta_sample(with_lazy, batch_shape, sample_inputs):
     concentration1 = Tensor(torch.randn(batch_shape).exp(), inputs)
     concentration0 = Tensor(torch.randn(batch_shape).exp(), inputs)
     with interpretation(lazy if with_lazy else eager):
-        funsor_dist = dist.Beta(concentration1, concentration0)
+        funsor_dist = (dist.Beta if reparametrized else dist.NonreparameterizedBeta)(
+            concentration1, concentration0)
 
     _check_sample(funsor_dist, sample_inputs, inputs)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -658,7 +658,7 @@ def test_von_mises_probs_density(batch_shape, syntax):
     assert_close(actual, expected)
 
 
-def _check_sample(funsor_dist, sample_inputs, inputs):
+def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-2, rtol=1e-2):
     """utility that compares a Monte Carlo estimate of a distribution mean with the true mean"""
     sample_value = funsor_dist.sample(frozenset(['value']), sample_inputs)
     expected_inputs = OrderedDict(
@@ -676,7 +676,7 @@ def _check_sample(funsor_dist, sample_inputs, inputs):
 
         # TODO check gradients as well
         check_funsor(actual_mean, expected_mean.inputs, expected_mean.output)
-        assert_close(actual_mean, expected_mean, atol=1e-2, rtol=1e-2)
+        assert_close(actual_mean, expected_mean, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -18,7 +18,7 @@ from funsor.interpreter import interpretation, reinterpret
 from funsor.integrate import Integrate
 from funsor.pyro.convert import dist_to_funsor
 from funsor.tensor import Einsum, Tensor, align_tensors
-from funsor.terms import Independent, Variable, lazy
+from funsor.terms import Independent, Variable, eager, lazy
 from funsor.testing import assert_close, check_funsor, random_mvn, random_tensor, xfail_param
 from funsor.util import get_backend
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -816,7 +816,7 @@ def test_beta_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
         funsor_dist = (dist.Beta if reparametrized else dist.NonreparameterizedBeta)(
             concentration1, concentration0)
 
-    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
+    _check_sample(funsor_dist, sample_inputs, inputs, statistic="variance", num_samples=100000)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -762,7 +762,7 @@ def test_mvn_sample(with_lazy, batch_shape, sample_inputs, event_shape):
     with interpretation(lazy if with_lazy else eager):
         funsor_dist = dist.MultivariateNormal(loc, scale_tril)
 
-    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
+    _check_sample(funsor_dist, sample_inputs, inputs, atol=5e-2, num_samples=200000)
 
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -788,7 +788,7 @@ def test_bernoullilogits_sample(batch_shape, sample_inputs):
     logits = Tensor(torch.rand(batch_shape), inputs)
     funsor_dist = dist.Bernoulli(logits=logits)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, atol=5e-2, num_samples=100000)
 
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
@@ -800,7 +800,7 @@ def test_bernoulliprobs_sample(batch_shape, sample_inputs):
     probs = Tensor(torch.rand(batch_shape), inputs)
     funsor_dist = dist.Bernoulli(probs=probs)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, atol=5e-2, num_samples=100000)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -695,6 +695,21 @@ def test_gamma_sample(batch_shape, sample_inputs):
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_normal_sample(batch_shape, sample_inputs):
+    sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    loc = Tensor(torch.randn(batch_shape), inputs)
+    scale = Tensor(torch.rand(batch_shape), inputs)
+    with interpretation(lazy):
+        funsor_dist = dist.Normal(loc, scale)
+
+    _check_sample(funsor_dist, sample_inputs, inputs)
+
+
+@pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
 def test_mvn_sample(batch_shape, sample_inputs, event_shape):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -658,9 +658,9 @@ def test_von_mises_probs_density(batch_shape, syntax):
     assert_close(actual, expected)
 
 
-def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-1, rtol=None, statistic="mean", skip_grad=False):
+def _check_sample(funsor_dist, sample_inputs, inputs, atol=1e-1, rtol=None,
+                  num_samples=100000, statistic="mean", skip_grad=False):
     """utility that compares a Monte Carlo estimate of a distribution mean with the true mean"""
-    num_samples = 100000
     samples_per_dim = int(num_samples ** (1./max(1, len(sample_inputs))))
     sample_inputs = OrderedDict((k, bint(samples_per_dim)) for k in sample_inputs)
 
@@ -745,7 +745,7 @@ def test_normal_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
     with interpretation(lazy if with_lazy else eager):
         funsor_dist = (dist.Normal if reparametrized else dist.NonreparameterizedNormal)(loc, scale)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])
@@ -816,7 +816,7 @@ def test_beta_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
         funsor_dist = (dist.Beta if reparametrized else dist.NonreparameterizedBeta)(
             concentration1, concentration0)
 
-    _check_sample(funsor_dist, sample_inputs, inputs)
+    _check_sample(funsor_dist, sample_inputs, inputs, num_samples=200000)
 
 
 @pytest.mark.parametrize("with_lazy", [True, xfail_param(False, reason="missing pattern")])

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -738,6 +738,19 @@ def test_bernoullilogits_sample(batch_shape, sample_inputs):
 
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+def test_bernoulliprobs_sample(batch_shape, sample_inputs):
+    sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, bint(v)) for k, v in zip(batch_dims, batch_shape))
+
+    probs = Tensor(torch.rand(batch_shape), inputs)
+    funsor_dist = dist.Bernoulli(probs=probs)
+
+    _check_sample(funsor_dist, sample_inputs, inputs)
+
+
+@pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 def test_beta_sample(batch_shape, sample_inputs):
     sample_inputs = OrderedDict((k, bint(10 ** (6 // len(sample_inputs)))) for k in sample_inputs)
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]


### PR DESCRIPTION
This PR adds a `Distribution.unscaled_sample` method for rewriting `Distribution` funsors to `Delta` funsors with correct Dice factors computed generically from Pyro's `TorchDistribution.score_parts` methods.

Questions for review:
- Is there a better way to test gradients generically?
- Can we make the tests less expensive and more reliable?