### PR TITLE
Add beta bernoulli conjugacy

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -232,6 +232,7 @@ FUNSOR_DIST_NAMES = [
     ('CategoricalLogits', ('logits',)),
     ('Delta', ('v', 'log_density')),
     ('Dirichlet', ('concentration',)),
+    ('DirichletMultinomial', ('concentration', 'total_count')),
     ('Gamma', ('concentration', 'rate')),
     ('Multinomial', ('total_count', 'probs')),
     ('MultivariateNormal', ('loc', 'scale_tril')),

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -551,6 +551,12 @@ def eager_mvn(loc, scale_tril, value):
     return gaussian(**{var: value - loc})
 
 
+def eager_beta_bernoulli(red_op, bin_op, reduced_vars, x, y):
+    backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
+    return eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x,
+                                       backend_dist.Binomial(total_count=1, probs=y.probs, value=y.value))
+
+
 def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
     dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
     if dirichlet_reduction:

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -13,6 +13,7 @@ from funsor.distribution import (  # noqa: F401
     LogNormal,
     backenddist_to_funsor,
     eager_beta,
+    eager_beta_bernoulli,
     eager_binomial,
     eager_categorical_funsor,
     eager_categorical_tensor,
@@ -205,6 +206,8 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
+    eager_beta_bernoulli)
 eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
     eager_dirichlet_multinomial)
 eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -20,6 +20,8 @@ from funsor.distribution import (  # noqa: F401
     eager_delta_funsor_variable,
     eager_delta_tensor,
     eager_delta_variable_variable,
+    eager_dirichlet_multinomial,
+    eager_dirichlet_posterior,
     eager_multinomial,
     eager_mvn,
     eager_normal,
@@ -183,6 +185,14 @@ def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
 
 
+JointDirichletMultinomial = Contraction[
+    Union[ops.LogAddExpOp, ops.NullOp],
+    ops.AddOp,
+    frozenset,
+    Tuple[Dirichlet, Multinomial],  # noqa: F821
+]
+
+
 eager.register(Beta, Funsor, Funsor, Funsor)(eager_beta)  # noqa: F821)
 eager.register(Binomial, Funsor, Funsor, Funsor)(eager_binomial)  # noqa: F821
 eager.register(Multinomial, Tensor, Tensor, Tensor)(eager_multinomial)  # noqa: F821)
@@ -195,35 +205,10 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-
-
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)  # noqa: F821
-def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
-    if dirichlet_reduction:
-        return DirichletMultinomial(concentration=x.concentration,  # noqa: F821
-                                    total_count=y.total_count,
-                                    value=y.value)
-    else:
-        return eager(Contraction, red_op, bin_op, reduced_vars, (x, y))
-
-
-JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
-    ops.AddOp,
-    frozenset,
-    Tuple[Dirichlet, Multinomial],  # noqa: F821
-]
-
-
-@eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)  # noqa: F821
-def eager_dirichlet_posterior(op, c, z):
-    if (z.concentration is c.terms[0].concentration) and (c.terms[1].total_count is z.total_count):
-        return Dirichlet(  # noqa: F821
-            concentration=z.concentration + c.terms[1].value,
-            value=c.terms[0].value)
-    else:
-        return None
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+    eager_dirichlet_multinomial)
+eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
+    eager_dirichlet_posterior)
 
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES if _get_numpyro_dist(x[0]) is not None)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -46,10 +46,7 @@ class _NumPyroWrapper_Binomial(dist.BinomialProbs):
 
 
 class _NumPyroWrapper_Categorical(dist.CategoricalProbs):
-    # this fix is not available in NumPyro 0.2.4
-    @property
-    def support(self):
-        return dist.constraints.integer_interval(0, self.probs.shape[-1] - 1)
+    pass
 
 
 class _NumPyroWrapper_Multinomial(dist.MultinomialProbs):

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -210,7 +210,7 @@ def _safesub(x, y):
     return x + np.clip(-y, a_min=None, a_max=finfo.max)
 
 
-@ops.stack.register(int, [array])
+@ops.stack.register(int, [(array, float, int)])
 def _stack(dim, *x):
     return np.stack(x, axis=dim)
 

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -16,6 +16,7 @@ from funsor.distribution import (  # noqa: F401
     LogNormal,
     backenddist_to_funsor,
     eager_beta,
+    eager_beta_bernoulli,
     eager_binomial,
     eager_categorical_funsor,
     eager_categorical_tensor,
@@ -189,6 +190,8 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
+    eager_beta_bernoulli)
 eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
     eager_dirichlet_multinomial)
 eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -22,6 +22,8 @@ from funsor.distribution import (  # noqa: F401
     eager_delta_funsor_funsor,
     eager_delta_funsor_variable,
     eager_delta_tensor,
+    eager_dirichlet_multinomial,
+    eager_dirichlet_posterior,
     eager_delta_variable_variable,
     eager_multinomial,
     eager_mvn,
@@ -167,6 +169,14 @@ def bernoulli_to_funsor(pyro_dist, output=None, dim_to_name=None):
     return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
 
 
+JointDirichletMultinomial = Contraction[
+    Union[ops.LogAddExpOp, ops.NullOp],
+    ops.AddOp,
+    frozenset,
+    Tuple[Dirichlet, Multinomial],  # noqa: F821
+]
+
+
 eager.register(Beta, Funsor, Funsor, Funsor)(eager_beta)  # noqa: F821)
 eager.register(Binomial, Funsor, Funsor, Funsor)(eager_binomial)  # noqa: F821
 eager.register(Multinomial, Tensor, Tensor, Tensor)(eager_multinomial)  # noqa: F821)
@@ -179,32 +189,7 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-
-
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)  # noqa: F821
-def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
-    if dirichlet_reduction:
-        return DirichletMultinomial(concentration=x.concentration,  # noqa: F821
-                                    total_count=y.total_count,
-                                    value=y.value)
-    else:
-        return eager(Contraction, red_op, bin_op, reduced_vars, (x, y))
-
-
-JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
-    ops.AddOp,
-    frozenset,
-    Tuple[Dirichlet, Multinomial],  # noqa: F821
-]
-
-
-@eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)  # noqa: F821
-def eager_dirichlet_posterior(op, c, z):
-    if (z.concentration is c.terms[0].concentration) and (c.terms[1].total_count is z.total_count):
-        return Dirichlet(  # noqa: F821
-            concentration=z.concentration + c.terms[1].value,
-            value=c.terms[0].value)
-    else:
-        return None
+eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+    eager_dirichlet_multinomial)
+eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
+    eager_dirichlet_posterior)

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -86,7 +86,6 @@ def _get_pyro_dist(dist_name):
 
 
 PYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
-    ('DirichletMultinomial', ('concentration', 'total_count')),
     ('VonMises', ('loc', 'concentration')),
 ]
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -243,7 +243,6 @@ def test_dirichlet_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (5,)], ids=str)
-@pytest.mark.xfail(get_backend() != 'torch', reason="DirichletMultinomial is not implemented yet in NumPyro")
 def test_dirichlet_multinomial_density(batch_shape, event_shape):
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
@@ -273,7 +272,6 @@ def test_dirichlet_multinomial_density(batch_shape, event_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(2,), (4,), (5,)], ids=str)
-@pytest.mark.xfail(get_backend() != 'torch', reason="DirichletMultinmial is not implemented yet in NumPyro")
 def test_dirichlet_multinomial_conjugate(batch_shape, event_shape):
     max_count = 10
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]


### PR DESCRIPTION
This PR supports the` collapse` handler by deferring the BernoulliProbs eager rule to Binomial with total_count=1.

Alternatively, I think we can define a BetaBernoulli contraction but I am not sure where we will put the implementation of `log_prob` computation. ~Should we implement a BetaBernoulli distribution in Pyro and do something like DirichletMultinomial?~ **Edit:** I think implementing Pyro's BetaBernoulli is unnecessary. We should find a way to do this directly in funsor.

Blocked by #377.