### PR TITLE
Tweak automated registration for distribution-to-funsor conversion

### DIFF
--- a/examples/sensor.py
+++ b/examples/sensor.py
@@ -101,7 +101,7 @@ class Model(nn.Module):
             )
         )(value=bias)
 
-        init_dist = torch.distributions.MultivariateNormal(
+        init_dist = dist.MultivariateNormal(
             torch.zeros(4), scale_tril=100. * torch.eye(4))
         self.init = dist_to_funsor(init_dist)(value="state")
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -230,7 +230,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
 ################################################################################
 
 
-def make_dist(backend_dist_class, param_names=()):
+def make_dist(backend_dist_class, param_names=(), generate_eager=True, generate_to_funsor=True):
     if not param_names:
         param_names = tuple(name for name in inspect.getfullargspec(backend_dist_class.__init__)[0][1:]
                             if name in backend_dist_class.arg_constraints)
@@ -244,7 +244,11 @@ def make_dist(backend_dist_class, param_names=()):
         '__init__': dist_init,
     })
 
-    eager.register(dist_class, *((Tensor,) * (len(param_names) + 1)))(dist_class.eager_log_prob)
+    if generate_eager:
+        eager.register(dist_class, *((Tensor,) * (len(param_names) + 1)))(dist_class.eager_log_prob)
+
+    if generate_to_funsor:
+        to_funsor.register(backend_dist_class)(functools.partial(backenddist_to_funsor, dist_class))
 
     return dist_class
 
@@ -277,9 +281,7 @@ FUNSOR_DIST_NAMES = [
 # Converting backend Distributions to funsors
 ###############################################
 
-def backenddist_to_funsor(backend_dist, output=None, dim_to_name=None):
-    funsor_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
-    funsor_dist_class = getattr(funsor_dist, type(backend_dist).__name__.split("Wrapper_")[-1])
+def backenddist_to_funsor(funsor_dist_class, backend_dist, output=None, dim_to_name=None):
     params = [to_funsor(
             getattr(backend_dist, param_name),
             output=funsor_dist_class._infer_param_domain(
@@ -309,16 +311,6 @@ def maskeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
 
 def transformeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
     raise NotImplementedError("TODO implement conversion of TransformedDistribution")
-
-
-def mvndist_to_funsor(backend_dist, output=None, dim_to_name=None, real_inputs=OrderedDict()):
-    funsor_dist = backenddist_to_funsor(backend_dist, output=output, dim_to_name=dim_to_name)
-    if len(real_inputs) == 0:
-        return funsor_dist
-    discrete, gaussian = funsor_dist(value="value").terms
-    inputs = OrderedDict((k, v) for k, v in gaussian.inputs.items() if v.dtype != 'real')
-    inputs.update(real_inputs)
-    return discrete + Gaussian(gaussian.info_vec, gaussian.precision, inputs)
 
 
 class CoerceDistributionToFunsor:

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -32,7 +32,6 @@ from funsor.distribution import (  # noqa: F401
     indepdist_to_funsor,
     make_dist,
     maskeddist_to_funsor,
-    mvndist_to_funsor,
     transformeddist_to_funsor,
 )
 from funsor.domains import Real, Reals
@@ -167,19 +166,17 @@ if hasattr(dist, "DirichletMultinomial"):
 # Converting PyTorch Distributions to funsors
 ###############################################
 
-to_funsor.register(dist.Distribution)(backenddist_to_funsor)
 to_funsor.register(dist.Independent)(indepdist_to_funsor)
 if hasattr(dist, "MaskedDistribution"):
     to_funsor.register(dist.MaskedDistribution)(maskeddist_to_funsor)
 to_funsor.register(dist.TransformedDistribution)(transformeddist_to_funsor)
-to_funsor.register(dist.MultivariateNormal)(mvndist_to_funsor)
 
 
 @to_funsor.register(dist.BinomialProbs)
 @to_funsor.register(dist.BinomialLogits)
 def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _NumPyroWrapper_Binomial(probs=numpyro_dist.probs)
-    return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
+    return backenddist_to_funsor(Binomial, new_pyro_dist, output, dim_to_name)  # noqa: F821
 
 
 @to_funsor.register(dist.CategoricalProbs)
@@ -188,14 +185,14 @@ def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
 @to_funsor.register(dist.CategoricalLogits)
 def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _NumPyroWrapper_Categorical(probs=numpyro_dist.probs)
-    return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
+    return backenddist_to_funsor(Categorical, new_pyro_dist, output, dim_to_name)  # noqa: F821
 
 
 @to_funsor.register(dist.MultinomialProbs)
 @to_funsor.register(dist.MultinomialLogits)
 def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _NumPyroWrapper_Multinomial(probs=numpyro_dist.probs)
-    return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
+    return backenddist_to_funsor(Multinomial, new_pyro_dist, output, dim_to_name)  # noqa: F821
 
 
 JointDirichletMultinomial = Contraction[

--- a/funsor/pyro/convert.py
+++ b/funsor/pyro/convert.py
@@ -140,7 +140,13 @@ def mvn_to_funsor(pyro_dist, event_inputs=(), real_inputs=OrderedDict()):
     assert isinstance(event_inputs, tuple)
     assert isinstance(real_inputs, OrderedDict)
     dim_to_name = default_dim_to_name(pyro_dist.batch_shape, event_inputs)
-    return to_funsor(pyro_dist, Real, dim_to_name, real_inputs=real_inputs)
+    funsor_dist = to_funsor(pyro_dist, Real, dim_to_name)
+    if len(real_inputs) == 0:
+        return funsor_dist
+    discrete, gaussian = funsor_dist(value="value").terms
+    inputs = OrderedDict((k, v) for k, v in gaussian.inputs.items() if v.dtype != 'real')
+    inputs.update(real_inputs)
+    return discrete + Gaussian(gaussian.info_vec, gaussian.precision, inputs)
 
 
 def funsor_to_mvn(gaussian, ndims, event_inputs=()):

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -35,7 +35,6 @@ from funsor.distribution import (  # noqa: F401
     indepdist_to_funsor,
     make_dist,
     maskeddist_to_funsor,
-    mvndist_to_funsor,
     transformeddist_to_funsor,
 )
 from funsor.domains import Real, Reals
@@ -158,17 +157,15 @@ def _infer_param_domain(cls, name, raw_shape):
 # Converting PyTorch Distributions to funsors
 ###############################################
 
-to_funsor.register(torch.distributions.Distribution)(backenddist_to_funsor)
 to_funsor.register(torch.distributions.Independent)(indepdist_to_funsor)
 to_funsor.register(MaskedDistribution)(maskeddist_to_funsor)
 to_funsor.register(torch.distributions.TransformedDistribution)(transformeddist_to_funsor)
-to_funsor.register(torch.distributions.MultivariateNormal)(mvndist_to_funsor)
 
 
 @to_funsor.register(torch.distributions.Bernoulli)
 def bernoulli_to_funsor(pyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _PyroWrapper_BernoulliLogits(logits=pyro_dist.logits)
-    return backenddist_to_funsor(new_pyro_dist, output, dim_to_name)
+    return backenddist_to_funsor(BernoulliLogits, new_pyro_dist, output, dim_to_name)  # noqa: F821
 
 
 JointDirichletMultinomial = Contraction[


### PR DESCRIPTION
Addresses #386. Motivated by @ordabayevy's [forum post](https://forum.pyro.ai/t/how-to-make-custom-distributions-funsor-compatible/2351/2) about generating Funsor wrappers for custom distributions.

Currently, generic `TorchDistribution`-to-`funsor.distribution.Distribution` conversion is handled by a single pattern:
```py
@to_funsor.register(pyro.distributions.Distribution)
def backenddist_to_funsor(backend_dist, output=None, dim_to_name=None):
    funsor_dist_class = ...
    ...
```
This design requires the pattern to somehow identify a Funsor counterpart `funsor_dist_class` to `backend_dist`, which it currently does somewhat hackily by looking in the global namespace.  This PR tweaks this logic so that no lookup is necessary:
```py
def backenddist_to_funsor(funsor_dist_class, backend_dist, ...):
    ...

to_funsor.register(MyDistribution)(functools.partial(backenddist_to_funsor, funsor_dist_class))
```
By including the final line above in the distribution wrapper generator `funsor.distribution.make_dist`, users should in many cases no longer need to implement `to_funsor` for custom distributions.

I have also deleted a superfluous conversion pattern `funsor.distribution.mvndist_to_funsor` whose functionality is duplicated in an `eager` pattern.

Tested:
- Refactor exercised by existing tests