### PR TITLE
Convert memoize to StatefulInterpretation

### DIFF
--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -107,14 +107,14 @@ def set_interpretation(new):
 
 
 @contextmanager
-def interpretation(new):
+def interpretation(new, stack=True):
     assert callable(new)
     global _INTERPRETATION
     old = _INTERPRETATION
-    new = InterpreterStack(new, old)
+    new = InterpreterStack(new, old) if stack else new
     try:
         _INTERPRETATION = new
-        yield new.default
+        yield new.default if stack else new
     finally:
         _INTERPRETATION = old
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -114,7 +114,7 @@ def interpretation(new):
     new = InterpreterStack(new, old)
     try:
         _INTERPRETATION = new
-        yield
+        yield new.default
     finally:
         _INTERPRETATION = old
 

--- a/funsor/memoize.py
+++ b/funsor/memoize.py
@@ -15,6 +15,6 @@ class Memoize(interpreter.StatefulInterpretation):
         key = (cls,) + tuple(id(arg) if (type(arg).__name__ == "DeviceArray") or not isinstance(arg, Hashable)
                              else arg for arg in args)
         if key not in self.cache:
-            with interpreter.interpretation(interpreter._INTERPRETATION.fallback):
+            with interpreter.interpretation(interpreter._INTERPRETATION.fallback, stack=False):
                 self.cache[key] = cls(*args)
         return self.cache[key]


### PR DESCRIPTION
Addresses #373 

This PR converts `funsor.memoize.memoize` into a `StatefulInterpretation` as in #369.  I had to make a couple of changes to the interpreter logic to get this working:
1. Have `interpreter.interpretation` yield its input
2. Add an option to disable interpreter stacking in `interpretation`, which was enabled by default in #369 

The second change was necessary to avoid a memory blowup caused by an interpreter being stacked with itself. It suggests the need for more tinkering with interpreter design to address a number of cases including `memoize` and `AdjointTape` where an interpretation invokes the previously active interpretation and does something with the result.