### PR TITLE
Fix and simplify Tensor output shape inference

### DIFF
--- a/funsor/jax.py
+++ b/funsor/jax.py
@@ -16,7 +16,7 @@ from funsor.adjoint import adjoint_ops
 from funsor.domains import bint, reals
 from funsor.interpreter import children, recursion_reinterpret
 from funsor.terms import Funsor, to_funsor
-from funsor.tensor import Tensor
+from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.util import quote
 
 
@@ -37,32 +37,8 @@ def _children_ground(x):
     return ()
 
 
-@to_funsor.register(DeviceArray)
-@to_funsor.register(Tracer)
-def tensor_to_funsor(x, output=None, dim_to_name=None):
-    if not dim_to_name:
-        output = output if output is not None else reals(*x.shape)
-        result = Tensor(x, dtype=output.dtype)
-        if result.output != output:
-            raise ValueError("Invalid shape: expected {}, actual {}"
-                             .format(output.shape, result.output.shape))
-        return result
-    else:
-        assert output is not None  # TODO attempt to infer output
-        assert all(isinstance(k, int) and k < 0 and isinstance(v, str)
-                   for k, v in dim_to_name.items())
-        # logic very similar to pyro.ops.packed.pack
-        # this should not touch memory, only reshape
-        # pack the tensor according to the dim => name mapping in inputs
-        packed_inputs = OrderedDict()
-        for dim, size in zip(range(len(x.shape) - len(output.shape)), x.shape):
-            name = dim_to_name.get(dim + len(output.shape) - len(x.shape), None)
-            if name is not None and size > 1:
-                packed_inputs[name] = bint(size)
-        shape = tuple(d.size for d in packed_inputs.values()) + output.shape
-        if x.shape != shape:
-            x = x.reshape(shape)
-        return Tensor(x, packed_inputs, dtype=output.dtype)
+to_funsor.register(DeviceArray)(tensor_to_funsor)
+to_funsor.register(Tracer)(tensor_to_funsor)
 
 
 @quote.register(DeviceArray)

--- a/funsor/jax.py
+++ b/funsor/jax.py
@@ -1,8 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
-
 import jax.numpy as np
 import numpy as onp
 from jax import lax
@@ -13,7 +11,6 @@ from jax.scipy.special import expit, logsumexp
 
 import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
-from funsor.domains import bint, reals
 from funsor.interpreter import children, recursion_reinterpret
 from funsor.terms import Funsor, to_funsor
 from funsor.tensor import Tensor, tensor_to_funsor

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -424,6 +424,8 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
                    for k, v in dim_to_name.items())
 
         if output is None:
+            # Assume the leftmost dim_to_name key refers to the leftmost dim of x
+            # when there is ambiguity about event shape
             batch_ndims = min(-min(dim_to_name.keys()), len(x.shape))
             output = reals(*x.shape[batch_ndims:])
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -424,11 +424,8 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
                    for k, v in dim_to_name.items())
 
         if output is None:
-            batch_ndims = max(dim_to_name.keys()) - min(dim_to_name.keys())
-            offset = 0
-            while len(x.shape[offset:]) > batch_ndims and x.shape[offset] == 1:
-                offset += 1
-            output = reals(*x.shape[offset + batch_ndims + 1:])
+            batch_ndims = min(-min(dim_to_name.keys()), len(x.shape))
+            output = reals(*x.shape[batch_ndims:])
 
         # logic very similar to pyro.ops.packed.pack
         # this should not touch memory, only reshape

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -936,3 +936,11 @@ def test_ops_expand(expand_shape):
     x = randn((3, 2))
     actual = ops.expand(x, expand_shape)
     assert actual.shape == (4, 3, 2)
+
+
+def test_tensor_to_funsor_ambiguous_output():
+    x = randn((2, 1))
+    f = funsor.to_funsor(x, output=None, dim_to_name=OrderedDict({-2: 'a'}))
+    f2 = funsor.to_funsor(x, output=reals(), dim_to_name=OrderedDict({-2: 'a'}))
+    assert f.inputs == f2.inputs == OrderedDict(a=bint(2))
+    assert f.output.shape == () == f2.output.shape


### PR DESCRIPTION
This PR fixes `to_funsor`'s output shape inference for tensors so that it correctly handles empty batch dimensions on the right.  The test added to `test_tensor.py` is a minimal failure case, and the changes are otherwise exercised by existing tests in `test/pyro/test_convert.py` and elsewhere.

I found this bug while working on examples for https://github.com/pyro-ppl/pyro/pull/2307