### PR TITLE
Reorganize ops

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -194,7 +194,8 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'torch': ('http://pytorch.org/docs/master/', None),
     'pyro': ('http://docs.pyro.ai/en/stable/', None),
-    'opt_einsum': ('https://optimized-einsum.readthedocs.io/en/stable/', None)
+    'opt_einsum': ('https://optimized-einsum.readthedocs.io/en/stable/', None),
+    'multipledispatch': ('https://multiple-dispatch.readthedocs.io/en/latest/', None),
 }
 
 # @jpchen's hack to get rtd builder to install latest pytorch

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,8 +11,8 @@ Funsor is a tensor-like library for functions and distributions
    :maxdepth: 2
    :caption: Funsor Core:
 
-   domains
    ops
+   domains
    interpretations
    funsors
    optimizer

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -1,18 +1,24 @@
 Operations
-----------
+==========
 
+Operation classes
+-----------------
 .. automodule:: funsor.ops.op
     :members:
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
 
+Builtin operations
+------------------
 .. automodule:: funsor.ops.builtin
     :members:
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
 
+Array operations
+----------------
 .. automodule:: funsor.ops.array
     :members:
     :undoc-members:

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -12,3 +12,9 @@ Operations
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
+
+.. automodule:: funsor.ops.array
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -1,6 +1,13 @@
 Operations
 ----------
-.. automodule:: funsor.ops
+
+.. automodule:: funsor.ops.op
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. automodule:: funsor.ops.builtin
     :members:
     :undoc-members:
     :show-inheritance:

--- a/funsor/ops/__init__.py
+++ b/funsor/ops/__init__.py
@@ -1,0 +1,3 @@
+from .array import *
+from .builtin import *
+from .op import *

--- a/funsor/ops/__init__.py
+++ b/funsor/ops/__init__.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .array import *
 from .builtin import *
 from .op import *

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -1,0 +1,276 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+from multipledispatch import Dispatcher
+
+from .builtin import log, max, min, reciprocal, safediv, safesub
+from .op import Op
+
+_builtin_all = all
+_builtin_any = any
+
+# This is used only for pattern matching.
+array = (np.ndarray, np.generic)
+
+all = Op(np.all)
+amax = Op(np.amax)
+amin = Op(np.amin)
+any = Op(np.any)
+astype = Dispatcher("ops.astype")
+cat = Dispatcher("ops.cat")
+clamp = Dispatcher("ops.clamp")
+diagonal = Dispatcher("ops.diagonal")
+einsum = Dispatcher("ops.einsum")
+full_like = Op(np.full_like)
+prod = Op(np.prod)
+stack = Dispatcher("ops.stack")
+sum = Op(np.sum)
+transpose = Dispatcher("ops.transpose")
+
+
+class ReshapeMeta(type):
+    _cache = {}
+
+    def __call__(cls, shape):
+        shape = tuple(shape)
+        try:
+            return ReshapeMeta._cache[shape]
+        except KeyError:
+            instance = super().__call__(shape)
+            ReshapeMeta._cache[shape] = instance
+            return instance
+
+
+class ReshapeOp(Op, metaclass=ReshapeMeta):
+    def __init__(self, shape):
+        self.shape = shape
+        super().__init__(self._default)
+
+    def __reduce__(self):
+        return ReshapeOp, (self.shape,)
+
+    def _default(self, x):
+        return x.reshape(self.shape)
+
+
+@astype.register(array, str)
+def _astype(x, dtype):
+    return x.astype(dtype)
+
+
+@cat.register(int, [array])
+def _cat(dim, *x):
+    return np.concatenate(x, axis=dim)
+
+
+@clamp.register(array, object, object)
+def _clamp(x, min, max):
+    return np.clip(x, a_min=min, a_max=max)
+
+
+@Op
+def cholesky(x):
+    """
+    Like :func:`numpy.linalg.cholesky` but uses sqrt for scalar matrices.
+    """
+    if x.shape[-1] == 1:
+        return np.sqrt(x)
+    return np.linalg.cholesky(x)
+
+
+@Op
+def cholesky_inverse(x):
+    """
+    Like :func:`torch.cholesky_inverse` but supports batching and gradients.
+    """
+    return cholesky_solve(new_eye(x, x.shape[:-1]), x)
+
+
+@Op
+def cholesky_solve(x, y):
+    y_inv = np.linalg.inv(y)
+    A = np.swapaxes(y_inv, -2, -1) @ y_inv
+    return A @ x
+
+
+@Op
+def detach(x):
+    return x
+
+
+@diagonal.register(array, int, int)
+def _diagonal(x, dim1, dim2):
+    return np.diagonal(x, axis1=dim1, axis2=dim2)
+
+
+@einsum.register(str, [array])
+def _einsum(x, *operand):
+    return np.einsum(x, *operand)
+
+
+@Op
+def expand(x, shape):
+    prepend_dim = len(shape) - np.ndim(x)
+    assert prepend_dim >= 0
+    shape = shape[:prepend_dim] + tuple(dx if size == -1 else size
+                                        for dx, size in zip(np.shape(x), shape[prepend_dim:]))
+    return np.broadcast_to(x, shape)
+    return np.broadcast_to(x, shape)
+
+
+@Op
+def finfo(x):
+    return np.finfo(x.dtype)
+
+
+@Op
+def is_numeric_array(x):
+    return True if isinstance(x, array) else False
+
+
+@Op
+def logsumexp(x, dim):
+    amax = np.amax(x, axis=dim, keepdims=True)
+    # treat the case x = -inf
+    amax = np.where(np.isfinite(amax), amax, 0.)
+    return log(np.sum(np.exp(x - amax), axis=dim)) + amax.squeeze(axis=dim)
+
+
+@max.register(array, array)
+def _max(x, y):
+    return np.maximum(x, y)
+
+
+@max.register((int, float), array)
+def _max(x, y):
+    return np.clip(y, a_min=x, a_max=None)
+
+
+@max.register(array, (int, float))
+def _max(x, y):
+    return np.clip(x, a_min=y, a_max=None)
+
+
+@min.register(array, array)
+def _min(x, y):
+    return np.minimum(x, y)
+
+
+@min.register((int, float), array)
+def _min(x, y):
+    return np.clip(y, a_min=None, a_max=x)
+
+
+@min.register(array, (int, float))
+def _min(x, y):
+    return np.clip(x, a_min=None, a_max=y)
+
+
+@Op
+def new_arange(x, stop):
+    return np.arange(stop)
+
+
+@new_arange.register(array, int, int, int)
+def _new_arange(x, start, stop, step):
+    return np.arange(start, stop, step)
+
+
+@Op
+def new_zeros(x, shape):
+    return np.zeros(shape, dtype=x.dtype)
+
+
+@Op
+def new_eye(x, shape):
+    n = shape[-1]
+    return np.broadcast_to(np.eye(n), shape + (n,))
+
+
+@Op
+def permute(x, dims):
+    return np.transpose(x, axes=dims)
+
+
+@reciprocal.register(array)
+def _reciprocal(x):
+    result = np.clip(np.reciprocal(x), a_max=np.finfo(x.dtype).max)
+    return result
+
+
+@safediv.register(object, array)
+def _safediv(x, y):
+    try:
+        finfo = np.finfo(y.dtype)
+    except ValueError:
+        finfo = np.iinfo(y.dtype)
+    return x * np.clip(np.reciprocal(y), a_min=None, a_max=finfo.max)
+
+
+@safesub.register(object, array)
+def _safesub(x, y):
+    try:
+        finfo = np.finfo(y.dtype)
+    except ValueError:
+        finfo = np.iinfo(y.dtype)
+    return x + np.clip(-y, a_min=None, a_max=finfo.max)
+
+
+@stack.register(int, [array])
+def _stack(dim, *x):
+    return np.stack(x, axis=dim)
+
+
+@transpose.register(array, int, int)
+def _transpose(x, dim1, dim2):
+    return np.swapaxes(x, dim1, dim2)
+
+
+@Op
+def triangular_solve(x, y, upper=False, transpose=False):
+    if transpose:
+        y = np.swapaxes(y, -2, -1)
+    return np.linalg.inv(y) @ x
+
+
+@Op
+def unsqueeze(x, dim):
+    return np.expand_dims(x, axis=dim)
+
+
+__all__ = [
+    'ReshapeOp',
+    'all',
+    'amax',
+    'amin',
+    'any',
+    'astype',
+    'cat',
+    'cholesky',
+    'cholesky_inverse',
+    'cholesky_solve',
+    'clamp',
+    'detach',
+    'diagonal',
+    'einsum',
+    'expand',
+    'finfo',
+    'full_like',
+    'is_numeric_array',
+    'logsumexp',
+    'new_arange',
+    'new_eye',
+    'new_zeros',
+    'permute',
+    'prod',
+    'stack',
+    'sum',
+    'transpose',
+    'triangular_solve',
+    'unsqueeze',
+]
+
+
+__doc__ = "\n".join(".. autodata:: {}\n".format(_name)
+                    for _name in __all__ if isinstance(globals()[_name], Op))

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-from multipledispatch import Dispatcher
 
 from .builtin import log, max, min, reciprocal, safediv, safesub
 from .op import Op
@@ -17,16 +16,16 @@ all = Op(np.all)
 amax = Op(np.amax)
 amin = Op(np.amin)
 any = Op(np.any)
-astype = Dispatcher("ops.astype")
-cat = Dispatcher("ops.cat")
-clamp = Dispatcher("ops.clamp")
-diagonal = Dispatcher("ops.diagonal")
-einsum = Dispatcher("ops.einsum")
+astype = Op("astype")
+cat = Op("cat")
+clamp = Op("clamp")
+diagonal = Op("diagonal")
+einsum = Op("einsum")
 full_like = Op(np.full_like)
 prod = Op(np.prod)
-stack = Dispatcher("ops.stack")
+stack = Op("stack")
 sum = Op(np.sum)
-transpose = Dispatcher("ops.transpose")
+transpose = Op("transpose")
 
 
 class ReshapeMeta(type):

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -4,14 +4,11 @@
 import operator
 from numbers import Number
 
-import numpy as np
-from multipledispatch import Dispatcher
+import numpy as np  # TODO remove dependency on numpy in this file
 
 from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, TransformOp
 
 _builtin_abs = abs
-_builtin_all = all
-_builtin_any = any
 _builtin_max = max
 _builtin_min = min
 _builtin_pow = pow
@@ -63,31 +60,6 @@ class NullOp(AssociativeOp):
 @NullOp
 def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
-
-
-class ReshapeMeta(type):
-    _cache = {}
-
-    def __call__(cls, shape):
-        shape = tuple(shape)
-        try:
-            return ReshapeMeta._cache[shape]
-        except KeyError:
-            instance = super().__call__(shape)
-            ReshapeMeta._cache[shape] = instance
-            return instance
-
-
-class ReshapeOp(Op, metaclass=ReshapeMeta):
-    def __init__(self, shape):
-        self.shape = shape
-        super().__init__(self._default)
-
-    def __reduce__(self):
-        return ReshapeOp, (self.shape,)
-
-    def _default(self, x):
-        return x.reshape(self.shape)
 
 
 class GetitemMeta(type):
@@ -270,215 +242,6 @@ UNITS[add] = 0.
 PRODUCT_INVERSES[mul] = safediv
 PRODUCT_INVERSES[add] = safesub
 
-
-######################
-# Numeric Array Ops
-######################
-
-
-all = Op(np.all)
-amax = Op(np.amax)
-amin = Op(np.amin)
-any = Op(np.any)
-astype = Dispatcher("ops.astype")
-cat = Dispatcher("ops.cat")
-clamp = Dispatcher("ops.clamp")
-diagonal = Dispatcher("ops.diagonal")
-einsum = Dispatcher("ops.einsum")
-full_like = Op(np.full_like)
-prod = Op(np.prod)
-stack = Dispatcher("ops.stack")
-sum = Op(np.sum)
-transpose = Dispatcher("ops.transpose")
-
-array = (np.ndarray, np.generic)
-
-
-@astype.register(array, str)
-def _astype(x, dtype):
-    return x.astype(dtype)
-
-
-@cat.register(int, [array])
-def _cat(dim, *x):
-    return np.concatenate(x, axis=dim)
-
-
-@clamp.register(array, object, object)
-def _clamp(x, min, max):
-    return np.clip(x, a_min=min, a_max=max)
-
-
-@Op
-def cholesky(x):
-    """
-    Like :func:`numpy.linalg.cholesky` but uses sqrt for scalar matrices.
-    """
-    if x.shape[-1] == 1:
-        return np.sqrt(x)
-    return np.linalg.cholesky(x)
-
-
-@Op
-def cholesky_inverse(x):
-    """
-    Like :func:`torch.cholesky_inverse` but supports batching and gradients.
-    """
-    return cholesky_solve(new_eye(x, x.shape[:-1]), x)
-
-
-@Op
-def cholesky_solve(x, y):
-    y_inv = np.linalg.inv(y)
-    A = np.swapaxes(y_inv, -2, -1) @ y_inv
-    return A @ x
-
-
-@Op
-def detach(x):
-    return x
-
-
-@diagonal.register(array, int, int)
-def _diagonal(x, dim1, dim2):
-    return np.diagonal(x, axis1=dim1, axis2=dim2)
-
-
-@einsum.register(str, [array])
-def _einsum(x, *operand):
-    return np.einsum(x, *operand)
-
-
-@Op
-def expand(x, shape):
-    prepend_dim = len(shape) - np.ndim(x)
-    assert prepend_dim >= 0
-    shape = shape[:prepend_dim] + tuple(dx if size == -1 else size
-                                        for dx, size in zip(np.shape(x), shape[prepend_dim:]))
-    return np.broadcast_to(x, shape)
-    return np.broadcast_to(x, shape)
-
-
-@Op
-def finfo(x):
-    return np.finfo(x.dtype)
-
-
-@Op
-def is_numeric_array(x):
-    return True if isinstance(x, array) else False
-
-
-@Op
-def logsumexp(x, dim):
-    amax = np.amax(x, axis=dim, keepdims=True)
-    # treat the case x = -inf
-    amax = np.where(np.isfinite(amax), amax, 0.)
-    return log(np.sum(np.exp(x - amax), axis=dim)) + amax.squeeze(axis=dim)
-
-
-@max.register(array, array)
-def _max(x, y):
-    return np.maximum(x, y)
-
-
-@max.register((int, float), array)
-def _max(x, y):
-    return np.clip(y, a_min=x, a_max=None)
-
-
-@max.register(array, (int, float))
-def _max(x, y):
-    return np.clip(x, a_min=y, a_max=None)
-
-
-@min.register(array, array)
-def _min(x, y):
-    return np.minimum(x, y)
-
-
-@min.register((int, float), array)
-def _min(x, y):
-    return np.clip(y, a_min=None, a_max=x)
-
-
-@min.register(array, (int, float))
-def _min(x, y):
-    return np.clip(x, a_min=None, a_max=y)
-
-
-@Op
-def new_arange(x, stop):
-    return np.arange(stop)
-
-
-@new_arange.register(array, int, int, int)
-def _new_arange(x, start, stop, step):
-    return np.arange(start, stop, step)
-
-
-@Op
-def new_zeros(x, shape):
-    return np.zeros(shape, dtype=x.dtype)
-
-
-@Op
-def new_eye(x, shape):
-    n = shape[-1]
-    return np.broadcast_to(np.eye(n), shape + (n,))
-
-
-@Op
-def permute(x, dims):
-    return np.transpose(x, axes=dims)
-
-
-@reciprocal.register(array)
-def _reciprocal(x):
-    result = np.clip(np.reciprocal(x), a_max=np.finfo(x.dtype).max)
-    return result
-
-
-@safediv.register(object, array)
-def _safediv(x, y):
-    try:
-        finfo = np.finfo(y.dtype)
-    except ValueError:
-        finfo = np.iinfo(y.dtype)
-    return x * np.clip(np.reciprocal(y), a_min=None, a_max=finfo.max)
-
-
-@safesub.register(object, array)
-def _safesub(x, y):
-    try:
-        finfo = np.finfo(y.dtype)
-    except ValueError:
-        finfo = np.iinfo(y.dtype)
-    return x + np.clip(-y, a_min=None, a_max=finfo.max)
-
-
-@stack.register(int, [array])
-def _stack(dim, *x):
-    return np.stack(x, axis=dim)
-
-
-@transpose.register(array, int, int)
-def _transpose(x, dim1, dim2):
-    return np.swapaxes(x, dim1, dim2)
-
-
-@Op
-def triangular_solve(x, y, upper=False, transpose=False):
-    if transpose:
-        y = np.swapaxes(y, -2, -1)
-    return np.linalg.inv(y) @ x
-
-
-@Op
-def unsqueeze(x, dim):
-    return np.expand_dims(x, axis=dim)
-
-
 __all__ = [
     'AddOp',
     'AssociativeOp',
@@ -494,38 +257,19 @@ __all__ = [
     'ReciprocalOp',
     'SampleOp',
     'SubOp',
-    'ReshapeOp',
     'abs',
     'add',
-    'all',
-    'amax',
-    'amin',
     'and_',
-    'any',
-    'astype',
-    'cat',
-    'cholesky',
-    'cholesky_inverse',
-    'cholesky_solve',
-    'clamp',
-    'detach',
-    'diagonal',
-    'einsum',
     'eq',
     'exp',
-    'expand',
-    'finfo',
-    'full_like',
     'ge',
     'getitem',
     'gt',
     'invert',
-    'is_numeric_array',
     'le',
     'log',
     'log1p',
     'logaddexp',
-    'logsumexp',
     'lt',
     'matmul',
     'max',
@@ -533,37 +277,19 @@ __all__ = [
     'mul',
     'ne',
     'neg',
-    'new_arange',
-    'new_eye',
-    'new_zeros',
     'nullop',
     'or_',
-    'permute',
     'pow',
-    'prod',
     'reciprocal',
     'safediv',
     'safesub',
     'sample',
     'sigmoid',
     'sqrt',
-    'stack',
     'sub',
-    'sum',
-    'transpose',
-    'triangular_solve',
     'truediv',
-    'unsqueeze',
     'xor',
 ]
 
-__doc__ = """
-Built-in operations
--------------------
-
-{}
-
-Operation classes
------------------
-""".format("\n".join(".. autodata:: {}\n".format(_name)
-                     for _name in __all__ if isinstance(globals()[_name], Op)))
+__doc__ = "\n".join(".. autodata:: {}\n".format(_name)
+                    for _name in __all__ if isinstance(globals()[_name], Op))

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -1,15 +1,21 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from multipledispatch import Dispatcher
 
 
 class Op(Dispatcher):
     def __init__(self, fn, *, name=None):
+        if isinstance(fn, str):
+            fn, name = None, fn
         if name is None:
             name = fn.__name__
         super(Op, self).__init__(name)
-        # register as default operation
-        for nargs in (1, 2):
-            default_signature = (object,) * nargs
-            self.add(default_signature, fn)
+        if fn is not None:
+            # register as default operation
+            for nargs in (1, 2):
+                default_signature = (object,) * nargs
+                self.add(default_signature, fn)
 
     def __copy__(self):
         return self

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -1,0 +1,69 @@
+from multipledispatch import Dispatcher
+
+
+class Op(Dispatcher):
+    def __init__(self, fn, *, name=None):
+        if name is None:
+            name = fn.__name__
+        super(Op, self).__init__(name)
+        # register as default operation
+        for nargs in (1, 2):
+            default_signature = (object,) * nargs
+            self.add(default_signature, fn)
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
+    def __reduce__(self):
+        return self.__name__
+
+    def __repr__(self):
+        return "ops." + self.__name__
+
+    def __str__(self):
+        return self.__name__
+
+
+class TransformOp(Op):
+    def set_inv(self, fn):
+        """
+        :param callable fn: A function that inputs an arg ``y`` and outputs a
+            value ``x`` such that ``y=self(x)``.
+        """
+        assert callable(fn)
+        self.inv = fn
+        return fn
+
+    def set_log_abs_det_jacobian(self, fn):
+        """
+        :param callable fn: A function that inputs two args ``x, y``, where
+            ``y=self(x)``, and returns ``log(abs(det(dy/dx)))``.
+        """
+        assert callable(fn)
+        self.log_abs_det_jacobian = fn
+        return fn
+
+    @staticmethod
+    def inv(x):
+        raise NotImplementedError
+
+    @staticmethod
+    def log_abs_det_jacobian(x, y):
+        raise NotImplementedError
+
+
+# Op registration tables.
+DISTRIBUTIVE_OPS = set()  # (add, mul) pairs
+UNITS = {}                # op -> value
+PRODUCT_INVERSES = {}     # op -> inverse op
+
+__all__ = [
+    'DISTRIBUTIVE_OPS',
+    'Op',
+    'PRODUCT_INVERSES',
+    'TransformOp',
+    'UNITS',
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ ignore = F811,E121,E123,E126,E226,E24,E704,W503,W504
 per-file-ignores =
     test/examples/test_bart.py:E128
     test/examples/test_sensor_fusion.py:E128
+    funsor/ops/__init__.py:F401,F403
 
 [isort]
 line_length = 120


### PR DESCRIPTION
Addresses #362 

This splits the `funsor.ops` module into three submodules:
- `ops.op` for `Op` base classes and registries
- `ops.builtin` for python builtin operations
- `ops.array` for numpy-like array functions  (mostly authored by @fehiepsi)

These boundaries are best-effort and will likely change a bit in the future, e.g.
- some numeric ops could be moved between `builtin` and `array`
- I'd prefer to avoid using `numpy` in `ops.builtin`
- some op classes could move from `ops.builtin` to `ops.op`

This also slightly changes the `Op` interface to eliminate direct need to use `Dispatcher` for array ops without default behavior; hopefully this will allow increased use of `Op` for pattern matching, but let me know if I've misunderstood.

## Tested
- refactoring is exercised by existing tests
- built docs locally