### PR TITLE
Pin pyro-api version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'test': [
             'flake8',
             'pandas',
-            'pyro-api>=0.1',
+            'pyro-api==0.1.1',
             'pytest-xdist==1.27.0',
             'pillow-simd',
             'scipy',


### PR DESCRIPTION
This pins `pyro-api==0.1.1` to avoid breaking changes in https://github.com/pyro-ppl/pyro-api/pull/19
The version can later be unpinned to `pyro-api>=0.1.2` in https://github.com/pyro-ppl/funsor/pull/327

This can be merged any time, and will keep funsor development unblocked after https://github.com/pyro-ppl/pyro-api/pull/19 merges