### PR TITLE
Support conjugacy for beta plate binomial

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -600,13 +600,11 @@ def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_plate_multinomial(op, x, reduced_vars):
-    assert reduced_vars.isdisjoint(x.probs.inputs)
-    # FIXME: it seems that funsor only allows x.value.reduce(ops.add, reduced_vars)
-    # when the following condition holds
+    if not reduced_vars.isdisjoint(x.probs.inputs):
+        return None
     if not reduced_vars.issubset(x.value.inputs):
         return None
-    # FIXME: is it necessary to create plates here?: we can use `reduced_vars` in `x.value.reduce`
-    plates = frozenset(Variable(v, x.inputs[v]) for v in reduced_vars)
+
     backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
     total_count = x.total_count
     for v in reduced_vars:
@@ -616,7 +614,7 @@ def eager_plate_multinomial(op, x, reduced_vars):
             total_count = total_count * x.inputs[v].size
     return backend_dist.Multinomial(total_count=total_count,
                                     probs=x.probs,
-                                    value=x.value.reduce(ops.add, plates))
+                                    value=x.value.reduce(ops.add, reduced_vars))
 
 
 def _log_beta(x, y):

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -597,6 +597,22 @@ def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
         return eager(Contraction, red_op, bin_op, reduced_vars, (x, y))
 
 
+def eager_plate_multinomial(op, x, reduced_vars):
+    import pdb; pdb.set_trace()
+    assert reduced_vars.isdisjoint(x.probs.inputs)
+    plates = frozenset(Variable(v, x.inputs[v]) for v in reduced_vars)
+    backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
+    total_count = x.total_count
+    for v in reduced_vars:
+        if v in total_count.inputs:
+            total_count = total_count.reduce(ops.add, v)
+        else:
+            total_count = total_count * x.inputs[v].size
+    return backend_dist.Multinomial(total_count=total_count,
+                                    probs=x.probs,
+                                    value=x.value.reduce(ops.add, plates))
+
+
 def _log_beta(x, y):
     return ops.lgamma(x) + ops.lgamma(y) - ops.lgamma(x + y)
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -589,7 +589,6 @@ def eager_dirichlet_categorical(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    print("aaaaaaaaaaaaaaa")
     dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
     if dirichlet_reduction:
         backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -589,6 +589,7 @@ def eager_dirichlet_categorical(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
+    print("aaaaaaaaaaaaaaa")
     dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
     if dirichlet_reduction:
         backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -601,6 +601,11 @@ def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
 
 def eager_plate_multinomial(op, x, reduced_vars):
     assert reduced_vars.isdisjoint(x.probs.inputs)
+    # FIXME: it seems that funsor only allows x.value.reduce(ops.add, reduced_vars)
+    # when the following condition holds
+    if not reduced_vars.issubset(x.value.inputs):
+        return None
+    # FIXME: is it necessary to create plates here?: we can use `reduced_vars` in `x.value.reduce`
     plates = frozenset(Variable(v, x.inputs[v]) for v in reduced_vars)
     backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
     total_count = x.total_count

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -598,7 +598,6 @@ def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_plate_multinomial(op, x, reduced_vars):
-    import pdb; pdb.set_trace()
     assert reduced_vars.isdisjoint(x.probs.inputs)
     plates = frozenset(Variable(v, x.inputs[v]) for v in reduced_vars)
     backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -287,9 +287,7 @@ eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisso
 if hasattr(dist, "DirichletMultinomial"):
     eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
         eager_dirichlet_posterior)
-# FIXME: to enable `Multinomial[Tensor, Funsor, Funsor]`, it seems that we need some mechanism
-# to lazily reduce 'plate' for a Variable `value`
-eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Funsor, Tensor], frozenset)(  # noqa: F821
+eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Funsor, Funsor], frozenset)(  # noqa: F821
     eager_plate_multinomial)
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES if _get_numpyro_dist(x[0]) is not None)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -29,6 +29,7 @@ from funsor.distribution import (  # noqa: F401
     eager_multinomial,
     eager_mvn,
     eager_normal,
+    eager_plate_multinomial,
     indepdist_to_funsor,
     make_dist,
     maskeddist_to_funsor,
@@ -36,8 +37,8 @@ from funsor.distribution import (  # noqa: F401
 )
 from funsor.domains import Real, Reals
 import funsor.ops as ops
-from funsor.tensor import Tensor, dummy_numeric_array
-from funsor.terms import Binary, Funsor, Variable, eager, to_funsor
+from funsor.tensor import Function, Tensor, dummy_numeric_array
+from funsor.terms import Binary, Funsor, Reduce, Variable, eager, to_funsor
 from funsor.util import methodof
 
 
@@ -228,6 +229,7 @@ eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisso
 if hasattr(dist, "DirichletMultinomial"):
     eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
         eager_dirichlet_posterior)
-
+eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Function, Funsor], frozenset)(  # noqa: F821
+    eager_plate_multinomial)
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES if _get_numpyro_dist(x[0]) is not None)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -37,7 +37,7 @@ from funsor.distribution import (  # noqa: F401
 )
 from funsor.domains import Real, Reals
 import funsor.ops as ops
-from funsor.tensor import Function, Tensor, dummy_numeric_array
+from funsor.tensor import Tensor, dummy_numeric_array
 from funsor.terms import Binary, Funsor, Reduce, Variable, eager, to_data, to_funsor
 from funsor.util import methodof
 
@@ -287,7 +287,9 @@ eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisso
 if hasattr(dist, "DirichletMultinomial"):
     eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
         eager_dirichlet_posterior)
-eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Function, Funsor], frozenset)(  # noqa: F821
+# FIXME: to enable `Multinomial[Tensor, Funsor, Funsor]`, it seems that we need some mechanism
+# to lazily reduce 'plate' for a Variable `value`
+eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Funsor, Tensor], frozenset)(  # noqa: F821
     eager_plate_multinomial)
 
 __all__ = list(x[0] for x in FUNSOR_DIST_NAMES if _get_numpyro_dist(x[0]) is not None)

--- a/funsor/memoize.py
+++ b/funsor/memoize.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import Hashable
+from collections.abc import Hashable
 from contextlib import contextmanager
 
 import funsor.interpreter as interpreter

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -7,7 +7,8 @@ import math
 import numbers
 import typing
 import warnings
-from collections import Hashable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Hashable
 from functools import reduce, singledispatch
 from weakref import WeakValueDictionary
 

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -41,7 +41,7 @@ from funsor.distribution import (  # noqa: F401
 )
 from funsor.domains import Real, Reals
 import funsor.ops as ops
-from funsor.tensor import Function, Tensor, dummy_numeric_array
+from funsor.tensor import Tensor, dummy_numeric_array
 from funsor.terms import Binary, Funsor, Reduce, Variable, eager, to_data, to_funsor
 from funsor.util import methodof
 
@@ -276,5 +276,5 @@ eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisso
     eager_gamma_poisson)
 eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
     eager_dirichlet_posterior)
-eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Function, Funsor], frozenset)(  # noqa: F821
+eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Funsor, Funsor], frozenset)(  # noqa: F821
     eager_plate_multinomial)

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -33,6 +33,7 @@ from funsor.distribution import (  # noqa: F401
     eager_multinomial,
     eager_mvn,
     eager_normal,
+    eager_plate_multinomial,
     indepdist_to_funsor,
     make_dist,
     maskeddist_to_funsor,
@@ -40,8 +41,8 @@ from funsor.distribution import (  # noqa: F401
 )
 from funsor.domains import Real, Reals
 import funsor.ops as ops
-from funsor.tensor import Tensor, dummy_numeric_array
-from funsor.terms import Binary, Funsor, Variable, eager, to_data, to_funsor
+from funsor.tensor import Function, Tensor, dummy_numeric_array
+from funsor.terms import Binary, Funsor, Reduce, Variable, eager, to_data, to_funsor
 from funsor.util import methodof
 
 
@@ -275,3 +276,5 @@ eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisso
     eager_gamma_poisson)
 eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
     eager_dirichlet_posterior)
+eager.register(Reduce, ops.AddOp, Multinomial[Tensor, Function, Funsor], frozenset)(  # noqa: F821
+    eager_plate_multinomial)

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1058,12 +1058,6 @@ def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
     reduced = p.reduce(ops.logaddexp, 'prior')
     assert isinstance(reduced, Tensor)
 
-    conditional = dist.Multinomial(probs=prior, total_count=total_count)
-    p = latent + conditional.reduce(ops.add, 'plate')
-    reduced_term = p.reduce(ops.logaddexp, 'prior')
-    # FIXME: this does not work
-    assert_close(reduced_term(value=obs), reduced)
-
     _assert_conjugate_density_ok(latent, conditional, obs)
 
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1057,11 +1057,14 @@ def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
     p = latent + conditional.reduce(ops.add, 'plate')
     reduced = p.reduce(ops.logaddexp, set(["prior"]))
     assert isinstance(reduced, Tensor)
-    # assert_close(reduced.concentration, concentration)
-    # assert_close(reduced.total_count, total_count)
-    # result = (p - reduced)(value=obs)
-    # assert isinstance(result, dist.Dirichlet)
-    # assert_close(result.concentration, concentration + obs)
+
+    # TODO: make this work, need to lazily reduce 'plate' dim of conditional.value
+    conditional = dist.Multinomial(probs=prior, total_count=total_count)
+    p = latent + conditional.reduce(ops.add, 'plate')
+    reduced = p.reduce(ops.logaddexp, set(["prior"]))
+    assert isinstance(reduced, dist.DirichletMultinomial)
+    assert_close(reduced.concentration, concentration)
+    assert_close(reduced.total_count, total_count.reduce(ops.add, 'plate'))
 
     _assert_conjugate_density_ok(latent, conditional, obs)
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1055,16 +1055,14 @@ def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
     latent = dist.Dirichlet(concentration, value=prior)
     conditional = dist.Multinomial(probs=prior, total_count=total_count, value=obs)
     p = latent + conditional.reduce(ops.add, 'plate')
-    reduced = p.reduce(ops.logaddexp, set(["prior"]))
+    reduced = p.reduce(ops.logaddexp, 'prior')
     assert isinstance(reduced, Tensor)
 
-    # TODO: make this work, need to lazily reduce 'plate' dim of conditional.value
     conditional = dist.Multinomial(probs=prior, total_count=total_count)
     p = latent + conditional.reduce(ops.add, 'plate')
-    reduced = p.reduce(ops.logaddexp, set(["prior"]))
-    assert isinstance(reduced, dist.DirichletMultinomial)
-    assert_close(reduced.concentration, concentration)
-    assert_close(reduced.total_count, total_count.reduce(ops.add, 'plate'))
+    reduced_term = p.reduce(ops.logaddexp, 'prior')
+    # FIXME: this does not work
+    assert_close(reduced_term(value=obs), reduced)
 
     _assert_conjugate_density_ok(latent, conditional, obs)
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1047,6 +1047,37 @@ def test_dirichlet_categorical_conjugate(batch_shape, size):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('size', [2, 4, 5], ids=str)
+def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
+    max_count = 10
+    batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
+    inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
+    full_shape = batch_shape + (size,)
+    prior = Variable("prior", Reals[size])
+    concentration = Tensor(ops.exp(randn(full_shape)), inputs)
+    value_data = ops.astype(randint(0, max_count, size=batch_shape + (7, size)), 'float32')
+    obs_inputs = inputs.copy()
+    obs_inputs['plate'] = Bint[7]
+    obs = Tensor(value_data, obs_inputs)
+    total_count_data = value_data.sum(-1)
+    total_count = Tensor(total_count_data, obs_inputs)
+    latent = dist.Dirichlet(concentration, value=prior)
+    conditional = dist.Multinomial(probs=prior, total_count=total_count, value=obs)
+    p = latent + conditional.reduce(ops.add, 'plate')
+    # marginalized = p.reduce(ops.logaddexp, set(["value"]))
+    # assert isinstance(marginalized, dist.Dirichlet)
+    reduced = p.reduce(ops.logaddexp, set(["prior"]))
+    assert isinstance(reduced, Tensor)
+    # assert_close(reduced.concentration, concentration)
+    # assert_close(reduced.total_count, total_count)
+    # result = (p - reduced)(value=obs)
+    # assert isinstance(result, dist.Dirichlet)
+    # assert_close(result.concentration, concentration + obs)
+
+    _assert_conjugate_density_ok(latent, conditional, obs)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
+@pytest.mark.parametrize('size', [2, 4, 5], ids=str)
 def test_dirichlet_multinomial_conjugate(batch_shape, size):
     max_count = 10
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1055,8 +1055,6 @@ def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
     latent = dist.Dirichlet(concentration, value=prior)
     conditional = dist.Multinomial(probs=prior, total_count=total_count, value=obs)
     p = latent + conditional.reduce(ops.add, 'plate')
-    # marginalized = p.reduce(ops.logaddexp, set(["value"]))
-    # assert isinstance(marginalized, dist.Dirichlet)
     reduced = p.reduce(ops.logaddexp, set(["prior"]))
     assert isinstance(reduced, Tensor)
     # assert_close(reduced.concentration, concentration)


### PR DESCRIPTION
Pair code with @fritzo and @eb8680.

Current issue:
- ~[ ] We need to address `expand` logic under `plate` handler somewhere: either funsor or pyro/numpyro. The latter is prefered, according to the discussion.~ it seems that no need to do so. We can just simply skip `plate` handler processes a Funsor `msg["fn"]`.

TODO
- [x] Lazily reduce `plate` dim for `conditional.value`.

Currently, there is several FIXME because we want to support the case `Multinomial.value` is a Funsor.
