### PR TITLE
Avoid numpy in ops.builtin

### DIFF
--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -1,9 +1,11 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import numpy as np
 
-from .builtin import log, max, min, reciprocal, safediv, safesub
+from .builtin import exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt
 from .op import Op
 
 _builtin_all = all
@@ -26,6 +28,18 @@ prod = Op(np.prod)
 stack = Op("stack")
 sum = Op(np.sum)
 transpose = Op("transpose")
+
+sqrt.register(array)(np.sqrt)
+exp.register(array)(np.exp)
+log1p.register(array)(np.log1p)
+
+
+@log.register(array)
+def _log(x):
+    if x.dtype == 'bool':
+        return np.where(x, 0., -math.inf)
+    with np.errstate(divide='ignore'):  # skip the warning of log(0.)
+        return np.log(x)
 
 
 class ReshapeMeta(type):

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -1,10 +1,9 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import operator
 from numbers import Number
-
-import numpy as np  # TODO remove dependency on numpy in this file
 
 from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, TransformOp
 
@@ -121,7 +120,7 @@ def _unary_add(x):
 
 @Op
 def sqrt(x):
-    return np.sqrt(x)
+    return math.sqrt(x)
 
 
 class ExpOp(TransformOp):
@@ -130,7 +129,7 @@ class ExpOp(TransformOp):
 
 @ExpOp
 def exp(x):
-    return np.exp(x)
+    return math.exp(x)
 
 
 @exp.set_log_abs_det_jacobian
@@ -144,10 +143,7 @@ class LogOp(TransformOp):
 
 @LogOp
 def log(x):
-    if isinstance(x, bool) or (isinstance(x, np.ndarray) and x.dtype == 'bool'):
-        return np.where(x, 0., float('-inf'))
-    with np.errstate(divide='ignore'):  # skip the warning of log(0.)
-        return np.log(x)
+    return math.log(x) if x > 0 else -math.inf
 
 
 @log.set_log_abs_det_jacobian
@@ -161,12 +157,12 @@ log.set_inv(exp)
 
 @Op
 def log1p(x):
-    return np.log1p(x)
+    return math.log1p(x)
 
 
 @Op
 def sigmoid(x):
-    return 1 / (1 + np.exp(-x))
+    return 1 / (1 + exp(-x))
 
 
 @Op


### PR DESCRIPTION
Addresses #362

@fehiepsi can you please confirm that the new `math` defaults will still work with jax? Let me know if I'm misunderstanding anything.