### PR TITLE
Pin pytest to 4.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ jobs:
               # Keep track of Pyro dev branch
               - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
               - pip install -e .[torch]
-              # - FUNSOR_BACKEND=torch make test
+              - FUNSOR_BACKEND=torch make test
         - name: jax
           python: 3.6
           script:
               - pip install -e .[jax]
               # Keep track of NumPyro master branch
               - pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
-              # - CI=1 FUNSOR_BACKEND=jax make test
+              - CI=1 FUNSOR_BACKEND=jax make test
         - name: torch35
           python: 3.5
           script:
@@ -52,4 +52,4 @@ jobs:
               # Keep track of Pyro dev branch
               - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
               - pip install -e .[torch]
-              # - FUNSOR_BACKEND=torch make test
+              - FUNSOR_BACKEND=torch make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
           name: numpy
           python: 3.6
           script:
-              - make test
+              - make test  # this fails
         - name: torch
           python: 3.6
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
           name: numpy
           python: 3.6
           script:
-              - make test  # this fails
+              - make test
         - name: torch
           python: 3.6
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ jobs:
               # Keep track of Pyro dev branch
               - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
               - pip install -e .[torch]
-              - FUNSOR_BACKEND=torch make test
+              # - FUNSOR_BACKEND=torch make test
         - name: jax
           python: 3.6
           script:
               - pip install -e .[jax]
               # Keep track of NumPyro master branch
               - pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
-              - CI=1 FUNSOR_BACKEND=jax make test
+              # - CI=1 FUNSOR_BACKEND=jax make test
         - name: torch35
           python: 3.5
           script:
@@ -52,4 +52,4 @@ jobs:
               # Keep track of Pyro dev branch
               - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
               - pip install -e .[torch]
-              - FUNSOR_BACKEND=torch make test
+              # - FUNSOR_BACKEND=torch make test

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             'flake8',
             'isort',
             'pandas',
-            'pytest>=4.1',
+            'pytest>=4.1<5',
             'pytest-xdist==1.27.0',
             'scipy',
             'sphinx>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     install_requires=[
         'makefun',
         'multipledispatch',
-        'numpy>=1.16.2',
-        'opt_einsum>=3.2.1',
+        'numpy>=1.7',
+        'opt_einsum>=2.3.2',
     ],
     extras_require={
         'torch': [
@@ -56,7 +56,7 @@ setup(
             'pytest==4.3.1',
             'pytest-xdist==1.27.0',
             'pillow-simd',
-            'scipy==1.5.1',
+            'scipy',
             'torchvision',
         ],
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     install_requires=[
         'makefun',
         'multipledispatch',
-        'numpy==1.16.2',
-        'opt_einsum==3.2.1',
+        'numpy>=1.16.2',
+        'opt_einsum>=3.2.1',
     ],
     extras_require={
         'torch': [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'makefun',
         'multipledispatch',
-        'numpy==1.16.2',
+        'numpy>=1.7',
         'opt_einsum>=2.3.2',
     ],
     extras_require={
@@ -63,7 +63,7 @@ setup(
             'flake8',
             'isort',
             'pandas',
-            'pytest>=4.1',
+            'pytest==4.3.1',
             'pytest-xdist==1.27.0',
             'scipy',
             'sphinx>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'makefun',
         'multipledispatch',
-        'numpy>=1.7',
+        'numpy==1.16.2',
         'opt_einsum>=2.3.2',
     ],
     extras_require={
@@ -63,7 +63,7 @@ setup(
             'flake8',
             'isort',
             'pandas',
-            'pytest>=4.1<5',
+            'pytest>=4.1',
             'pytest-xdist==1.27.0',
             'scipy',
             'sphinx>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     install_requires=[
         'makefun',
         'multipledispatch',
-        'numpy>=1.7',
-        'opt_einsum>=2.3.2',
+        'numpy==1.16.2',
+        'opt_einsum==3.2.1',
     ],
     extras_require={
         'torch': [
@@ -53,10 +53,10 @@ setup(
             'flake8',
             'pandas',
             'pyro-api>=0.1.2',
-            'pytest>=4.1',
+            'pytest==4.3.1',
             'pytest-xdist==1.27.0',
             'pillow-simd',
-            'scipy',
+            'scipy==1.5.1',
             'torchvision',
         ],
         'dev': [


### PR DESCRIPTION
Travis [failed](https://travis-ci.com/github/pyro-ppl/funsor/jobs/365072551) with the latest pytest version, so I would like to pin pytest to the latest version [4.3.1](https://travis-ci.com/github/pyro-ppl/funsor/jobs/360281253#L332) that passed Travis #337. Recent PRs are passed because Travis pip didn't install the latest pytest version, only `4.3.1` (I don't know why).