### PR TITLE
Add support for most remaining atomic distributions

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -391,10 +391,9 @@ class CoerceDistributionToFunsor:
 
 @to_data.register(Distribution)
 def distribution_to_data(funsor_dist, name_to_dim=None):
-    pyro_dist_class = funsor_dist.dist_class
     params = [to_data(getattr(funsor_dist, param_name), name_to_dim=name_to_dim)
               for param_name in funsor_dist._ast_fields if param_name != 'value']
-    pyro_dist = pyro_dist_class(**dict(zip(funsor_dist._ast_fields[:-1], params)))
+    pyro_dist = funsor_dist.dist_class(**dict(zip(funsor_dist._ast_fields[:-1], params)))
     funsor_event_shape = funsor_dist.value.output.shape
     pyro_dist = pyro_dist.to_event(max(len(funsor_event_shape) - len(pyro_dist.event_shape), 0))
     if pyro_dist.event_shape != funsor_event_shape:

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -277,8 +277,6 @@ FUNSOR_DIST_NAMES = [
     ('NonreparameterizedGamma', ('concentration', 'rate')),
     ('NonreparameterizedNormal', ('loc', 'scale')),
     ('Normal', ('loc', 'scale')),
-    ('Poisson', ('rate',)),
-    ('VonMises', ('loc', 'concentration')),
 ]
 
 

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -54,6 +54,10 @@ class _NumPyroWrapper_Categorical(dist.CategoricalProbs):
     pass
 
 
+class _NumPyroWrapper_Geometric(dist.GeometricProbs):
+    pass
+
+
 class _NumPyroWrapper_Multinomial(dist.MultinomialProbs):
     pass
 
@@ -75,7 +79,8 @@ class _NumPyroWrapper_NonreparameterizedNormal(dist.Normal):
 
 
 def _get_numpyro_dist(dist_name):
-    if dist_name in ['Binomial', 'Categorical', 'Multinomial'] or dist_name.startswith('Nonreparameterized'):
+    if dist_name in ['Binomial', 'Categorical', 'Geometric', 'Multinomial'] or \
+            dist_name.startswith('Nonreparameterized'):
         return globals().get('_NumPyroWrapper_' + dist_name)
     else:
         return getattr(dist, dist_name, None)
@@ -87,7 +92,7 @@ NUMPYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
     ("ContinuousBernoulli", ("logits",)),
     ("Exponential", ()),
     ("FisherSnedecor", ()),
-    # ("Geometric", ("probs",)),  # TODO resolve probs/logits
+    ("Geometric", ("probs",)),
     ("Gumbel", ()),
     ("HalfCauchy", ()),
     ("HalfNormal", ()),
@@ -226,6 +231,12 @@ def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
 def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _NumPyroWrapper_Categorical(probs=numpyro_dist.probs)
     return backenddist_to_funsor(Categorical, new_pyro_dist, output, dim_to_name)  # noqa: F821
+
+
+@to_funsor.register(dist.GeometricProbs)
+def categorical_to_funsor(numpyro_dist, output=None, dim_to_name=None):
+    new_pyro_dist = _NumPyroWrapper_Geometric(probs=numpyro_dist.probs)
+    return backenddist_to_funsor(Geometric, new_pyro_dist, output, dim_to_name)  # noqa: F821
 
 
 @to_funsor.register(dist.MultinomialProbs)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -81,7 +81,24 @@ def _get_numpyro_dist(dist_name):
         return getattr(dist, dist_name, None)
 
 
-NUMPYRO_DIST_NAMES = FUNSOR_DIST_NAMES
+NUMPYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
+    ("Cauchy", ()),
+    ("Chi2", ()),
+    ("ContinuousBernoulli", ("logits",)),
+    ("Exponential", ()),
+    ("FisherSnedecor", ()),
+    # ("Geometric", ("probs",)),  # TODO resolve probs/logits
+    ("Gumbel", ()),
+    ("HalfCauchy", ()),
+    ("HalfNormal", ()),
+    ("Laplace", ()),
+    ("LowRankMultivariateNormal", ()),
+    ("Pareto", ()),
+    ("Poisson", ()),
+    ("StudentT", ()),
+    ("Uniform", ()),
+    ("VonMises", ()),
+]
 _HAS_RSAMPLE_DISTS = ['Beta', 'Dirichlet', 'Gamma', 'Normal', 'MultivariateNormal']
 
 
@@ -160,6 +177,20 @@ if hasattr(dist, "DirichletMultinomial"):
             return Reals[raw_shape[-1]]
         assert name == "total_count"
         return Real
+
+
+# TODO fix LowRankMultivariateNormal.arg_constraints upstream
+@methodof(LowRankMultivariateNormal)  # noqa: F821
+@classmethod
+@functools.lru_cache(maxsize=5000)
+def _infer_param_domain(cls, name, raw_shape):
+    if name == "loc":
+        return Reals[raw_shape[-1]]
+    elif name == "cov_factor":
+        return Reals[raw_shape[-2:]]
+    elif name == "cov_diag":
+        return Reals[raw_shape[-1]]
+    raise ValueError(f"{name} invalid param for {cls}")
 
 
 ###############################################

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -33,6 +33,15 @@ def xfail_if_not_implemented(msg="Not implemented"):
         pytest.xfail(reason='{}:\n{}'.format(msg, e))
 
 
+@contextlib.contextmanager
+def xfail_if_not_found(msg="Not implemented"):
+    try:
+        yield
+    except AttributeError as e:
+        import pytest
+        pytest.xfail(reason='{}:\n{}'.format(msg, e))
+
+
 class ActualExpected(namedtuple('LazyComparison', ['actual', 'expected'])):
     """
     Lazy string formatter for test assertions.

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -213,6 +213,14 @@ def multinomial_to_data(funsor_dist, name_to_dim=None):
     raise NotImplementedError("inhomogeneous total_count not supported")
 
 
+# Convert Delta **distribution** to raw data
+@to_data.register(Delta)  # noqa: F821
+def deltadist_to_data(funsor_dist, name_to_dim=None):
+    v = to_data(funsor_dist.v, name_to_dim=name_to_dim)
+    log_density = to_data(funsor_dist.log_density, name_to_dim=name_to_dim)
+    return dist.Delta(v, log_density, event_dim=len(funsor_dist.v.output.shape))
+
+
 ###############################################
 # Converting PyTorch Distributions to funsors
 ###############################################
@@ -226,6 +234,13 @@ to_funsor.register(torch.distributions.TransformedDistribution)(transformeddist_
 def bernoulli_to_funsor(pyro_dist, output=None, dim_to_name=None):
     new_pyro_dist = _PyroWrapper_BernoulliLogits(logits=pyro_dist.logits)
     return backenddist_to_funsor(BernoulliLogits, new_pyro_dist, output, dim_to_name)  # noqa: F821
+
+
+@to_funsor.register(dist.Delta)  # Delta **distribution**
+def deltadist_to_funsor(pyro_dist, output=None, dim_to_name=None):
+    v = to_funsor(pyro_dist.v, output=Reals[pyro_dist.event_shape], dim_to_name=dim_to_name)
+    log_density = to_funsor(pyro_dist.log_density, output=Real, dim_to_name=dim_to_name)
+    return Delta(v, log_density)  # noqa: F821
 
 
 JointDirichletMultinomial = Contraction[

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -115,6 +115,27 @@ for batch_shape in [(), (5,), (2, 3)]:
             funsor.Bint[size],
         )
 
+    # Cauchy
+    DistTestCase(
+        "backend_dist.Cauchy(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
+    # Chi2
+    DistTestCase(
+        "backend_dist.Chi2(df=case.df)",
+        (("df", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
+    # ContinuousBernoulli
+    DistTestCase(
+        "backend_dist.ContinuousBernoulli(logits=case.logits)",
+        (("logits", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
     # TODO figure out what this should be...
     # # Delta
     # for event_shape in [(),]:  # (4,), (3, 2)]:
@@ -146,6 +167,20 @@ for batch_shape in [(), (5,), (2, 3)]:
             funsor.Reals[event_shape],
         )
 
+    # Exponential
+    DistTestCase(
+        "backend_dist.Exponential(rate=case.rate)",
+        (("rate", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
+    # FisherSnedecor
+    DistTestCase(
+        "backend_dist.FisherSnedecor(df1=case.df1, df2=case.df2)",
+        (("df1", f"rand({batch_shape})"), ("df2", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
     # Gamma
     DistTestCase(
         "backend_dist.Gamma(case.concentration, case.rate)",
@@ -158,6 +193,51 @@ for batch_shape in [(), (5,), (2, 3)]:
         (("concentration", f"rand({batch_shape})"), ("rate", f"rand({batch_shape})")),
         funsor.Real,
     )
+
+    # Geometric
+    DistTestCase(
+        "backend_dist.Geometric(probs=case.probs)",
+        (("probs", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
+    # Gumbel
+    DistTestCase(
+        "backend_dist.Gumbel(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
+    # HalfCauchy
+    DistTestCase(
+        "backend_dist.HalfCauchy(scale=case.scale)",
+        (("scale", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
+    # HalfNormal
+    DistTestCase(
+        "backend_dist.HalfNormal(scale=case.scale)",
+        (("scale", f"rand({batch_shape})"),),
+        funsor.Real,
+    )
+
+    # Laplace
+    DistTestCase(
+        "backend_dist.Laplace(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
+    # LowRankMultivariateNormal
+    for event_shape in [(3,), (4,)]:
+        DistTestCase(
+            "backend_dist.LowRankMultivariateNormal(loc=case.loc, cov_factor=case.cov_factor, cov_diag=case.cov_diag)",
+            (("loc", f"randn({batch_shape + event_shape})"),
+             ("cov_factor", f"randn({batch_shape + event_shape + (2,)})"),
+             ("cov_diag", f"rand({batch_shape + event_shape})")),
+            funsor.Reals[event_shape],
+        )
 
     # Multinomial
     for event_shape in [(1,), (4,)]:
@@ -176,6 +256,13 @@ for batch_shape in [(), (5,), (2, 3)]:
             funsor.Reals[event_shape],
         )
 
+    # NegativeBinomial
+    DistTestCase(
+        "backend_dist.NegativeBinomial(total_count=case.total_count, probs=case.probs)",
+        (("total_count", "randint(10, 12, ())" if get_backend() == "jax" else "5"), ("probs", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
     # Normal
     DistTestCase(
         "backend_dist.Normal(case.loc, case.scale)",
@@ -189,6 +276,21 @@ for batch_shape in [(), (5,), (2, 3)]:
         funsor.Real,
     )
 
+    # OneHotCategorical
+    for size in [2, 4]:
+        DistTestCase(
+            "backend_dist.OneHotCategorical(probs=case.probs)",
+            (("probs", f"rand({batch_shape + (size,)})"),),
+            funsor.Reals[size],  # funsor.Bint[size],
+        )
+
+    # Pareto
+    DistTestCase(
+        "backend_dist.Pareto(scale=case.scale, alpha=case.alpha)",
+        (("scale", f"rand({batch_shape})"), ("alpha", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
     # Poisson
     DistTestCase(
         "backend_dist.Poisson(rate=case.rate)",
@@ -196,11 +298,40 @@ for batch_shape in [(), (5,), (2, 3)]:
         funsor.Real,
     )
 
+    # TODO implement RelaxedBernoulli._infer_param_domain for temperature
+    # RelaxedBernoulli
+    DistTestCase(
+        "backend_dist.RelaxedBernoulli(temperature=case.temperature, logits=case.logits)",
+        (("temperature", f"rand({batch_shape})"), ("logits", f"rand({batch_shape})")),
+        funsor.Real,
+    )
+
+    # StudentT
+    DistTestCase(
+        "backend_dist.StudentT(df=case.df, loc=case.loc, scale=case.scale)",
+        (("df", f"rand({batch_shape})"), ("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        funsor.Real
+    )
+
+    # Uniform
+    DistTestCase(
+        "backend_dist.Uniform(low=case.low, high=case.high)",
+        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        funsor.Real
+    )
+
     # VonMises
     DistTestCase(
         "backend_dist.VonMises(case.loc, case.concentration)",
         (("loc", f"rand({batch_shape})"), ("concentration", f"rand({batch_shape})")),
         funsor.Real,
+    )
+
+    # Weibull
+    DistTestCase(
+        "backend_dist.Weibull(scale=case.scale, concentration=case.concentration)",
+        (("scale", f"rand({batch_shape})"), ("concentration", f"rand({batch_shape})")),
+        funsor.Real
     )
 
 

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -137,13 +137,13 @@ for batch_shape in [(), (5,), (2, 3)]:
     )
 
     # TODO figure out what this should be...
-    # # Delta
-    # for event_shape in [(),]:  # (4,), (3, 2)]:
-    #     TEST_CASES += [DistTestCase(
-    #         "backend_dist.Delta(case.v, case.log_density)",
-    #         (("v", f"rand({batch_shape + event_shape})"), ("log_density", f"rand({batch_shape})")),
-    #         funsor.Real,  # s[event_shape],
-    #     )]
+    # Delta
+    for event_shape in [(), (4,), (3, 2)]:
+        DistTestCase(
+            f"backend_dist.Delta(v=case.v, log_density=case.log_density, event_dim={len(event_shape)})",
+            (("v", f"rand({batch_shape + event_shape})"), ("log_density", f"rand({batch_shape})")),
+            funsor.Reals[event_shape],
+        )
 
     # Dirichlet
     for event_shape in [(1,), (4,)]:

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -13,7 +13,7 @@ import funsor.ops as ops
 from funsor.distribution import BACKEND_TO_DISTRIBUTIONS_BACKEND
 from funsor.interpreter import interpretation
 from funsor.terms import lazy, to_data, to_funsor
-from funsor.testing import assert_close, check_funsor, rand, randint, randn, random_scale_tril, xfail_if_not_implemented  # noqa: F401,E501
+from funsor.testing import assert_close, check_funsor, rand, randint, randn, random_scale_tril, xfail_if_not_found, xfail_if_not_implemented  # noqa: F401,E501
 from funsor.util import get_backend
 
 
@@ -354,7 +354,8 @@ def _default_dim_to_name(inputs_shape, event_inputs=None):
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
 def test_generic_distribution_to_funsor(case):
 
-    raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
+    with xfail_if_not_found():
+        raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(lazy):
@@ -374,7 +375,8 @@ def test_generic_distribution_to_funsor(case):
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
 def test_generic_log_prob(case):
 
-    raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
+    with xfail_if_not_found():
+        raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     funsor_dist = to_funsor(raw_dist, output=funsor.Real, dim_to_name=dim_to_name)
@@ -396,7 +398,8 @@ def test_generic_log_prob(case):
 @pytest.mark.parametrize("expand", [False, True])
 def test_generic_enumerate_support(case, expand):
 
-    raw_dist = eval(case.raw_dist)
+    with xfail_if_not_found():
+        raw_dist = eval(case.raw_dist)
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(lazy):
@@ -415,7 +418,8 @@ def test_generic_enumerate_support(case, expand):
 @pytest.mark.parametrize("sample_shape", [(), (2,), (4, 3)], ids=str)
 def test_generic_sample(case, sample_shape):
 
-    raw_dist = eval(case.raw_dist)
+    with xfail_if_not_found():
+        raw_dist = eval(case.raw_dist)
 
     dim_to_name, name_to_dim = _default_dim_to_name(sample_shape + raw_dist.batch_shape)
     with interpretation(lazy):
@@ -438,7 +442,8 @@ def test_generic_sample(case, sample_shape):
 ])
 def test_generic_stats(case, statistic):
 
-    raw_dist = eval(case.raw_dist)
+    with xfail_if_not_found():
+        raw_dist = eval(case.raw_dist)
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(lazy):


### PR DESCRIPTION
Addresses #386. ~~Blocked by #389.~~

This PR adds Funsor wrappers for most of the remaining atomic distributions in `torch.distributions` and `numpyro.distributions`, and test cases in `test_distribution_generic.py`.  I have also added a small helper `xfail_if_not_found` to make writing tests for multiple backends a bit easier.

Tested:
- All new distributions tested via the test infrastructure added in #389