### PR TITLE
Refactor domains to be types

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from funsor.domains import Domain, bint, find_domain, reals
+from funsor.domains import Domain, bint, find_domain, make_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.sum_product import MarkovProduct
@@ -64,6 +64,7 @@ __all__ = [
     'integrate',
     'interpreter',
     'joint',
+    'make_domain',
     'memoize',
     # 'minipyro',  # TODO: enable when minipyro is backend-agnostic
     'montecarlo',

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -14,7 +14,7 @@ import funsor.delta
 import funsor.ops as ops
 from funsor.affine import is_affine
 from funsor.cnf import GaussianMixture
-from funsor.domains import Domain, reals
+from funsor.domains import make_domain, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import (Tensor, align_tensors, dummy_numeric_array, get_default_prototype,
@@ -164,7 +164,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             out_dtype = int(instance.support.upper_bound + 1)
         else:
             out_dtype = 'real'
-        return Domain(dtype=out_dtype, shape=out_shape)
+        return make_domain(dtype=out_dtype, shape=out_shape)
 
     @classmethod
     @functools.lru_cache(maxsize=5000)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -92,11 +92,6 @@ class BintType(Domain):
             BintType._type_cache[size] = result
         return result
 
-    def __reduce__(cls):
-        if cls is Bint:
-            return "Bint"
-        return operator.getitem, (BintType, cls.size)
-
     num_elements = 1
 
     def __iter__(cls):

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -115,7 +115,7 @@ class BintType(Domain):
 
 
 @functools.partial(copyreg.pickle, BintType)
-def _pickle_real(cls):
+def _pickle_bint(cls):
     if cls is Bint:
         return "Bint"
     return operator.getitem, (Bint, cls.size)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -129,6 +129,7 @@ class BintType(type):
         return ()
 
     # DEPRECATED
+    @property
     def num_elements(cls):
         warnings.warn("Bint[n].num_elements is deprecated",
                       DeprecationWarning)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -34,7 +34,7 @@ class RealMeta(Domain):
             Real._type_cache[shape] = result
         return result
 
-    @lazy_property
+    @property
     def num_elements(cls):
         return reduce(operator.mul, cls.shape, 1)
 
@@ -118,7 +118,7 @@ def bint(size):
 
 
 # SHIM
-def domain(shape, dtype):
+def make_domain(shape, dtype):
     return Real[shape] if dtype == "real" else Bint[dtype]
 
 

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -7,7 +7,7 @@ from weakref import WeakValueDictionary
 
 import funsor
 import funsor.ops as ops
-from funsor.util import broadcast_shape, get_tracing_state, lazy_property, quote
+from funsor.util import broadcast_shape, get_tracing_state, quote
 
 
 class Domain(type):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -12,7 +12,7 @@ from functools import singledispatch
 
 import numpy as np
 
-from funsor.domains import Domain
+from funsor.domains import BintType, RealsType
 from funsor.ops import Op, is_numeric_array
 from funsor.registry import KeyedRegistry
 from funsor.util import is_nn_module
@@ -151,7 +151,8 @@ _ground_types = (
     functools.partial,
     types.FunctionType,
     types.BuiltinFunctionType,
-    Domain,
+    BintType,
+    RealsType,
     Op,
     np.generic,
     np.ndarray,
@@ -218,7 +219,7 @@ for t in _ground_types:
 
 
 def is_atom(x):
-    if isinstance(x, (tuple, frozenset)) and not isinstance(x, Domain):
+    if isinstance(x, (tuple, frozenset)):
         return len(x) == 0 or all(is_atom(c) for c in x)
     return isinstance(x, _ground_types) or is_numeric_array(x) or is_nn_module(x)
 

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -22,7 +22,7 @@ import torch
 
 from funsor.cnf import Contraction
 from funsor.delta import Delta
-from funsor.domains import Domain, bint, reals
+from funsor.domains import make_domain, bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import Tensor, align_tensors
@@ -72,7 +72,7 @@ def tensor_to_funsor(tensor, event_inputs=(), event_output=0, dtype="real"):
     assert isinstance(event_inputs, tuple)
     assert isinstance(event_output, int) and event_output >= 0
     inputs_shape = tensor.shape[:tensor.dim() - event_output]
-    output = Domain(dtype=dtype, shape=tensor.shape[tensor.dim() - event_output:])
+    output = make_domain(dtype=dtype, shape=tensor.shape[tensor.dim() - event_output:])
     dim_to_name = default_dim_to_name(inputs_shape, event_inputs)
     return to_funsor(tensor, output, dim_to_name)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -108,7 +108,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     :param numeric_array data: A PyTorch tensor or NumPy ndarray.
     :param OrderedDict inputs: An optional mapping from input name (str) to
-        datatype (:class:`~funsor.domains.Domain` ). Defaults to empty.
+        datatype (``funsor.domains.Domain``). Defaults to empty.
     :param dtype: optional output datatype. Defaults to "real".
     :type dtype: int or the string "real".
     """
@@ -760,7 +760,7 @@ class Function(Funsor):
     :class:`Function` s are usually created via the :func:`function` decorator.
 
     :param callable fn: A native PyTorch or NumPy function to wrap.
-    :param funsor.domains.Domain output: An output domain.
+    :param type output: An output domain.
     :param Funsor args: Funsor arguments.
     """
     def __init__(self, fn, output, args):
@@ -887,7 +887,7 @@ def function(*signature):
     assert signature
     inputs, output = signature[:-1], signature[-1]
     assert all(isinstance(d, Domain) for d in inputs)
-    assert isinstance(output, (Domain, tuple))
+    assert isinstance(output, tuple) or isinstance(output, Domain)
     return functools.partial(_function, inputs, output)
 
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -16,7 +16,7 @@ from multipledispatch.variadic import Variadic
 import funsor
 import funsor.ops as ops
 from funsor.delta import Delta
-from funsor.domains import Domain, domain, bint, find_domain, reals
+from funsor.domains import Domain, bint, find_domain, make_domain, reals
 from funsor.ops import GetitemOp, MatmulOp, Op, ReshapeOp
 from funsor.terms import (
     Binary,
@@ -32,7 +32,7 @@ from funsor.terms import (
     to_data,
     to_funsor
 )
-from funsor.util import getargspec, get_backend, get_tracing_state, is_nn_module, quote
+from funsor.util import get_backend, get_tracing_state, getargspec, is_nn_module, quote
 
 
 def get_default_prototype():
@@ -120,7 +120,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             for (k, d), size in zip(inputs, data.shape):
                 assert d.dtype == size
         inputs = OrderedDict(inputs)
-        output = domain(data.shape[len(inputs):], dtype)
+        output = make_domain(data.shape[len(inputs):], dtype)
         fresh = frozenset(inputs.keys())
         bound = frozenset()
         super(Tensor, self).__init__(inputs, output, fresh, bound)
@@ -1018,7 +1018,7 @@ def stack(parts, dim=0):
     assert dim < 0
     split = dim + len(shape) + 1
     shape = shape[:split] + (len(parts),) + shape[split:]
-    output = domain(shape, parts[0].dtype)
+    output = make_domain(shape, parts[0].dtype)
     fn = functools.partial(ops.stack, dim)
     return Function(fn, output, parts)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -16,7 +16,7 @@ from multipledispatch.variadic import Variadic
 import funsor
 import funsor.ops as ops
 from funsor.delta import Delta
-from funsor.domains import Domain, bint, find_domain, reals
+from funsor.domains import Domain, domain, bint, find_domain, reals
 from funsor.ops import GetitemOp, MatmulOp, Op, ReshapeOp
 from funsor.terms import (
     Binary,
@@ -120,7 +120,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             for (k, d), size in zip(inputs, data.shape):
                 assert d.dtype == size
         inputs = OrderedDict(inputs)
-        output = Domain(data.shape[len(inputs):], dtype)
+        output = domain(data.shape[len(inputs):], dtype)
         fresh = frozenset(inputs.keys())
         bound = frozenset()
         super(Tensor, self).__init__(inputs, output, fresh, bound)
@@ -1018,7 +1018,7 @@ def stack(parts, dim=0):
     assert dim < 0
     split = dim + len(shape) + 1
     shape = shape[:split] + (len(parts),) + shape[split:]
-    output = Domain(shape, parts[0].dtype)
+    output = domain(shape, parts[0].dtype)
     fn = functools.partial(ops.stack, dim)
     return Function(fn, output, parts)
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1064,7 +1064,7 @@ class Number(Funsor, metaclass=NumberMeta):
             assert isinstance(dtype, str) and dtype == "real"
             data = float(data)
         inputs = OrderedDict()
-        output = Domain((), dtype)
+        output = reals() if dtype == "real" else bint(dtype)
         super(Number, self).__init__(inputs, output)
         self.data = data
 
@@ -1428,7 +1428,7 @@ class Lambda(Funsor):
         inputs = expr.inputs.copy()
         inputs.pop(var.name, None)
         shape = (var.dtype,) + expr.output.shape
-        output = Domain(shape, expr.dtype)
+        output = reals(*shape) if expr.dtype == "real" else bint(expr.size)
         fresh = frozenset()
         bound = frozenset({var.name})
         super(Lambda, self).__init__(inputs, output, fresh, bound)

--- a/test/test_cnf.py
+++ b/test/test_cnf.py
@@ -9,7 +9,7 @@ import pytest
 
 from funsor import ops
 from funsor.cnf import Contraction, BACKEND_TO_EINSUM_BACKEND, BACKEND_TO_LOGSUMEXP_BACKEND
-from funsor.domains import bint  # noqa F403
+from funsor.domains import Bint, bint  # noqa F403
 from funsor.domains import reals
 from funsor.einsum import einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -6,7 +6,7 @@ import pickle
 
 import pytest
 
-from funsor.domains import bint, reals  # noqa F401
+from funsor.domains import Bint, Real, Reals, bint, reals  # noqa F401
 
 
 @pytest.mark.parametrize('expr', [
@@ -22,3 +22,36 @@ def test_pickle(expr):
     f.seek(0)
     y = pickle.load(f)
     assert y is x
+
+
+def test_cache():
+    assert Bint[1] is Bint[1]
+    assert Real is Reals[()]
+    assert Reals[2, 3] is Reals[2, 3]
+
+
+def test_subclass():
+    assert issubclass(Bint, Bint)
+    assert issubclass(Bint[1], Bint)
+    assert issubclass(Bint[1], Bint[1])
+    assert issubclass(Bint[2], Bint)
+    assert issubclass(Bint[2], Bint[2])
+    assert not issubclass(Bint, Bint[1])
+    assert not issubclass(Bint, Bint[2])
+    assert not issubclass(Bint[1], Bint[2])
+    assert not issubclass(Bint[2], Bint[1])
+
+    assert issubclass(Reals, Reals)
+    assert issubclass(Real, Real)
+    assert issubclass(Real, Reals)
+    assert issubclass(Reals[2], Reals)
+    assert issubclass(Reals[2], Reals[2])
+    assert not issubclass(Reals, Real)
+    assert not issubclass(Reals, Real[2])
+    assert not issubclass(Real, Reals[2])
+    assert not issubclass(Real[2], Real)
+
+    assert not issubclass(Reals, Bint)
+    assert not issubclass(Bint, Reals)
+    assert not issubclass(Reals[2], Bint[2])
+    assert not issubclass(Bint[2], Reals[2])

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -9,7 +9,7 @@ import pytest
 
 import funsor
 import funsor.ops as ops
-from funsor.domains import Domain, bint, find_domain, reals
+from funsor.domains import Bint, Real, bint, find_domain, make_domain, reals
 from funsor.interpreter import interpretation
 from funsor.terms import Cat, Lambda, Number, Slice, Stack, Variable, lazy
 from funsor.testing import (assert_close, assert_equiv, check_funsor, empty,
@@ -25,8 +25,8 @@ def test_quote(output_shape, inputs):
         import torch  # noqa: F401
 
     sizes = {'a': 4, 'b': 5, 'c': 6}
-    inputs = OrderedDict((k, bint(sizes[k])) for k in inputs)
-    x = random_tensor(inputs, reals(*output_shape))
+    inputs = OrderedDict((k, Bint[sizes[k]]) for k in inputs)
+    x = random_tensor(inputs, Real[output_shape])
     s = funsor.quote(x)
     assert isinstance(s, str)
     assert_close(eval(s), x)
@@ -300,7 +300,7 @@ def test_unary(symbol, dims):
 
     x = Tensor(data, inputs, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, inputs, funsor.Domain((), dtype), expected_data)
+    check_funsor(actual, inputs, funsor.make_domain((), dtype), expected_data)
 
 
 BINARY_OPS = [
@@ -340,7 +340,7 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
     expected_data = binary_eval(symbol, aligned[0], aligned[1])
 
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, inputs, Domain((), dtype), expected_data)
+    check_funsor(actual, inputs, make_domain((), dtype), expected_data)
 
 
 @pytest.mark.parametrize('output_shape2', [(), (2,), (3, 2)], ids=str)
@@ -595,7 +595,7 @@ def test_reduce_subset(dims, reduced_vars, op):
         else:
             for pos in reversed(sorted(map(dims.index, reduced_vars))):
                 data = REDUCE_OP_TO_NUMERIC[op](data, pos)
-        check_funsor(actual, expected_inputs, Domain((), dtype))
+        check_funsor(actual, expected_inputs, make_domain((), dtype))
         assert_close(actual, Tensor(data, expected_inputs, dtype),
                      atol=1e-5, rtol=1e-5)
 
@@ -618,7 +618,7 @@ def test_reduce_event(op, event_shape, dims):
     x = Tensor(data, inputs, dtype=dtype)
     op_name = numeric_op.__name__[1:] if op in [ops.min, ops.max] else numeric_op.__name__
     actual = getattr(x, op_name)()
-    check_funsor(actual, inputs, Domain((), dtype), expected_data)
+    check_funsor(actual, inputs, make_domain((), dtype), expected_data)
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (2, 3)])

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -12,7 +12,7 @@ import pytest
 
 import funsor
 import funsor.ops as ops
-from funsor.domains import Bint, Real, bint, find_domain, make_domain, reals
+from funsor.domains import Bint, Reals, bint, find_domain, make_domain, reals
 from funsor.interpreter import interpretation
 from funsor.terms import Cat, Lambda, Number, Slice, Stack, Variable, lazy
 from funsor.testing import (assert_close, assert_equiv, check_funsor, empty,
@@ -29,7 +29,7 @@ def test_quote(output_shape, inputs):
 
     sizes = {'a': 4, 'b': 5, 'c': 6}
     inputs = OrderedDict((k, Bint[sizes[k]]) for k in inputs)
-    x = random_tensor(inputs, Real[output_shape])
+    x = random_tensor(inputs, Reals[output_shape])
     s = funsor.quote(x)
     assert isinstance(s, str)
     assert_close(eval(s), x)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -15,7 +15,7 @@ import pytest
 import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction
-from funsor.domains import Bint, Real, bint, make_domain, reals
+from funsor.domains import Bint, Real, Reals, bint, make_domain, reals
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import REDUCE_OP_TO_NUMERIC
 from funsor.terms import (
@@ -44,6 +44,7 @@ from funsor.testing import assert_close, check_funsor, random_tensor
 assert Binary  # flake8
 assert Subs  # flake8
 assert Contraction  # flake8
+assert Reals  # flake8
 
 np.seterr(all='ignore')
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -71,7 +71,7 @@ def test_to_data_error():
     with pytest.raises(ValueError):
         to_data(Variable('x', Real))
     with pytest.raises(ValueError):
-        to_data(Variable('y', Bint(12)))
+        to_data(Variable('y', Bint[12]))
 
 
 def test_cons_hash():

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -12,7 +12,7 @@ import pytest
 import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction
-from funsor.domains import Bint, Real, bint, domain, reals
+from funsor.domains import Bint, Real, bint, make_domain, reals
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import REDUCE_OP_TO_NUMERIC
 from funsor.terms import (
@@ -69,9 +69,9 @@ def test_to_data():
 
 def test_to_data_error():
     with pytest.raises(ValueError):
-        to_data(Variable('x', reals()))
+        to_data(Variable('x', Real))
     with pytest.raises(ValueError):
-        to_data(Variable('y', bint(12)))
+        to_data(Variable('y', Bint(12)))
 
 
 def test_cons_hash():
@@ -205,7 +205,7 @@ def test_unary(symbol, data):
 
     x = Number(data, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, {}, domain((), dtype), expected_data)
+    check_funsor(actual, {}, make_domain((), dtype), expected_data)
 
 
 BINARY_OPS = [
@@ -240,7 +240,7 @@ def test_binary(symbol, data1, data2):
     x1 = Number(data1, dtype)
     x2 = Number(data2, dtype)
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, {}, domain((), dtype), expected_data)
+    check_funsor(actual, {}, make_domain((), dtype), expected_data)
     with interpretation(normalize):
         actual_reflect = binary_eval(symbol, x1, x2)
     assert actual.output == actual_reflect.output
@@ -258,7 +258,7 @@ def test_reduce_all(op):
     with interpretation(sequential):
         f = x * y + z
         dtype = f.dtype
-        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, domain((), dtype))
+        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, make_domain((), dtype))
         actual = f.reduce(op)
 
     with interpretation(sequential):
@@ -285,7 +285,7 @@ def test_reduce_subset(op, reduced_vars):
     z = Variable('z', bint(4))
     f = x * y + z
     dtype = f.dtype
-    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, domain((), dtype))
+    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, make_domain((), dtype))
     if isinstance(op, ops.LogAddExpOp):
         pytest.skip()  # not defined for integers
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -12,7 +12,7 @@ import pytest
 import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction
-from funsor.domains import Domain, bint, reals
+from funsor.domains import Bint, Real, bint, domain, reals
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import REDUCE_OP_TO_NUMERIC
 from funsor.terms import (
@@ -205,7 +205,7 @@ def test_unary(symbol, data):
 
     x = Number(data, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, {}, Domain((), dtype), expected_data)
+    check_funsor(actual, {}, domain((), dtype), expected_data)
 
 
 BINARY_OPS = [
@@ -240,7 +240,7 @@ def test_binary(symbol, data1, data2):
     x1 = Number(data1, dtype)
     x2 = Number(data2, dtype)
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, {}, Domain((), dtype), expected_data)
+    check_funsor(actual, {}, domain((), dtype), expected_data)
     with interpretation(normalize):
         actual_reflect = binary_eval(symbol, x1, x2)
     assert actual.output == actual_reflect.output
@@ -258,7 +258,7 @@ def test_reduce_all(op):
     with interpretation(sequential):
         f = x * y + z
         dtype = f.dtype
-        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Domain((), dtype))
+        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, domain((), dtype))
         actual = f.reduce(op)
 
     with interpretation(sequential):
@@ -285,7 +285,7 @@ def test_reduce_subset(op, reduced_vars):
     z = Variable('z', bint(4))
     f = x * y + z
     dtype = f.dtype
-    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Domain((), dtype))
+    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, domain((), dtype))
     if isinstance(op, ops.LogAddExpOp):
         pytest.skip()  # not defined for integers
 


### PR DESCRIPTION
Addresses #351 

This refactors so that
- `Domain = type`
- `Bint[n]` and `Reals[m,n]` are type hints (still instances of `Domain`)

This does not appear to cause any overhead, e.g. test_sum_product.py seems to reduce from 95sec to 89 sec.

## Tasks
- [x] refactor `Domain`, `Reals[]`, `Bint[]`
- [x] get tests to pass using shims `reals()` and `bint()`
- [x] mark shims deprecated

for follow-up PRs:
- remove usage of shims from library code
- remove shims (`bint()`, `reals()`, etc.)