### PR TITLE
Fix sphinx warning about lazy_property

### DIFF
--- a/funsor/util.py
+++ b/funsor/util.py
@@ -24,6 +24,10 @@ class lazy_property(object):
         setattr(obj, self.fn.__name__, value)
         return value
 
+    # This is needed to pacify sphinx.
+    def __call__(self):
+        raise ValueError
+
 
 def getargspec(fn):
     """


### PR DESCRIPTION
Fixes the warning
```
WARNING: Failed to get a method signature for funsor.gaussian.Gaussian.log_normalizer: <funsor.util.lazy_property object at 0x7fde24898d68> is not a callable object
```