### PR TITLE
Materialize diagonal name substitutions in Tensor.eager_subs

### DIFF
--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -201,8 +201,6 @@ class Tensor(Funsor, metaclass=TensorMeta):
                 if k in subs:
                     v = subs[k]
                     if isinstance(v, Variable):
-                        if var_counts[v] > 1:
-                            continue
                         del subs[k]
                         k = v.name
                     elif isinstance(v, Slice):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1047,3 +1047,12 @@ def test_detach():
     assert_close(x, y)
     assert x.data.requires_grad
     assert not y.data.requires_grad
+
+
+def test_diagonal_rename():
+    x = Tensor(randn(2, 2, 3), OrderedDict(a=funsor.Bint[2], b=funsor.Bint[2], c=funsor.Bint[3]), 'real')
+    d = Variable("d", funsor.Bint[2])
+    dt = x.materialize(d)
+    yt = x(a=dt, b=dt)
+    y = x(a=d, b=d)
+    assert_close(y, yt)


### PR DESCRIPTION
Resolves #381 

This PR materializes variables substituted into tensors multiple times, e.g.
```py
x = funsor.Tensor(torch.randn(2, 2, 3), OrderedDict(a=funsor.Bint[2], b=funsor.Bint[2], c=funsor.Bint[3]), 'real')
y = x(a="d", b="d")
```
reduces to
```py
x = funsor.Tensor(torch.randn(2, 2, 3), OrderedDict(a=funsor.Bint[2], b=funsor.Bint[2], c=funsor.Bint[3]), 'real')
y = x(a=x.materialize(Variable("d", Bint[2])), b=x.materialize(Variable("d", Bint[2])))
```