### PR TITLE
Import pytest lazily and remove install dependency

### DIFF
--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -10,7 +10,6 @@ from functools import reduce
 
 import numpy as np
 import opt_einsum
-import pytest
 from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic
 
@@ -29,6 +28,7 @@ def xfail_if_not_implemented(msg="Not implemented"):
     try:
         yield
     except NotImplementedError as e:
+        import pytest
         pytest.xfail(reason='{}:\n{}'.format(msg, e))
 
 
@@ -185,6 +185,7 @@ def check_funsor(x, inputs, output, data=None):
 
 
 def xfail_param(*args, **kwargs):
+    import pytest
     return pytest.param(*args, marks=[pytest.mark.xfail(**kwargs)])
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'multipledispatch',
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
-        'pytest>=4.1',
     ],
     extras_require={
         'torch': [
@@ -54,6 +53,7 @@ setup(
             'flake8',
             'pandas',
             'pyro-api>=0.1.2',
+            'pytest>=4.1',
             'pytest-xdist==1.27.0',
             'pillow-simd',
             'scipy',
@@ -63,6 +63,7 @@ setup(
             'flake8',
             'isort',
             'pandas',
+            'pytest>=4.1',
             'pytest-xdist==1.27.0',
             'scipy',
             'sphinx>=2.0',


### PR DESCRIPTION
Resolves #336 

This removes the install dependency on pytest by lazily loading pytest in two places in testing.py. I believe this is very safe because those two functions are only used to mark pytest tests.