### PR TITLE
Fix a userwarning about integer divison in PyTorch 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ docs: FORCE
 	$(MAKE) -C docs html
 
 lint: FORCE
-	flake8 --per-file-ignores='funsor/distributions.py:F821'
+	flake8
 
 license: FORCE
 	python scripts/update_headers.py

--- a/examples/eeg_slds.py
+++ b/examples/eeg_slds.py
@@ -251,7 +251,7 @@ def main(args):
         print("[raw data shape] {}".format(data.shape))
         data = data[::20, :]
         print("[data shape after thinning] {}".format(data.shape))
-        eye_state = [int(l) for l in data[:, -1].tolist()]
+        eye_state = [int(d) for d in data[:, -1].tolist()]
         data = torch.tensor(data[:, :-1]).float()
     # in test mode (for continuous integration on github) so create fake data
     else:

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -327,7 +327,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
         for name, domain in reversed(list(event_inputs.items())):
             size = domain.dtype
             point = Tensor(mod_sample % size, sb_inputs, size)
-            mod_sample = mod_sample / size
+            mod_sample = mod_sample // size
             results.append(Delta(name, point))
 
         # Account for the log normalizer factor.

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -179,8 +179,8 @@ def set_backend(backend):
         import jax  # noqa: F401
         import funsor.jax  # noqa: F401
     else:
-        raise ValueError(f"backend should be either 'numpy', 'torch', or 'jax'"
-                         ", got {backend}")
+        raise ValueError("backend should be either 'numpy', 'torch', or 'jax'"
+                         ", got {}".format(backend))
 
 
 def get_backend():

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,10 @@
 max-line-length = 120
 exclude = docs/src, build, dist
 ignore = F811,E121,E123,E126,E226,E24,E704,W503,W504
+per-file-ignores =
+    funsor/distributions.py:F821
+    test/examples/test_bart.py:E128
+    test/examples/test_sensor_fusion.py:E128
 
 [isort]
 line_length = 120


### PR DESCRIPTION
`Tensor.unscaled_sample` has been triggering the following `UserWarning` with PyTorch 1.5:
```
UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.
```
This PR makes the suggested change (`/` to `//`).  It may be necessary to merge this to placate Travis before any of https://github.com/pyro-ppl/pyro/pull/2307 can be merged.