### PR TITLE
Make torch backend log return the correct dtype of a boolean tensor

### DIFF
--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -107,7 +107,7 @@ def _is_numeric_array(x):
 @ops.log.register(torch.Tensor)
 def _log(x):
     if x.dtype in (torch.bool, torch.uint8, torch.long):
-        x = x.float()
+        x = x.to(dtype=torch.get_default_dtype())
     return x.log()
 
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -941,3 +941,15 @@ def test_tensor_to_funsor_ambiguous_output():
     f2 = funsor.to_funsor(x, output=reals(), dim_to_name=OrderedDict({-2: 'a'}))
     assert f.inputs == f2.inputs == OrderedDict(a=bint(2))
     assert f.output.shape == () == f2.output.shape
+
+
+@pytest.mark.skipif(get_backend() != "torch", reason="torch-specific regression")
+def test_log_correct_dtype():
+    import torch
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    x = Tensor(torch.rand(3, dtype=torch.get_default_dtype()))
+    try:
+        assert (x == x).all().log().data.dtype is x.data.dtype
+    finally:
+        torch.set_default_dtype(old_dtype)


### PR DESCRIPTION
Blocking https://github.com/pyro-ppl/pyro/pull/2595

In `funsor.delta.Delta.eager_subs` and `eager_reduce`, we compute log-density terms by checking equality of an input and a point:
```py
log_density += (value == point).all().log()
```
However, the PyTorch backend's `ops.log` calls `.float()` to cast boolean inputs like the result of `Funsor.all()` to floating-point tensors, so when the default dtype is not `float32` this produces results with incorrect dtype.  This PR makes `ops.log` use the default `dtype` instead and adds a regression test that would have caught this.