### PR TITLE
Add helper to coerce distributions to funsors

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -292,7 +292,7 @@ def mvndist_to_funsor(backend_dist, output=None, dim_to_name=None, real_inputs=O
     return discrete + Gaussian(gaussian.info_vec, gaussian.precision, inputs)
 
 
-class CoerceToFunsor:
+class CoerceDistributionToFunsor:
     """
     Handler to reinterpret a backend distribution ``D`` as a corresponding
     funsor during ``type(D).__call__()`` in case any constructor args are
@@ -301,7 +301,7 @@ class CoerceToFunsor:
     Example usage::
 
         # in foo/distribution.py
-        coerce_to_funsor = CoerceToFunsor("foo")
+        coerce_to_funsor = CoerceDistributionToFunsor("foo")
 
         class DistributionMeta(type):
             def __call__(cls, *args, **kwargs):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -793,8 +793,10 @@ def to_funsor(x, output=None, dim_to_name=None, **kwargs):
 def funsor_to_funsor(x, output=None, dim_to_name=None):
     if output is not None and x.output != output:
         raise ValueError("Output mismatch: {} vs {}".format(x.output, output))
-    if dim_to_name is not None and list(x.inputs.keys()) != list(dim_to_name.values()):
-        raise ValueError("Inputs mismatch: {} vs {}".format(x.inputs, dim_to_name))
+    if dim_to_name is not None:
+        bint_names = {name for name, domain in x.inputs.items() if domain.dtype != "real"}
+        if not bint_names.issubset(dim_to_name.values()):
+            raise ValueError("Inputs mismatch: {} vs {}".format(x.inputs, dim_to_name))
     return x
 
 

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -111,6 +111,18 @@ Multinomial._infer_value_domain = classmethod(_multinomial_infer_value_domain)  
 DirichletMultinomial._infer_value_domain = classmethod(_multinomial_infer_value_domain)  # noqa: F821
 
 
+# TODO fix Dirichlet.arg_constraints["concentration"] to be a
+# constraints.independent[constraints.positive]
+@classmethod
+@functools.lru_cache(maxsize=5000)
+def _dirichlet_infer_param_domain(cls, name, raw_shape):
+    assert name == "concentration"
+    return Reals[raw_shape[-1]]
+
+
+Dirichlet._infer_param_domain = _dirichlet_infer_param_domain
+
+
 ###############################################
 # Converting PyTorch Distributions to funsors
 ###############################################

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -36,6 +36,7 @@ from funsor.domains import Real, Reals
 import funsor.ops as ops
 from funsor.tensor import Tensor, dummy_numeric_array
 from funsor.terms import Binary, Funsor, Variable, eager, to_funsor
+from funsor.util import methodof
 
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES)
@@ -95,46 +96,59 @@ for dist_name, param_names in PYRO_DIST_NAMES:
 
 
 # Delta has to be treated specially because of its weird shape inference semantics
-Delta._infer_value_domain = classmethod(lambda cls, **kwargs: kwargs['v'])  # noqa: F821
+@methodof(Delta)  # noqa: F821
+@staticmethod
+def _infer_value_domain(**kwargs):
+    return kwargs['v']
 
 
 # Multinomial and related dists have dependent Bint dtypes, so we just make them 'real'
 # See issue: https://github.com/pyro-ppl/funsor/issues/322
+@methodof(Binomial)  # noqa: F821
+@methodof(Multinomial)  # noqa: F821
+@methodof(DirichletMultinomial)  # noqa: F821
+@classmethod
 @functools.lru_cache(maxsize=5000)
-def _multinomial_infer_value_domain(cls, **kwargs):
+def _infer_value_domain(cls, **kwargs):
     instance = cls.dist_class(**{k: dummy_numeric_array(domain) for k, domain in kwargs.items()}, validate_args=False)
     return Reals[instance.event_shape]
 
 
-Binomial._infer_value_domain = classmethod(_multinomial_infer_value_domain)  # noqa: F821
-Multinomial._infer_value_domain = classmethod(_multinomial_infer_value_domain)  # noqa: F821
-DirichletMultinomial._infer_value_domain = classmethod(_multinomial_infer_value_domain)  # noqa: F821
+# TODO fix Delta.arg_constraints["v"] to be a
+# constraints.independent[constraints.real]
+@methodof(Delta)  # noqa: F821
+@staticmethod
+@functools.lru_cache(maxsize=5000)
+def _infer_param_domain(name, raw_shape):
+    if name == "v":
+        return Reals[raw_shape]
+    elif name == "log_density":
+        return Real
+    else:
+        raise ValueError(name)
 
 
 # TODO fix Dirichlet.arg_constraints["concentration"] to be a
 # constraints.independent[constraints.positive]
-@classmethod
+@methodof(Dirichlet)  # noqa: F821
+@methodof(NonreparameterizedDirichlet)  # noqa: F821
+@staticmethod
 @functools.lru_cache(maxsize=5000)
-def _dirichlet_infer_param_domain(cls, name, raw_shape):
+def _infer_param_domain(name, raw_shape):
     assert name == "concentration"
     return Reals[raw_shape[-1]]
 
 
-Dirichlet._infer_param_domain = _dirichlet_infer_param_domain  # noqa: F821
-
-
 # TODO fix DirichletMultinomial.arg_constraints["concentration"] to be a
 # constraints.independent[constraints.positive]
+@methodof(DirichletMultinomial)  # noqa: F821
 @classmethod
 @functools.lru_cache(maxsize=5000)
-def _dirichlet_multinomial_infer_param_domain(cls, name, raw_shape):
+def _infer_param_domain(cls, name, raw_shape):
     if name == "concentration":
         return Reals[raw_shape[-1]]
     assert name == "total_count"
     return Real
-
-
-DirichletMultinomial._infer_param_domain = _dirichlet_multinomial_infer_param_domain  # noqa: F821
 
 
 ###############################################

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -120,7 +120,7 @@ def _dirichlet_infer_param_domain(cls, name, raw_shape):
     return Reals[raw_shape[-1]]
 
 
-Dirichlet._infer_param_domain = _dirichlet_infer_param_domain
+Dirichlet._infer_param_domain = _dirichlet_infer_param_domain  # noqa: F821
 
 
 # TODO fix DirichletMultinomial.arg_constraints["concentration"] to be a
@@ -134,7 +134,7 @@ def _dirichlet_multinomial_infer_param_domain(cls, name, raw_shape):
     return Real
 
 
-DirichletMultinomial._infer_param_domain = _dirichlet_multinomial_infer_param_domain
+DirichletMultinomial._infer_param_domain = _dirichlet_multinomial_infer_param_domain  # noqa: F821
 
 
 ###############################################

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -32,7 +32,7 @@ from funsor.distribution import (  # noqa: F401
     mvndist_to_funsor,
     transformeddist_to_funsor,
 )
-from funsor.domains import Reals
+from funsor.domains import Real, Reals
 import funsor.ops as ops
 from funsor.tensor import Tensor, dummy_numeric_array
 from funsor.terms import Binary, Funsor, Variable, eager, to_funsor
@@ -121,6 +121,20 @@ def _dirichlet_infer_param_domain(cls, name, raw_shape):
 
 
 Dirichlet._infer_param_domain = _dirichlet_infer_param_domain
+
+
+# TODO fix DirichletMultinomial.arg_constraints["concentration"] to be a
+# constraints.independent[constraints.positive]
+@classmethod
+@functools.lru_cache(maxsize=5000)
+def _dirichlet_multinomial_infer_param_domain(cls, name, raw_shape):
+    if name == "concentration":
+        return Reals[raw_shape[-1]]
+    assert name == "total_count"
+    return Real
+
+
+DirichletMultinomial._infer_param_domain = _dirichlet_multinomial_infer_param_domain
 
 
 ###############################################

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -212,3 +212,25 @@ def is_nn_module(x):
 
         return isinstance(x, torch.nn.Module)
     return False
+
+
+def methodof(cls, name=None):
+    """
+    Decorator to set the named method of the given class. Can be stacked.
+
+    Example usage::
+
+       @methodof(MyClass)
+       def __call__(self, x):
+           return x
+    """
+    def decorator(fn):
+        name_ = name
+        if name_ is None:
+            fn_ = fn
+            while not hasattr(fn_, "__name__"):
+                fn_ = fn_.__func__
+            name_ = fn_.__name__
+        setattr(cls, name_, fn)
+        return fn
+    return decorator

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -32,7 +32,7 @@ if get_backend() == "torch":
     from funsor.pyro.convert import dist_to_funsor
 
 
-@pyest.mark.xfail(get_backend() == "jax", "flaky test")
+@pytest.mark.xfail(get_backend() == "jax", "flaky test")
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('eager', [False, True])
 def test_beta_density(batch_shape, eager):

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -32,6 +32,7 @@ if get_backend() == "torch":
     from funsor.pyro.convert import dist_to_funsor
 
 
+@pyest.mark.xfail(get_backend() == "jax", "flaky test")
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('eager', [False, True])
 def test_beta_density(batch_shape, eager):

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -32,7 +32,7 @@ if get_backend() == "torch":
     from funsor.pyro.convert import dist_to_funsor
 
 
-@pytest.mark.xfail(get_backend() == "jax", "flaky test")
+@pytest.mark.xfail(get_backend() == "jax", reason="flaky test")
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('eager', [False, True])
 def test_beta_density(batch_shape, eager):


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro/issues/2618
Blocking https://github.com/pyro-ppl/pyro/pull/2620
pair coded with @eb8680

This adds a helper to coerce raw backend `Distrbution` classes to funsors if any of the `RawDistribution.__init__()` arguments are funsors rather than backend-specific arrays. This is a possible intermediate step to allow partial use of funsors in inference algorithms without the need to use a special `dist` module.