### PR TITLE
Move set_backend(os.environ(...)) from __init__.py to conftest.py

### DIFF
--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -53,6 +53,7 @@ def parallel_loss_fn(model, guide, parallel=True):
 
 
 def run_expt(args):
+    funsor.set_backend("torch")
 
     optim = args["optim"]
     lr = args["learnrate"]

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -11,6 +11,7 @@ import pyro
 import pyro.poutine as poutine
 import torch
 
+import funsor
 import funsor.ops as ops
 from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -42,10 +42,6 @@ from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     testing
 )
 
-# TODO: move to `funsor.util` when the following circular import issue is resolved
-# funsor.domains -> funsor.util -> set_backend -> funsor.torch -> funsor.domains
-set_backend(get_backend())
-
 
 __all__ = [
     'Array',

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -4,12 +4,11 @@
 import functools
 import inspect
 import re
-import os
 
 import numpy as np
 
-_FUNSOR_BACKEND = os.environ.get("FUNSOR_BACKEND", "numpy")
-_JAX_LOADED = True if _FUNSOR_BACKEND == "jax" else False
+_FUNSOR_BACKEND = "numpy"
+_JAX_LOADED = False
 
 
 class lazy_property(object):
@@ -150,13 +149,10 @@ def broadcast_shape(*shapes, **kwargs):
 
 def set_backend(backend):
     """
-    Set backend for Funsor. Currently, only three backends are supported:
-    "numpy", "torch", and "jax". And Funsor only runs with one backend
-    at a time.
+    Set backend for Funsor.
 
-    The default backend will be "numpy". We can change the default backend
-    by specifying a new one in the environment variable `FUNSOR_BACKEND`,
-    e.g. `FUNSOR_BACKEND=torch`.
+    Currently three backends are supported: "numpy" (default), "torch", and
+    "jax". Funsor runs with only one backend at a time.
 
     .. note: When `jax` backend is set, we cannot revert back to the default
     `numpy` backend because we dispatch to using `jax.numpy` all ops with

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,14 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import numpy as np
 
 import funsor.util
+
+_BACKEND = os.environ.get("FUNSOR_BACKEND", "numpy")
+funsor.util.set_backend(_BACKEND)
 
 
 def _disallow_set_backend(*args):
@@ -12,13 +17,12 @@ def _disallow_set_backend(*args):
 
 def pytest_runtest_setup(item):
     np.random.seed(0)
-    backend = funsor.util.get_backend()
-    if backend == "torch":
+    if _BACKEND == "torch":
         import pyro
 
         pyro.set_rng_seed(0)
         pyro.enable_validation(True)
-    elif backend == "jax":
+    elif _BACKEND == "jax":
         from jax.config import config
 
         config.update('jax_platform_name', 'cpu')


### PR DESCRIPTION
Addresses #362, #207, https://github.com/pyro-ppl/pyro/issues/2630

## Motivation

This PR aims to resolve cyclic dependency issues that are preventing Pyro from depending on `funsor`. The underlying issue is that `funsor.torch` depends on Pyro for distributions and some math helpers, but we would like Pyro to be able to depend on Funsor. This cyclic dependency is an issue because `funsor.torch` calls `import pyro` and then `pyro` calls `import funsor`. This PR resolves the issue by delaying backend-specific module loading until `set_backend()` is called, so that Pyro can `import funsor` without any Pyro dependencies. Then once `pyro` is fully loaded, Pyro code that uses Funsor can call `funsor.set_backend("torch")` as needed, triggering full loading of `funsor.torch`.

## Implementation

This PR moves the backend configuration
```py
set_backend(os.environ.get("FUNSOR_BACKEND", "numpy"))
```
from `funsor/__init__.py` to `test/conftest.py`. After this PR, the `FUNSOR_BACKEND` environment variable is no longer part of the public interface; instead it merely controls pytest testing. Henceforth all examples explicitly call `set_backend("torch")`; in the future we may also make the examples more generic and read backend from an environment variable.
