### PR TITLE
Unify Reals,Bint into Array

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -1,15 +1,15 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from funsor.domains import Domain, bint, find_domain, make_domain, reals
+from funsor.domains import Array, Bint, Domain, Real, Reals, bint, find_domain, reals
 from funsor.integrate import Integrate
 from funsor.interpreter import reinterpret
 from funsor.sum_product import MarkovProduct
-from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
 from funsor.tensor import Tensor, function
-from funsor.util import set_backend, get_backend, pretty, quote
+from funsor.terms import Cat, Funsor, Independent, Lambda, Number, Slice, Stack, Variable, of_shape, to_data, to_funsor
+from funsor.util import get_backend, pretty, quote, set_backend
 
-from . import (
+from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     adjoint,
     affine,
     cnf,
@@ -22,12 +22,11 @@ from . import (
     interpreter,
     joint,
     memoize,
-    # minipyro,  # TODO: enable when minipyro is backend-agnostic
     montecarlo,
     ops,
     sum_product,
     terms,
-    testing,
+    testing
 )
 
 # TODO: move to `funsor.util` when the following circular import issue is resolved
@@ -36,6 +35,8 @@ set_backend(get_backend())
 
 
 __all__ = [
+    'Array',
+    'Bint',
     'Cat',
     'Domain',
     'Funsor',
@@ -44,6 +45,8 @@ __all__ = [
     'Lambda',
     'MarkovProduct',
     'Number',
+    'Real',
+    'Reals',
     'Slice',
     'Stack',
     'Tensor',
@@ -64,7 +67,6 @@ __all__ = [
     'integrate',
     'interpreter',
     'joint',
-    'make_domain',
     'memoize',
     # 'minipyro',  # TODO: enable when minipyro is backend-agnostic
     'montecarlo',

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -14,7 +14,7 @@ import funsor.delta
 import funsor.ops as ops
 from funsor.affine import is_affine
 from funsor.cnf import GaussianMixture
-from funsor.domains import make_domain, reals
+from funsor.domains import Array, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import (Tensor, align_tensors, dummy_numeric_array, get_default_prototype,
@@ -164,7 +164,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             out_dtype = int(instance.support.upper_bound + 1)
         else:
             out_dtype = 'real'
-        return make_domain(dtype=out_dtype, shape=out_shape)
+        return Array[out_dtype, out_shape]
 
     @classmethod
     @functools.lru_cache(maxsize=5000)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copyreg
-import functools
 import operator
 import warnings
 from functools import reduce
@@ -11,33 +10,55 @@ from weakref import WeakValueDictionary
 import funsor.ops as ops
 from funsor.util import broadcast_shape, get_backend, get_tracing_state, quote
 
-
 Domain = type
 
 
-class RealsType(Domain):
+class ArrayType(Domain):
+    """
+    Base class of array-like domains.
+    """
     _type_cache = WeakValueDictionary()
 
-    def __getitem__(cls, shape):
-        if not isinstance(shape, tuple):
-            shape = (shape,)
+    def __getitem__(cls, dtype_shape):
+        dtype, shape = dtype_shape
+
         # in some JAX versions, shape can be np.int64 type
         if get_tracing_state() or get_backend() == "jax":
-            shape = tuple(map(int, shape))
+            if dtype not in (None, "real"):
+                dtype = int(dtype)
+            if shape is not None:
+                shape = tuple(map(int, shape))
 
-        result = RealsType._type_cache.get(shape, None)
+        assert cls.dtype in (dtype, None)
+        assert cls.shape in (shape, None)
+
+        key = dtype, shape
+        result = ArrayType._type_cache.get(key, None)
         if result is None:
-            assert cls is Reals
-            assert all(isinstance(size, int) and size >= 0 for size in shape)
-            name = "Reals[{}]".format(",".join(map(str, shape))) if shape else "Real"
-            result = RealsType(name, (), {"shape": shape})
-            RealsType._type_cache[shape] = result
+            if dtype == "real":
+                if shape:
+                    assert all(isinstance(size, int) and size >= 0 for size in shape)
+                    name = "Reals[{}]".format(",".join(map(str, shape)))
+                else:
+                    name = "Real"
+                result = RealsType(name, (), {"shape": shape})
+            elif isinstance(dtype, int):
+                assert dtype >= 0
+                name = "Bint[{}, {}]".format(dtype, ",".join(map(str, shape)))
+                result = BintType(name, (), {"dtype": dtype, "shape": shape})
+            else:
+                raise ValueError("invalid dtype: {}".format(dtype))
+            ArrayType._type_cache[key] = result
         return result
 
     def __subclasscheck__(cls, subcls):
-        if not isinstance(subcls, RealsType):
+        if not isinstance(subcls, type(subcls)):
             return False
-        return cls is Reals or cls is subcls
+        if cls.dtype not in (None, subcls.dtype):
+            return False
+        if cls.shape not in (None, subcls.shape):
+            return False
+        return True
 
     def __repr__(cls):
         return cls.__name__
@@ -49,109 +70,61 @@ class RealsType(Domain):
     def num_elements(cls):
         return reduce(operator.mul, cls.shape, 1)
 
-    # DEPRECATED
+
+class RealsType(ArrayType):
+    dtype = "real"
+
+    def __getitem__(cls, shape):
+        return super().__getitem__(("real", shape))
+
+
+class BintType(ArrayType):
+    def __getitem__(cls, size_shape):
+        if isinstance(size_shape, tuple):
+            size, shape = size_shape[0], size_shape[1:]
+        else:
+            size, shape = size_shape, ()
+        return super().__getitem__((size, shape))
+
     @property
-    def dtype(self):
-        warnings.warn("domain.dtype is deprecated, "
-                      "use isinstance(domain, RealsType) instead",
-                      DeprecationWarning)
-        return "real"
-
-
-@functools.partial(copyreg.pickle, RealsType)
-def _pickle_real(cls):
-    if cls is Reals:
-        return "Reals"
-    return operator.getitem, (Reals, cls.shape)
-
-
-class Reals(metaclass=RealsType):
-    """
-    Type of a real-valued array with known shape::
-
-        Reals[()] = Real  # scalar
-        Reals[8]          # vector of length 8
-        Reals[3,3]        # 3x3 matrix
-
-    To dispatch on domain type, we recommend either ``@singledispatch``,
-    ``@multipledispatch``, or ``isinstance(domain, RealsType)``.
-    """
-
-
-Real = Reals[()]  # just an alias
-
-
-class BintType(type):
-    _type_cache = WeakValueDictionary()
-
-    def __getitem__(cls, size):
-        # in some JAX versions, shape can be np.int64 type
-        if get_tracing_state() or get_backend() == "jax":
-            size = int(size)
-
-        result = BintType._type_cache.get(size, None)
-        if result is None:
-            assert cls is Bint
-            assert isinstance(size, int) and size >= 0, size
-            name = "Bint[{}]".format(size)
-            result = BintType(name, (), {"size": size})
-            BintType._type_cache[size] = result
-        return result
-
-    def __subclasscheck__(cls, subcls):
-        if not isinstance(subcls, BintType):
-            return False
-        return cls is Bint or cls is subcls
-
-    def __repr__(cls):
-        return cls.__name__
-
-    def __str__(cls):
-        return cls.__name__
+    def size(cls):
+        return cls.dtype
 
     def __iter__(cls):
         from funsor.terms import Number
         return (Number(i, cls.size) for i in range(cls.size))
 
-    # DEPRECATED
-    @property
-    def dtype(cls):
-        warnings.warn("domain.dtype is deprecated, "
-                      "use isinstance(domain, BintType) instead",
-                      DeprecationWarning)
-        return cls.size
 
-    # DEPRECATED
-    @property
-    def shape(cls):
-        warnings.warn("Bint[n].shape is deprecated",
-                      DeprecationWarning)
-        return ()
-
-    # DEPRECATED
-    @property
-    def num_elements(cls):
-        warnings.warn("Bint[n].num_elements is deprecated",
-                      DeprecationWarning)
-        return 1
+def _pickle_array(cls):
+    if cls in (Array, Real, Reals, Bint):
+        return cls.__name__
+    return operator.getitem, (Array, (cls.dtype, cls.shape))
 
 
-@functools.partial(copyreg.pickle, BintType)
-def _pickle_bint(cls):
-    if cls is Bint:
-        return "Bint"
-    return operator.getitem, (Bint, cls.size)
+copyreg.pickle(ArrayType, _pickle_array)
+copyreg.pickle(RealsType, _pickle_array)
+copyreg.pickle(BintType, _pickle_array)
 
+# Singletons
+Array = ArrayType("Array", (), {"dtype": None, "shape": None})
 
-class Bint(metaclass=BintType):
-    """
-    Factory for bounded integer types::
+Real = Array["real", ()]
+Reals = Array["real", None]
+Reals.__doc__ = """
+Type of a real-valued array with known shape::
 
-        Bint[5]  # integers ranging in {0,1,2,3,4}
+    Reals[()] = Real  # scalar
+    Reals[8]          # vector of length 8
+    Reals[3,3]        # 3x3 matrix
+"""
 
-    To dispatch on domain type, we recommend either ``@singledispatch``,
-    ``@multipledispatch``, or ``isinstance(domain, BintType)``.
-    """
+Bint = BintType("Bint", (), {"dtype": None, "shape": None})
+Bint.__doc__ = """
+Factory for bounded integer types::
+
+    Bint[5]        # integers ranging in {0,1,2,3,4}
+    Bint[2, 3, 3]  # 3x3 matrices with entries in {0,1}
+"""
 
 
 # DEPRECATED
@@ -166,13 +139,6 @@ def bint(size):
     warnings.warn("reals(...) is deprecated, use Reals[...] instead",
                   DeprecationWarning)
     return Bint[size]
-
-
-# DEPRECATED
-def make_domain(shape, dtype):
-    warnings.warn("make_domain is deprecated, use Bint or Reals instead",
-                  DeprecationWarning)
-    return Reals[shape] if dtype == "real" else Bint[dtype]
 
 
 @quote.register(BintType)

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -12,7 +12,7 @@ from functools import singledispatch
 
 import numpy as np
 
-from funsor.domains import BintType, RealsType
+from funsor.domains import ArrayType
 from funsor.ops import Op, is_numeric_array
 from funsor.registry import KeyedRegistry
 from funsor.util import is_nn_module
@@ -151,8 +151,7 @@ _ground_types = (
     functools.partial,
     types.FunctionType,
     types.BuiltinFunctionType,
-    BintType,
-    RealsType,
+    ArrayType,
     Op,
     np.generic,
     np.ndarray,

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -22,7 +22,7 @@ import torch
 
 from funsor.cnf import Contraction
 from funsor.delta import Delta
-from funsor.domains import make_domain, bint, reals
+from funsor.domains import Array, bint, reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import Tensor, align_tensors
@@ -72,7 +72,7 @@ def tensor_to_funsor(tensor, event_inputs=(), event_output=0, dtype="real"):
     assert isinstance(event_inputs, tuple)
     assert isinstance(event_output, int) and event_output >= 0
     inputs_shape = tensor.shape[:tensor.dim() - event_output]
-    output = make_domain(dtype=dtype, shape=tensor.shape[tensor.dim() - event_output:])
+    output = Array[dtype, tensor.shape[tensor.dim() - event_output:]]
     dim_to_name = default_dim_to_name(inputs_shape, event_inputs)
     return to_funsor(tensor, output, dim_to_name)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -16,7 +16,7 @@ from multipledispatch.variadic import Variadic
 import funsor
 import funsor.ops as ops
 from funsor.delta import Delta
-from funsor.domains import Domain, bint, find_domain, make_domain, reals
+from funsor.domains import Array, Domain, bint, find_domain, reals
 from funsor.ops import GetitemOp, MatmulOp, Op, ReshapeOp
 from funsor.terms import (
     Binary,
@@ -120,7 +120,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             for (k, d), size in zip(inputs, data.shape):
                 assert d.dtype == size
         inputs = OrderedDict(inputs)
-        output = make_domain(data.shape[len(inputs):], dtype)
+        output = Array[dtype, data.shape[len(inputs):]]
         fresh = frozenset(inputs.keys())
         bound = frozenset()
         super(Tensor, self).__init__(inputs, output, fresh, bound)
@@ -1018,7 +1018,7 @@ def stack(parts, dim=0):
     assert dim < 0
     split = dim + len(shape) + 1
     shape = shape[:split] + (len(parts),) + shape[split:]
-    output = make_domain(shape, parts[0].dtype)
+    output = Array[parts[0].dtype, shape]
     fn = functools.partial(ops.stack, dim)
     return Function(fn, output, parts)
 

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -47,9 +47,9 @@ def test_subclass():
     assert issubclass(Reals[2], Reals)
     assert issubclass(Reals[2], Reals[2])
     assert not issubclass(Reals, Real)
-    assert not issubclass(Reals, Real[2])
+    assert not issubclass(Reals, Reals[2])
     assert not issubclass(Real, Reals[2])
-    assert not issubclass(Real[2], Real)
+    assert not issubclass(Reals[2], Real)
 
     assert not issubclass(Reals, Bint)
     assert not issubclass(Bint, Reals)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import itertools
 import io
+import itertools
 import pickle
 from collections import OrderedDict
 
@@ -12,12 +12,11 @@ import pytest
 
 import funsor
 import funsor.ops as ops
-from funsor.domains import Bint, Reals, bint, find_domain, make_domain, reals
+from funsor.domains import Array, Bint, Reals, bint, find_domain, reals
 from funsor.interpreter import interpretation
-from funsor.terms import Cat, Lambda, Number, Slice, Stack, Variable, lazy
-from funsor.testing import (assert_close, assert_equiv, check_funsor, empty,
-                            rand, randn, random_tensor, zeros)
 from funsor.tensor import REDUCE_OP_TO_NUMERIC, Einsum, Tensor, align_tensors, numeric_array, stack, tensordot
+from funsor.terms import Cat, Lambda, Number, Slice, Stack, Variable, lazy
+from funsor.testing import assert_close, assert_equiv, check_funsor, empty, rand, randn, random_tensor, zeros
 from funsor.util import get_backend
 
 
@@ -323,7 +322,7 @@ def test_unary(symbol, dims):
 
     x = Tensor(data, inputs, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, inputs, funsor.make_domain((), dtype), expected_data)
+    check_funsor(actual, inputs, Array[dtype, ()], expected_data)
 
 
 BINARY_OPS = [
@@ -363,7 +362,7 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
     expected_data = binary_eval(symbol, aligned[0], aligned[1])
 
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, inputs, make_domain((), dtype), expected_data)
+    check_funsor(actual, inputs, Array[dtype, ()], expected_data)
 
 
 @pytest.mark.parametrize('output_shape2', [(), (2,), (3, 2)], ids=str)
@@ -618,7 +617,7 @@ def test_reduce_subset(dims, reduced_vars, op):
         else:
             for pos in reversed(sorted(map(dims.index, reduced_vars))):
                 data = REDUCE_OP_TO_NUMERIC[op](data, pos)
-        check_funsor(actual, expected_inputs, make_domain((), dtype))
+        check_funsor(actual, expected_inputs, Array[dtype, ()])
         assert_close(actual, Tensor(data, expected_inputs, dtype),
                      atol=1e-5, rtol=1e-5)
 
@@ -641,7 +640,7 @@ def test_reduce_event(op, event_shape, dims):
     x = Tensor(data, inputs, dtype=dtype)
     op_name = numeric_op.__name__[1:] if op in [ops.min, ops.max] else numeric_op.__name__
     actual = getattr(x, op_name)()
-    check_funsor(actual, inputs, make_domain((), dtype), expected_data)
+    check_funsor(actual, inputs, Array[dtype, ()], expected_data)
 
 
 @pytest.mark.parametrize('shape', [(), (4,), (2, 3)])

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import itertools
 import io
+import itertools
 import pickle
 import typing
 from collections import OrderedDict
@@ -15,7 +15,7 @@ import pytest
 import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction
-from funsor.domains import Bint, Real, Reals, bint, make_domain, reals
+from funsor.domains import Array, Bint, Real, Reals, bint, reals
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import REDUCE_OP_TO_NUMERIC
 from funsor.terms import (
@@ -240,7 +240,7 @@ def test_unary(symbol, data):
 
     x = Number(data, dtype)
     actual = unary_eval(symbol, x)
-    check_funsor(actual, {}, make_domain((), dtype), expected_data)
+    check_funsor(actual, {}, Array[dtype, ()], expected_data)
 
 
 BINARY_OPS = [
@@ -275,7 +275,7 @@ def test_binary(symbol, data1, data2):
     x1 = Number(data1, dtype)
     x2 = Number(data2, dtype)
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, {}, make_domain((), dtype), expected_data)
+    check_funsor(actual, {}, Array[dtype, ()], expected_data)
     with interpretation(normalize):
         actual_reflect = binary_eval(symbol, x1, x2)
     assert actual.output == actual_reflect.output
@@ -293,7 +293,7 @@ def test_reduce_all(op):
     with interpretation(sequential):
         f = x * y + z
         dtype = f.dtype
-        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, make_domain((), dtype))
+        check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Array[dtype, ()])
         actual = f.reduce(op)
 
     with interpretation(sequential):
@@ -320,7 +320,7 @@ def test_reduce_subset(op, reduced_vars):
     z = Variable('z', bint(4))
     f = x * y + z
     dtype = f.dtype
-    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, make_domain((), dtype))
+    check_funsor(f, {'x': bint(2), 'y': bint(3), 'z': bint(4)}, Array[dtype, ()])
     if isinstance(op, ops.LogAddExpOp):
         pytest.skip()  # not defined for integers
 


### PR DESCRIPTION
Addresses #322, #351 , #348 

This unifies `BintType` and `RealsType` types into a common `ArrayType` with support for `.dtype` and `.shape` (I have unmarked those deprecated). After this PR `Bint[size, i,j,k]` denotes a homogeneously-bounded `i x j x k`-sized array of `Bint`. This PR does not yet use those integer valued arrays in distributions or elsewhere; that is for follow-up.

This PR also clarifies the role of `Bint`. Whereas I had previously thought we would need heterogeneously-bounded distributions (as e.g. [requested](https://github.com/pytorch/pytorch/issues/42407) of `dist.Multinomial`), I now believe we can restrict to homogeneously-bounded `Bint` types, and add a separate heterogeneous type `Tuple[Bint[2], Bint[3])` for indexing into arrays. This PR does not add that `Tuple`, but it does clarify the planned type hierarchy:
```
Domain
+-- ArrayType                                 \
|   +-- RealsType                              }  support .dtype, .shape
|   +-- BintType  # homogeneously bounded     /
+--TupleType      # heterogeneously bounded   }   does not support .dtype, .shape
```

## Tested
- [x] pure refactoring is covered by existing tests