### PR TITLE
Add DirichletMultinomial for jax backend

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -232,6 +232,7 @@ FUNSOR_DIST_NAMES = [
     ('CategoricalLogits', ('logits',)),
     ('Delta', ('v', 'log_density')),
     ('Dirichlet', ('concentration',)),
+    ('DirichletMultinomial', ('concentration', 'total_count')),
     ('Gamma', ('concentration', 'rate')),
     ('Multinomial', ('total_count', 'probs')),
     ('MultivariateNormal', ('loc', 'scale_tril')),

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -241,7 +241,8 @@ FUNSOR_DIST_NAMES = [
     ('NonreparameterizedGamma', ('concentration', 'rate')),
     ('NonreparameterizedNormal', ('loc', 'scale')),
     ('Normal', ('loc', 'scale')),
-    ('Poisson', ('rate',))
+    ('Poisson', ('rate',)),
+    ('VonMises', ('loc', 'concentration')),
 ]
 
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -351,7 +351,7 @@ class CoerceDistributionToFunsor:
             funsor_cls = getattr(self.module, cls.__name__, None)
             # resolve the issues Binomial/Multinomial are functions in NumPyro, which
             # fallback to either BinomialProbs or BinomialLogits
-            if funsor_cls is None:
+            if funsor_cls is None and cls.__name__.endswith("Probs"):
                 funsor_cls = getattr(self.module, cls.__name__[:-5], None)
             cls._funsor_cls = funsor_cls
         if funsor_cls is None:

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -20,6 +20,8 @@ from funsor.distribution import (  # noqa: F401
     eager_delta_funsor_variable,
     eager_delta_tensor,
     eager_delta_variable_variable,
+    eager_dirichlet_multinomial,
+    eager_dirichlet_posterior,
     eager_multinomial,
     eager_mvn,
     eager_normal,
@@ -183,6 +185,14 @@ def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
 
 
+JointDirichletMultinomial = Contraction[
+    Union[ops.LogAddExpOp, ops.NullOp],
+    ops.AddOp,
+    frozenset,
+    Tuple[Dirichlet, Multinomial],  # noqa: F821
+]
+
+
 eager.register(Beta, Funsor, Funsor, Funsor)(eager_beta)  # noqa: F821)
 eager.register(Binomial, Funsor, Funsor, Funsor)(eager_binomial)  # noqa: F821
 eager.register(Multinomial, Tensor, Tensor, Tensor)(eager_multinomial)  # noqa: F821)
@@ -195,35 +205,10 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-
-
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)  # noqa: F821
-def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
-    if dirichlet_reduction:
-        return DirichletMultinomial(concentration=x.concentration,  # noqa: F821
-                                    total_count=y.total_count,
-                                    value=y.value)
-    else:
-        return eager(Contraction, red_op, bin_op, reduced_vars, (x, y))
-
-
-JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
-    ops.AddOp,
-    frozenset,
-    Tuple[Dirichlet, Multinomial],  # noqa: F821
-]
-
-
-@eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)  # noqa: F821
-def eager_dirichlet_posterior(op, c, z):
-    if (z.concentration is c.terms[0].concentration) and (c.terms[1].total_count is z.total_count):
-        return Dirichlet(  # noqa: F821
-            concentration=z.concentration + c.terms[1].value,
-            value=c.terms[0].value)
-    else:
-        return None
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+    eager_dirichlet_multinomial)
+eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
+    eager_dirichlet_posterior)
 
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES if _get_numpyro_dist(x[0]) is not None)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -46,10 +46,7 @@ class _NumPyroWrapper_Binomial(dist.BinomialProbs):
 
 
 class _NumPyroWrapper_Categorical(dist.CategoricalProbs):
-    # this fix is not available in NumPyro 0.2.4
-    @property
-    def support(self):
-        return dist.constraints.integer_interval(0, self.probs.shape[-1] - 1)
+    pass
 
 
 class _NumPyroWrapper_Multinomial(dist.MultinomialProbs):

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -210,7 +210,7 @@ def _safesub(x, y):
     return x + np.clip(-y, a_min=None, a_max=finfo.max)
 
 
-@ops.stack.register(int, [array])
+@ops.stack.register(int, [(array, float, int)])
 def _stack(dim, *x):
     return np.stack(x, axis=dim)
 

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -210,7 +210,7 @@ def _safesub(x, y):
     return x + np.clip(-y, a_min=None, a_max=finfo.max)
 
 
-@ops.stack.register(int, [(array, float, int)])
+@ops.stack.register(int, [array + (int, float)])
 def _stack(dim, *x):
     return np.stack(x, axis=dim)
 

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -22,6 +22,8 @@ from funsor.distribution import (  # noqa: F401
     eager_delta_funsor_funsor,
     eager_delta_funsor_variable,
     eager_delta_tensor,
+    eager_dirichlet_multinomial,
+    eager_dirichlet_posterior,
     eager_delta_variable_variable,
     eager_multinomial,
     eager_mvn,
@@ -167,6 +169,14 @@ def bernoulli_to_funsor(pyro_dist, output=None, dim_to_name=None):
     return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
 
 
+JointDirichletMultinomial = Contraction[
+    Union[ops.LogAddExpOp, ops.NullOp],
+    ops.AddOp,
+    frozenset,
+    Tuple[Dirichlet, Multinomial],  # noqa: F821
+]
+
+
 eager.register(Beta, Funsor, Funsor, Funsor)(eager_beta)  # noqa: F821)
 eager.register(Binomial, Funsor, Funsor, Funsor)(eager_binomial)  # noqa: F821
 eager.register(Multinomial, Tensor, Tensor, Tensor)(eager_multinomial)  # noqa: F821)
@@ -179,32 +189,7 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-
-
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)  # noqa: F821
-def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
-    if dirichlet_reduction:
-        return DirichletMultinomial(concentration=x.concentration,  # noqa: F821
-                                    total_count=y.total_count,
-                                    value=y.value)
-    else:
-        return eager(Contraction, red_op, bin_op, reduced_vars, (x, y))
-
-
-JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
-    ops.AddOp,
-    frozenset,
-    Tuple[Dirichlet, Multinomial],  # noqa: F821
-]
-
-
-@eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)  # noqa: F821
-def eager_dirichlet_posterior(op, c, z):
-    if (z.concentration is c.terms[0].concentration) and (c.terms[1].total_count is z.total_count):
-        return Dirichlet(  # noqa: F821
-            concentration=z.concentration + c.terms[1].value,
-            value=c.terms[0].value)
-    else:
-        return None
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+    eager_dirichlet_multinomial)
+eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
+    eager_dirichlet_posterior)

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -87,9 +87,7 @@ def _get_pyro_dist(dist_name):
         return getattr(dist, dist_name)
 
 
-PYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
-    ('VonMises', ('loc', 'concentration')),
-]
+PYRO_DIST_NAMES = FUNSOR_DIST_NAMES
 
 
 for dist_name, param_names in PYRO_DIST_NAMES:

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -86,7 +86,6 @@ def _get_pyro_dist(dist_name):
 
 
 PYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
-    ('DirichletMultinomial', ('concentration', 'total_count')),
     ('VonMises', ('loc', 'concentration')),
 ]
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -29,6 +29,16 @@ if get_backend() != "numpy":
     backend_dist = dist.dist
 
 
+def _skip_for_numpyro_version(version="0.2.4"):
+    if get_backend() == "jax":
+        import numpyro
+
+        if numpyro.__version__ <= version:
+            return True
+
+    return False
+
+
 @pytest.mark.xfail(get_backend() == "jax", reason="flaky test")
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('eager', [False, True])
@@ -240,6 +250,9 @@ def test_dirichlet_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
+# TODO change xfail to skipif when NumPyro > 0.4.0 is released
+@pytest.mark.xfail(_skip_for_numpyro_version("0.4.0"),
+                   reason="DirichletMultinomial is not available in NumPyro 0.4.0")
 def test_dirichlet_multinomial_density(batch_shape, event_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
@@ -269,6 +282,8 @@ def test_dirichlet_multinomial_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(2,), (4,), (5,)], ids=str)
+@pytest.mark.xfail(_skip_for_numpyro_version("0.4.0"),
+                   reason="DirichletMultinomial is not available in NumPyro 0.4.0")
 def test_dirichlet_multinomial_conjugate(batch_shape, event_shape):
     max_count = 10
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
@@ -831,21 +846,11 @@ def test_mvn_sample(with_lazy, batch_shape, sample_inputs, event_shape):
     _check_sample(funsor_dist_class, params, sample_inputs, inputs, atol=7e-2, num_samples=200000, with_lazy=with_lazy)
 
 
-def _skip_for_numpyro_2_4():
-    if get_backend() == "jax":
-        import numpyro
-
-        if numpyro.__version__ == "0.2.4":
-            return True
-
-    return False
-
-
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
 @pytest.mark.parametrize('reparametrized', [True, False])
-@pytest.mark.skipif(_skip_for_numpyro_2_4(),
+@pytest.mark.skipif(_skip_for_numpyro_version("0.2.4"),
                     reason="Dirichlet samples might take 0/1 values in NumPyro 0.2.4")
 def test_dirichlet_sample(batch_shape, sample_inputs, event_shape, reparametrized):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
@@ -888,7 +893,7 @@ def test_bernoulliprobs_sample(batch_shape, sample_inputs):
 @pytest.mark.parametrize('sample_inputs', [(), ('ii',), ('ii', 'jj'), ('ii', 'jj', 'kk')])
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('reparametrized', [True, False])
-@pytest.mark.skipif(_skip_for_numpyro_2_4(),
+@pytest.mark.skipif(_skip_for_numpyro_version("0.2.4"),
                     reason="Dirichlet samples might take 0/1 values in NumPyro 0.2.4")
 def test_beta_sample(with_lazy, batch_shape, sample_inputs, reparametrized):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -18,7 +18,7 @@ from funsor.domains import Bint, Real, Reals
 from funsor.integrate import Integrate
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import Einsum, Tensor, align_tensors, numeric_array
-from funsor.terms import Independent, Variable, eager, lazy
+from funsor.terms import Independent, Variable, eager, lazy, to_funsor
 from funsor.testing import assert_close, check_funsor, rand, randint, randn, random_mvn, random_tensor, xfail_param
 from funsor.util import get_backend
 
@@ -27,9 +27,6 @@ pytestmark = pytest.mark.skipif(get_backend() == "numpy",
 if get_backend() != "numpy":
     dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
     backend_dist = dist.dist
-
-if get_backend() == "torch":
-    from funsor.pyro.convert import dist_to_funsor
 
 
 @pytest.mark.xfail(get_backend() == "jax", reason="flaky test")
@@ -550,23 +547,21 @@ def _check_mvn_affine(d1, data):
     assert_close(actual, expected)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_one_var():
     x = Variable('x', Reals[2])
     data = dict(x=Tensor(randn(2)))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 2))
+        d = to_funsor(random_mvn((), 2), Real)
         d = d(value=2 * x + 1)
     _check_mvn_affine(d, data)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_two_vars():
     x = Variable('x', Reals[2])
     y = Variable('y', Reals[2])
     data = dict(x=Tensor(randn(2)), y=Tensor(randn(2)))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 2))
+        d = to_funsor(random_mvn((), 2), Real)
         d = d(value=x - y)
     _check_mvn_affine(d, data)
 
@@ -582,47 +577,43 @@ def test_mvn_affine_matmul():
     _check_mvn_affine(d, data)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_matmul_sub():
     x = Variable('x', Reals[2])
     y = Variable('y', Reals[3])
     m = Tensor(randn(2, 3))
     data = dict(x=Tensor(randn(2)), y=Tensor(randn(3)))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 3))
+        d = to_funsor(random_mvn((), 3), Real)
         d = d(value=x @ m - y)
     _check_mvn_affine(d, data)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_einsum():
     c = Tensor(randn(3, 2, 2))
     x = Variable('x', Reals[2, 2])
     y = Variable('y', Real)
     data = dict(x=Tensor(randn(2, 2)), y=Tensor(randn(())))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 3))
+        d = to_funsor(random_mvn((), 3), Real)
         d = d(value=Einsum("abc,bc->a", c, x) + y)
     _check_mvn_affine(d, data)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_getitem():
     x = Variable('x', Reals[2, 2])
     data = dict(x=Tensor(randn(2, 2)))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 2))
+        d = to_funsor(random_mvn((), 2), Real)
         d = d(value=x[0] - x[1])
     _check_mvn_affine(d, data)
 
 
-@pytest.mark.xfail(get_backend() == 'jax', reason='dist_to_funsor for jax backend is not available yet')
 def test_mvn_affine_reshape():
     x = Variable('x', Reals[2, 2])
     y = Variable('y', Reals[4])
     data = dict(x=Tensor(randn(2, 2)), y=Tensor(randn(4)))
     with interpretation(lazy):
-        d = dist_to_funsor(random_mvn((), 4))
+        d = to_funsor(random_mvn((), 4), Real)
         d = d(value=x.reshape((4,)) - y)
     _check_mvn_affine(d, data)
 
@@ -682,7 +673,6 @@ def test_gamma_probs_density(batch_shape, syntax):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('syntax', ['eager', 'lazy'])
-@pytest.mark.xfail(get_backend() != 'torch', reason="VonMises is not implemented yet in NumPyro")
 def test_von_mises_probs_density(batch_shape, syntax):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -243,7 +243,6 @@ def test_dirichlet_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
-@pytest.mark.xfail(get_backend() != 'torch', reason="DirichletMultinomial is not implemented yet in NumPyro")
 def test_dirichlet_multinomial_density(batch_shape, event_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
@@ -273,7 +272,6 @@ def test_dirichlet_multinomial_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(2,), (4,), (5,)], ids=str)
-@pytest.mark.xfail(get_backend() != 'torch', reason="DirichletMultinmial is not implemented yet in NumPyro")
 def test_dirichlet_multinomial_conjugate(batch_shape, event_shape):
     max_count = 10
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]


### PR DESCRIPTION
~This is blocked until DirichletMultinomial is available in NumPyro.~

~Blocked by https://github.com/pyro-ppl/numpyro/pull/772~

I also enhanced `ops.stack` to support int/float types in jax backend and enabled jax backend in various tests.