### PR TITLE
Support copy, deepcopy, pickle, detach

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import copyreg
 import operator
 from collections import namedtuple
 from functools import reduce
@@ -29,6 +30,12 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
             raise ValueError(repr(dtype))
         return super(Domain, cls).__new__(cls, shape, dtype)
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
     def __repr__(self):
         shape = tuple(self.shape)
         if isinstance(self.dtype, int):
@@ -53,6 +60,13 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     def size(self):
         assert isinstance(self.dtype, int)
         return self.dtype
+
+
+def pickle_domain(x):
+    return Domain, (x.shape, x.dtype)
+
+
+copyreg.pickle(Domain, pickle_domain)
 
 
 @quote.register(Domain)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import copyreg
 import operator
 from collections import namedtuple
 from functools import reduce
@@ -36,6 +35,9 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     def __deepcopy__(self, memo):
         return self
 
+    def __reduce__(self):
+        return Domain, (self.shape, self.dtype)
+
     def __repr__(self):
         shape = tuple(self.shape)
         if isinstance(self.dtype, int):
@@ -60,9 +62,6 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
     def size(self):
         assert isinstance(self.dtype, int)
         return self.dtype
-
-
-copyreg.pickle(Domain, lambda x: (Domain, (x.shape, x.dtype)))
 
 
 @quote.register(Domain)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -62,11 +62,7 @@ class Domain(namedtuple('Domain', ['shape', 'dtype'])):
         return self.dtype
 
 
-def pickle_domain(x):
-    return Domain, (x.shape, x.dtype)
-
-
-copyreg.pickle(Domain, pickle_domain)
+copyreg.pickle(Domain, lambda x: (Domain, (x.shape, x.dtype)))
 
 
 @quote.register(Domain)

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -164,7 +164,7 @@ class GetitemOp(Op, metaclass=GetitemMeta):
         self.__name__ = 'GetitemOp({})'.format(offset)
 
     def __reduce__(self):
-        return GetitemOp, self.offset
+        return GetitemOp, (self.offset,)
 
     def _default(self, x, y):
         return x[self._prefix + (y,)] if self.offset else x[y]

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -163,6 +163,9 @@ class GetitemOp(Op, metaclass=GetitemMeta):
         super(GetitemOp, self).__init__(self._default)
         self.__name__ = 'GetitemOp({})'.format(offset)
 
+    def __reduce__(self):
+        return GetitemOp, self.offset
+
     def _default(self, x, y):
         return x[self._prefix + (y,)] if self.offset else x[y]
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -32,13 +32,13 @@ class Op(Dispatcher):
     def __deepcopy__(self, memo):
         return self
 
+    def __reduce__(self):
+        return self.__name__
+
     def __repr__(self):
         return "ops." + self.__name__
 
     def __str__(self):
-        return self.__name__
-
-    def __reduce__(self):
         return self.__name__
 
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -135,6 +135,9 @@ class ReshapeOp(Op, metaclass=ReshapeMeta):
         self.shape = shape
         super().__init__(self._default)
 
+    def __reduce__(self):
+        return ReshapeOp, (self.shape,)
+
     def _default(self, x):
         return x.reshape(self.shape)
 

--- a/funsor/ops.py
+++ b/funsor/ops.py
@@ -17,17 +17,28 @@ _builtin_sum = sum
 
 
 class Op(Dispatcher):
-    def __init__(self, fn):
-        super(Op, self).__init__(fn.__name__)
+    def __init__(self, fn, *, name=None):
+        if name is None:
+            name = fn.__name__
+        super(Op, self).__init__(name)
         # register as default operation
         for nargs in (1, 2):
             default_signature = (object,) * nargs
             self.add(default_signature, fn)
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
     def __repr__(self):
         return "ops." + self.__name__
 
     def __str__(self):
+        return self.__name__
+
+    def __reduce__(self):
         return self.__name__
 
 
@@ -264,8 +275,8 @@ def _logaddexp(x, y):
     return log(exp(x - shift) + exp(y - shift)) + shift
 
 
-logaddexp = LogAddExpOp(_logaddexp)
-sample = SampleOp(_logaddexp)
+logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
+sample = SampleOp(_logaddexp, name="sample")
 
 
 @SubOp

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import copyreg
 import functools
 import itertools
 import math
@@ -208,9 +207,6 @@ class FunsorMeta(type):
             cls._cons_cache = WeakValueDictionary()
             cls._type_cache = WeakValueDictionary()
 
-        # Support pickling, copy.copy() and copy.deepcopy().
-        copyreg.pickle(cls, lambda x: (type(x).__origin__, x._ast_values))
-
     def __call__(cls, *args, **kwargs):
         if cls.__args__:
             cls = cls.__origin__
@@ -358,6 +354,12 @@ class Funsor(object, metaclass=FunsorMeta):
     @property
     def shape(self):
         return self.output.shape
+
+    def __copy__(self):
+        return self
+
+    def __reduce__(self):
+        return type(self).__origin__, self._ast_values
 
     def __hash__(self):
         return id(self)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -173,16 +173,6 @@ def moment_matching(cls, *args):
 
 interpreter.set_interpretation(eager)  # Use eager interpretation by default.
 
-FUNSORS = {}
-
-
-def pickle_funsor(x):
-    return unpickle_funsor, (type(x).__name__, x._ast_values)
-
-
-def unpickle_funsor(name, args):
-    return FUNSORS[name](*args)
-
 
 class FunsorMeta(type):
     """
@@ -219,8 +209,7 @@ class FunsorMeta(type):
             cls._type_cache = WeakValueDictionary()
 
         # Support pickling, copy.copy() and copy.deepcopy().
-        copyreg.pickle(cls, pickle_funsor)
-        FUNSORS[cls.__name__] = cls
+        copyreg.pickle(cls, lambda x: (type(x).__origin__, x._ast_values))
 
     def __call__(cls, *args, **kwargs):
         if cls.__args__:

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -40,7 +40,6 @@ for basename, comment in file_types:
         lineno += 1
         while lines[lineno].startswith(comment.format("Copyright")):
             lineno += 1
-            changed = True
 
         # Ensure next line is an SPDX short identifier.
         if not lines[lineno].startswith(comment.format("SPDX-License-Identifier")):
@@ -49,7 +48,7 @@ for basename, comment in file_types:
         lineno += 1
 
         # Ensure next line is blank.
-        if not lines[lineno].isspace():
+        if lineno < len(lines) and not lines[lineno].isspace():
             lines.insert(lineno, "\n")
             changed = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ per-file-ignores =
 [isort]
 line_length = 120
 multi_line_output=3
-not_skip = __init__.py
 known_first_party = funsor, test
 known_third_party = opt_einsum, pyro, pyroapi, torch, torchvision
 

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -1,0 +1,24 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import pickle
+
+import pytest
+
+from funsor.domains import bint, reals  # noqa F401
+
+
+@pytest.mark.parametrize('expr', [
+    "bint(2)",
+    "reals()",
+    "reals(4)",
+    "reals(3, 2)",
+])
+def test_pickle(expr):
+    x = eval(expr)
+    f = io.BytesIO()
+    pickle.dump(x, f)
+    f.seek(0)
+    y = pickle.load(f)
+    y is x

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -21,4 +21,4 @@ def test_pickle(expr):
     pickle.dump(x, f)
     f.seek(0)
     y = pickle.load(f)
-    y is x
+    assert y == x  # TODO promote to "y is x"

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -122,6 +122,7 @@ EXPR_STRINGS = [
     "Number(0.)",
     "Number(1, dtype=10)",
     "-Variable('x', reals())",
+    "Variable('x', reals(3))[Variable('i', bint(3))]",
     "Variable('x', reals()) + Variable('y', reals())",
     "Variable('x', reals())(x=Number(0.))",
     "Number(1) / Variable('x', reals())",

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -152,7 +152,7 @@ def test_pickle(expr):
     pickle.dump(x, f)
     f.seek(0)
     y = pickle.load(f)
-    y is x
+    assert y is x
 
 
 @pytest.mark.parametrize('expr', EXPR_STRINGS)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -1,7 +1,10 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import itertools
+import io
+import pickle
 import typing
 from collections import OrderedDict
 from functools import reduce
@@ -113,7 +116,7 @@ def test_quote(interp):
         check_quote(Lambda(Variable('i', bint(2)), z))
 
 
-@pytest.mark.parametrize('expr', [
+EXPR_STRINGS = [
     "Variable('x', bint(3))",
     "Variable('x', reals())",
     "Number(0.)",
@@ -121,7 +124,36 @@ def test_quote(interp):
     "-Variable('x', reals())",
     "Variable('x', reals()) + Variable('y', reals())",
     "Variable('x', reals())(x=Number(0.))",
-])
+    "Number(1) / Variable('x', reals())",
+    "Stack('i', (Number(0), Variable('z', reals())))",
+    "Cat('i', (Stack('i', (Number(0),)), Stack('i', (Number(1), Number(2)))))",
+    "Stack('t', (Number(1), Variable('x', reals()))).reduce(ops.logaddexp, 't')",
+]
+
+
+@pytest.mark.parametrize('expr', EXPR_STRINGS)
+def test_copy_immutable(expr):
+    x = eval(expr)
+    assert copy.copy(x) is x
+
+
+@pytest.mark.parametrize('expr', EXPR_STRINGS)
+def test_deepcopy_immutable(expr):
+    x = eval(expr)
+    assert copy.deepcopy(x) is x
+
+
+@pytest.mark.parametrize('expr', EXPR_STRINGS)
+def test_pickle(expr):
+    x = eval(expr)
+    f = io.BytesIO()
+    pickle.dump(x, f)
+    f.seek(0)
+    y = pickle.load(f)
+    y is x
+
+
+@pytest.mark.parametrize('expr', EXPR_STRINGS)
 def test_reinterpret(expr):
     x = eval(expr)
     assert funsor.reinterpret(x) is x

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -123,6 +123,7 @@ EXPR_STRINGS = [
     "Number(1, dtype=10)",
     "-Variable('x', reals())",
     "Variable('x', reals(3))[Variable('i', bint(3))]",
+    "Variable('x', reals(2, 2)).reshape((4,))",
     "Variable('x', reals()) + Variable('y', reals())",
     "Variable('x', reals())(x=Number(0.))",
     "Number(1) / Variable('x', reals())",


### PR DESCRIPTION
This aims to add support for Pyro's `detach(-)` function by adding support for `copy.copy()` and `copy.deepcopy()`, which is in turn implemented via new methods `.__copy__()`, `.__deepcopy__()` , and `.__reduce__()`. As a side effect of `.__reduce__()` we get pickle support.

## Tested
- [x] tests that `copy`ing and `deepcopy`ing immutable objects is a no-op, as is the [behavior of copy.copy()](https://github.com/python/cpython/blob/fa5d7251987c70a9c5d58b59a0b36ac9287eaafa/Lib/copy.py#L107) on other immutable objects like tuples and slices
- [x] test that copying a `Tensor` copies the underlying leaf `torch.Tensor`
- [x] test pickling of misc `Funsor`s
- [x] test `torch.save()` of misc `Funsor`s