### PR TITLE
Add TanhOp and AtanhOp

### DIFF
--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -17,6 +17,7 @@ import funsor.ops as ops
 ################################################################################
 
 array = (onp.generic, onp.ndarray, DeviceArray, Tracer)
+ops.atanh.register(array)(np.arctanh)
 ops.clamp.register(array, object, object)(np.clip)
 ops.exp.register(array)(np.exp)
 ops.full_like.register(array, object)(np.full_like)
@@ -26,6 +27,7 @@ ops.min.register(array)(np.minimum)
 ops.permute.register(array, (tuple, list))(np.transpose)
 ops.sigmoid.register(array)(expit)
 ops.sqrt.register(array)(np.sqrt)
+ops.tanh.register(array)(np.tanh)
 ops.transpose.register(array, int, int)(np.swapaxes)
 ops.unsqueeze.register(array, int)(np.expand_dims)
 

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -5,7 +5,7 @@ import math
 
 import numpy as np
 
-from .builtin import AssociativeOp, add, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt
+from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
 from .op import DISTRIBUTIVE_OPS, Op
 
 _builtin_all = all
@@ -32,6 +32,8 @@ transpose = Op("transpose")
 sqrt.register(array)(np.sqrt)
 exp.register(array)(np.exp)
 log1p.register(array)(np.log1p)
+tanh.register(array)(np.tanh)
+atanh.register(array)(np.arctanh)
 
 
 class LogAddExpOp(AssociativeOp):

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -147,6 +147,44 @@ exp.set_inv(log)
 log.set_inv(exp)
 
 
+class TanhOp(TransformOp):
+    pass
+
+
+@TanhOp
+def tanh(x):
+    return math.tanh(x)
+
+
+@tanh.set_inv
+def tanh_inv(y):
+    return atanh(y)
+
+
+@tanh.set_log_abs_det_jacobian
+def tanh_log_abs_det_jacobian(x, y):
+    return 2. * (math.log(2.) - x - softplus(-2. * x))
+
+
+class AtanhOp(TransformOp):
+    pass
+
+
+@AtanhOp
+def atanh(x):
+    return math.atanh(x)
+
+
+@atanh.set_inv
+def atanh_inv(y):
+    return tanh(y)
+
+
+@atanh.set_log_abs_det_jacobian
+def atanh_log_abs_det_jacobian(x, y):
+    return -2. * (math.log(2.) - x - softplus(-2. * x))
+
+
 @Op
 def log1p(x):
     return math.log1p(x)
@@ -160,6 +198,11 @@ def sigmoid(x):
 @Op
 def pow(x, y):
     return x ** y
+
+
+@Op
+def softplus(x):
+    return log(1. + exp(x))
 
 
 @AssociativeOp
@@ -223,6 +266,7 @@ PRODUCT_INVERSES[add] = safesub
 __all__ = [
     'AddOp',
     'AssociativeOp',
+    'AtanhOp',
     'DivOp',
     'ExpOp',
     'GetitemOp',
@@ -233,9 +277,11 @@ __all__ = [
     'NullOp',
     'ReciprocalOp',
     'SubOp',
+    'TanhOp',
     'abs',
     'add',
     'and_',
+    'atanh',
     'eq',
     'exp',
     'ge',
@@ -262,6 +308,7 @@ __all__ = [
     'sigmoid',
     'sqrt',
     'sub',
+    'tanh',
     'truediv',
     'xor',
 ]

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -182,7 +182,7 @@ def atanh_inv(y):
 
 @atanh.set_log_abs_det_jacobian
 def atanh_log_abs_det_jacobian(x, y):
-    return -2. * (math.log(2.) - x - softplus(-2. * x))
+    return -tanh.log_abs_det_jacobian(y, x)
 
 
 @Op
@@ -190,9 +190,23 @@ def log1p(x):
     return math.log1p(x)
 
 
-@Op
+class SigmoidOp(TransformOp):
+    pass
+
+
+@SigmoidOp
 def sigmoid(x):
     return 1 / (1 + exp(-x))
+
+
+@sigmoid.set_inv
+def sigmoid_inv(y):
+    return log(y) - log1p(-y)
+
+
+@sigmoid.set_log_abs_det_jacobian
+def sigmoid_log_abs_det_jacobian(x, y):
+    return -softplus(-x) - softplus(x)
 
 
 @Op
@@ -276,6 +290,7 @@ __all__ = [
     'NegOp',
     'NullOp',
     'ReciprocalOp',
+    'SigmoidOp',
     'SubOp',
     'TanhOp',
     'abs',

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -592,6 +592,9 @@ class Funsor(object, metaclass=FunsorMeta):
     def abs(self):
         return Unary(ops.abs, self)
 
+    def atanh(self):
+        return Unary(ops.atanh, self)
+
     def sqrt(self):
         return Unary(ops.sqrt, self)
 
@@ -606,6 +609,9 @@ class Funsor(object, metaclass=FunsorMeta):
 
     def sigmoid(self):
         return Unary(ops.sigmoid, self)
+
+    def tanh(self):
+        return Unary(ops.tanh, self)
 
     def reshape(self, shape):
         return Unary(ops.ReshapeOp(shape), self)
@@ -1634,6 +1640,11 @@ def _abs(x):
     return Unary(ops.abs, x)
 
 
+@ops.atanh.register(Funsor)
+def _atanh(x):
+    return Unary(ops.atanh, x)
+
+
 @ops.sqrt.register(Funsor)
 def _sqrt(x):
     return Unary(ops.sqrt, x)
@@ -1667,6 +1678,11 @@ def _reciprocal(x):
 @ops.sigmoid.register(Funsor)
 def _sigmoid(x):
     return Unary(ops.sigmoid, x)
+
+
+@ops.tanh.register(Funsor)
+def _tanh(x):
+    return Unary(ops.tanh, x)
 
 
 __all__ = [

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -11,12 +11,15 @@ import funsor.ops as ops
 ################################################################################
 
 ops.abs.register(torch.Tensor)(torch.abs)
+ops.atanh.register(torch.Tensor)(torch.atanh)
 ops.cholesky_solve.register(torch.Tensor, torch.Tensor)(torch.cholesky_solve)
 ops.clamp.register(torch.Tensor, object, object)(torch.clamp)
 ops.exp.register(torch.Tensor)(torch.exp)
 ops.full_like.register(torch.Tensor, object)(torch.full_like)
 ops.log1p.register(torch.Tensor)(torch.log1p)
+ops.sigmoid.register(torch.Tensor)(torch.sigmoid)
 ops.sqrt.register(torch.Tensor)(torch.sqrt)
+ops.tanh.register(torch.Tensor)(torch.tanh)
 ops.transpose.register(torch.Tensor, int, int)(torch.transpose)
 ops.unsqueeze.register(torch.Tensor, int)(torch.unsqueeze)
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -316,6 +316,8 @@ def test_unary(symbol, dims):
     if symbol == '~':
         data = ops.astype(data, 'uint8')
         dtype = 2
+    if symbol == 'atanh':
+        data = ops.clamp(data, -0.99, 0.99)
     if get_backend() != "torch" and symbol in ["abs", "atanh", "sqrt", "exp", "log", "log1p", "sigmoid", "tanh"]:
         expected_data = getattr(ops, symbol)(data)
     else:

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -305,7 +305,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('dims', [(), ('a',), ('a', 'b')])
 @pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid',
+    '~', '-', 'abs', 'atanh', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid', 'tanh',
 ])
 def test_unary(symbol, dims):
     sizes = {'a': 3, 'b': 4}
@@ -316,7 +316,7 @@ def test_unary(symbol, dims):
     if symbol == '~':
         data = ops.astype(data, 'uint8')
         dtype = 2
-    if get_backend() != "torch" and symbol in ["abs", "sqrt", "exp", "log", "log1p", "sigmoid"]:
+    if get_backend() != "torch" and symbol in ["abs", "atanh", "sqrt", "exp", "log", "log1p", "sigmoid", "tanh"]:
         expected_data = getattr(ops, symbol)(data)
     else:
         expected_data = unary_eval(symbol, data)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -238,7 +238,7 @@ def unary_eval(symbol, x):
 
 @pytest.mark.parametrize('data', [0, 0.5, 1])
 @pytest.mark.parametrize('symbol', [
-    '~', '-', 'abs', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid',
+    '~', '-', 'atanh', 'abs', 'sqrt', 'exp', 'log', 'log1p', 'sigmoid', 'tanh',
 ])
 def test_unary(symbol, data):
     dtype = 'real'

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -245,6 +245,8 @@ def test_unary(symbol, data):
     if symbol == '~':
         data = bool(data)
         dtype = 2
+    if symbol == 'atanh':
+        data = min(data, 0.99)
     expected_data = unary_eval(symbol, data)
 
     x = Number(data, dtype)


### PR DESCRIPTION
Addresses #386 

This PR adds two new `TransformOp`s, `tanh` and `atanh`, which correspond to `torch.distributions.transforms.TanhTransform` and its inverse. It also upgrades `ops.sigmoid` to a `TransformOp`. These will be useful in testing transformed distributions.

Tested:
- Added `tanh` and `atanh` to unary op tests in `test_terms.py` and `test_tensor.py`