### PR TITLE
Fix apache license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache License 2.0',
+        'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
The current license does not allow me to upload the package to PyPI because it does not belong to [this list](https://pypi.org/classifiers/).

After this is fixed, can I tag 0.2.0 to this commit instead of the previous commit?