### PR TITLE
Support converting funsor.terms.Independent to and from data

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -406,6 +406,8 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
 
 @to_data.register(Independent[typing.Union[Independent, Distribution], str, str, str])
 def indep_to_data(funsor_dist, name_to_dim=None):
+    if not isinstance(funsor_dist.fn, (Independent, Distribution, Gaussian)):
+        raise NotImplementedError(f"cannot convert {funsor_dist} to data")
     name_to_dim = OrderedDict((name, dim - 1) for name, dim in name_to_dim.items())
     name_to_dim.update({funsor_dist.bint_var: -1})
     backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()]).dist

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -406,7 +406,18 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
 
 @to_data.register(Independent[typing.Union[Independent, Distribution], str, str, str])
 def indep_to_data(funsor_dist, name_to_dim=None):
-    raise NotImplementedError("TODO implement conversion of Independent")
+    name_to_dim = OrderedDict((name, dim - 1) for name, dim in name_to_dim.items())
+    name_to_dim.update({funsor_dist.bint_var: -1})
+    backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()]).dist
+    result = to_data(funsor_dist.fn, name_to_dim=name_to_dim)
+
+    # collapse nested Independents into a single Independent for conversion
+    reinterpreted_batch_ndims = 1
+    while isinstance(result, backend_dist.Independent):
+        result = result.base_dist
+        reinterpreted_batch_ndims += 1
+
+    return backend_dist.Independent(result, reinterpreted_batch_ndims)
 
 
 @to_data.register(Gaussian)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1543,6 +1543,15 @@ class Independent(Funsor):
         result = result.reduce(ops.add, self.bint_var)
         return result
 
+    def mean(self):
+        raise NotImplementedError("mean() not yet implemented for Independent")
+
+    def variance(self):
+        raise NotImplementedError("variance() not yet implemented for Independent")
+
+    def entropy(self):
+        raise NotImplementedError("entropy() not yet implemented for Independent")
+
 
 @eager.register(Independent, Funsor, str, str, str)
 def eager_independent_trivial(fn, reals_var, bint_var, diag_var):

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -203,13 +203,22 @@ for batch_shape in [(), (5,), (2, 3)]:
         funsor.Real,
     )
 
-    # Normal.to_event
-    for event_shape in [(2,), (3,), (2, 3)]:
+    # Independent
+    for indep_shape in [(3,), (2, 3)]:
+        # Beta.to_event
         DistTestCase(
-            f"backend_dist.Normal(case.loc, case.scale).to_event({len(event_shape)})",
-            (("loc", f"randn({batch_shape + event_shape})"), ("scale", f"rand({batch_shape + event_shape})")),
-            funsor.Reals[event_shape],
+            f"backend_dist.Beta(case.concentration1, case.concentration0).to_event({len(indep_shape)})",
+            (("concentration1", f"ops.exp(randn({batch_shape + indep_shape}))"),
+             ("concentration0", f"ops.exp(randn({batch_shape + indep_shape}))")),
+            funsor.Reals[indep_shape],
         )
+        # Dirichlet.to_event
+        for event_shape in [(2,), (4,)]:
+            DistTestCase(
+                f"backend_dist.Dirichlet(case.concentration).to_event({len(indep_shape)})",
+                (("concentration", f"rand({batch_shape + indep_shape + event_shape})"),),
+                funsor.Reals[indep_shape + event_shape],
+            )
 
 
 ###########################

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -280,7 +280,7 @@ def test_generic_log_prob(case):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4)
+    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=5e-4)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -203,6 +203,14 @@ for batch_shape in [(), (5,), (2, 3)]:
         funsor.Real,
     )
 
+    # Normal.to_event
+    for event_shape in [(2,), (3,), (2, 3)]:
+        DistTestCase(
+            f"backend_dist.Normal(case.loc, case.scale).to_event({len(event_shape)})",
+            (("loc", f"randn({batch_shape + event_shape})"), ("scale", f"rand({batch_shape + event_shape})")),
+            funsor.Reals[event_shape],
+        )
+
 
 ###########################
 # Generic tests:
@@ -233,9 +241,7 @@ def test_generic_distribution_to_funsor(case):
     assert isinstance(actual_dist, backend_dist.Distribution)
     assert issubclass(type(actual_dist), type(raw_dist))  # subclass to handle wrappers
     assert funsor_dist.inputs["value"] == expected_value_domain
-    for param_name in funsor_dist.params.keys():
-        if param_name == "value":
-            continue
+    for param_name, _ in case.raw_params:
         assert hasattr(raw_dist, param_name)
         assert_close(getattr(actual_dist, param_name), getattr(raw_dist, param_name))
 

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -381,7 +381,7 @@ def test_generic_distribution_to_funsor(case):
 
     assert isinstance(actual_dist, backend_dist.Distribution)
     assert issubclass(type(actual_dist), type(raw_dist))  # subclass to handle wrappers
-    while isinstance(raw_dist, (backend_dist.Independent, backend_dist.TransformedDistribution)):
+    while isinstance(raw_dist, backend_dist.Independent):
         raw_dist = raw_dist.base_dist
         actual_dist = actual_dist.base_dist
         assert isinstance(actual_dist, backend_dist.Distribution)


### PR DESCRIPTION
Addresses #386 

This PR implements a generic `to_data` pattern for `funsor.terms.Independent`, allowing the conversion of `{numpyro,torch}.distributions.Independent`-wrapped distributions to and from Funsor terms.

Tested:
- `sample`, `log_prob` and conversion tested using the infrastructure from #389 