### PR TITLE
Allow .reduce(op, vars_not_in_inputs)

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -198,14 +198,15 @@ def eager_contraction_generic_recursive(red_op, bin_op, reduced_vars, terms):
     terms = list(terms)
     leaf_reduced = False
     reduced_once = frozenset(v for v, count in counts.items() if count == 1)
-    for i, term in enumerate(terms):
-        unique_vars = reduced_once & term.input_vars
-        if unique_vars:
-            result = term.reduce(red_op, unique_vars)
-            if result is not normalize(Contraction, red_op, nullop, unique_vars, (term,)):
-                terms[i] = result
-                reduced_vars -= unique_vars
-                leaf_reduced = True
+    if reduced_once:
+        for i, term in enumerate(terms):
+            unique_vars = reduced_once & term.input_vars
+            if unique_vars:
+                result = term.reduce(red_op, unique_vars)
+                if result is not normalize(Contraction, red_op, nullop, unique_vars, (term,)):
+                    terms[i] = result
+                    reduced_vars -= unique_vars
+                    leaf_reduced = True
     if leaf_reduced:
         return Contraction(red_op, bin_op, reduced_vars, *terms)
 

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -236,7 +236,7 @@ def eager_contraction_to_reduce(red_op, bin_op, reduced_vars, term):
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Funsor, Funsor)
 def eager_contraction_to_binary(red_op, bin_op, reduced_vars, lhs, rhs):
 
-    if reduced_vars - (reduced_vars.intersection(lhs.input_vars, rhs.input_vars)):
+    if not reduced_vars.issubset(lhs.input_vars & rhs.input_vars):
         args = red_op, bin_op, reduced_vars, (lhs, rhs)
         result = eager.dispatch(Contraction, *args)(*args)
         if result is not None:

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -50,7 +50,7 @@ class Contraction(Funsor):
         assert isinstance(bin_op, AssociativeOp)
         assert all(isinstance(v, Funsor) for v in terms)
         assert isinstance(reduced_vars, frozenset)
-        assert all(isinstance(v, str) for v in reduced_vars)
+        assert all(isinstance(v, Variable) for v in reduced_vars)
         assert isinstance(terms, tuple) and len(terms) > 0
 
         assert not (isinstance(red_op, NullOp) and isinstance(bin_op, NullOp))
@@ -62,17 +62,17 @@ class Contraction(Funsor):
             assert reduced_vars and len(terms) > 1
             assert (red_op, bin_op) in DISTRIBUTIVE_OPS
 
+        fresh = frozenset()
+        bound = {v.name: v.output for v in reduced_vars}
         inputs = OrderedDict()
         for v in terms:
-            inputs.update((k, d) for k, d in v.inputs.items() if k not in reduced_vars)
+            inputs.update((k, d) for k, d in v.inputs.items() if k not in bound)
 
         if bin_op is nullop:
             output = terms[0].output
         else:
             output = reduce(lambda lhs, rhs: find_domain(bin_op, lhs, rhs),
                             [v.output for v in reversed(terms)])
-        fresh = frozenset()
-        bound = reduced_vars
         super(Contraction, self).__init__(inputs, output, fresh, bound)
         self.red_op = red_op
         self.bin_op = bin_op
@@ -144,11 +144,9 @@ class Contraction(Funsor):
         return result
 
     def _alpha_convert(self, alpha_subs):
-        reduced_vars = frozenset(alpha_subs.get(k, k) for k in self.reduced_vars)
-        bound_types = {}
-        for term in self.terms:
-            bound_types.update({k: term.inputs[k] for k in self.bound.intersection(term.inputs)})
-        alpha_subs = {k: to_funsor(v, bound_types[k]) for k, v in alpha_subs.items()}
+        reduced_vars = frozenset(to_funsor(alpha_subs.get(var.name, var), var.output)
+                                 for var in self.reduced_vars)
+        alpha_subs = {k: to_funsor(v, self.bound[k]) for k, v in alpha_subs.items()}
         red_op, bin_op, _, terms = super()._alpha_convert(alpha_subs)
         return red_op, bin_op, reduced_vars, terms
 
@@ -185,8 +183,9 @@ def eager_contraction_generic_recursive(red_op, bin_op, reduced_vars, terms):
     # push down leaf reductions
     terms, reduced_vars, leaf_reduced = list(terms), frozenset(reduced_vars), False
     for i, v in enumerate(terms):
-        unique_vars = reduced_vars.intersection(v.inputs) - \
-            frozenset().union(*(reduced_vars.intersection(vv.inputs) for vv in terms if vv is not v))
+        unique_vars = reduced_vars.intersection(v.input_vars) - \
+            frozenset().union(*(reduced_vars.intersection(vv.input_vars)
+                                for vv in terms if vv is not v))
         if unique_vars:
             result = v.reduce(red_op, unique_vars)
             if result is not normalize(Contraction, red_op, nullop, unique_vars, (v,)):
@@ -203,8 +202,8 @@ def eager_contraction_generic_recursive(red_op, bin_op, reduced_vars, terms):
     for i, lhs in enumerate(terms[0:-1]):
         for j_, rhs in enumerate(terms[i+1:]):
             j = i + j_ + 1
-            unique_vars = reduced_vars.intersection(lhs.inputs, rhs.inputs) - \
-                frozenset().union(*(reduced_vars.intersection(vv.inputs)
+            unique_vars = reduced_vars.intersection(lhs.input_vars, rhs.input_vars) - \
+                frozenset().union(*(reduced_vars.intersection(vv.input_vars)
                                     for vv in terms[:i] + terms[i+1:j] + terms[j+1:]))
             result = Contraction(red_op, bin_op, unique_vars, lhs, rhs)
             if result is not normalize(Contraction, red_op, bin_op, unique_vars, (lhs, rhs)):  # did we make progress?
@@ -225,7 +224,7 @@ def eager_contraction_to_reduce(red_op, bin_op, reduced_vars, term):
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Funsor, Funsor)
 def eager_contraction_to_binary(red_op, bin_op, reduced_vars, lhs, rhs):
 
-    if reduced_vars - (reduced_vars.intersection(lhs.inputs, rhs.inputs)):
+    if reduced_vars - (reduced_vars.intersection(lhs.input_vars, rhs.input_vars)):
         args = red_op, bin_op, reduced_vars, (lhs, rhs)
         result = eager.dispatch(Contraction, *args)(*args)
         if result is not None:
@@ -277,8 +276,8 @@ def _eager_contract_tensors(reduced_vars, terms, backend):
         data = data.reshape(batch_shape + event_shape)
         operands.append(data)
 
-    for k in reduced_vars:
-        del inputs[k]
+    for var in reduced_vars:
+        inputs.pop(var.name, None)
     batch_shape = tuple(v.size for v in inputs.values())
     event_shape = broadcast_shape(*(term.shape for term in terms))
     einsum_output = ("".join(symbols[k] for k in inputs) +

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -137,26 +137,21 @@ class Delta(Funsor, metaclass=DeltaMeta):
         return Delta(tuple(new_terms.items())) + log_density if new_terms else log_density
 
     def eager_reduce(self, op, reduced_vars):
-        reduced_names = frozenset(v.name for v in reduced_vars)
-        assert reduced_names.issubset(self.inputs)
+        assert reduced_vars.issubset(self.inputs)
         if op is ops.logaddexp:
-            if reduced_names - self.fresh and self.fresh - reduced_names:
-                result = self
-                if reduced_names & self.fresh:
-                    result = result.eager_reduce(op, reduced_names & self.fresh)
-                    if result is not self:
-                        if reduced_names - self.fresh:
-                            result = result.eager_reduce(op, reduced_names - self.fresh)
-                            if result is not self:
-                                return result
+            if reduced_vars - self.fresh and self.fresh - reduced_vars:
+                result = self.eager_reduce(op, reduced_vars & self.fresh) if reduced_vars & self.fresh else self
+                if result is not self:
+                    result = result.eager_reduce(op, reduced_vars - self.fresh) if reduced_vars - self.fresh else self
+                    return result if result is not self else None
                 return None
 
             result_terms = [(name, (point, log_density)) for name, (point, log_density) in self.terms
-                            if name not in reduced_names]
+                            if name not in reduced_vars]
 
             result_terms, scale = [], Number(0)
             for name, (point, log_density) in self.terms:
-                if name in reduced_names:
+                if name in reduced_vars:
                     # XXX obscenely wasteful - need a lazy Zero term
                     if point.inputs:
                         scale += (point == point).all().log()
@@ -166,7 +161,7 @@ class Delta(Funsor, metaclass=DeltaMeta):
                     result_terms.append((name, (point, log_density)))
 
             result = Delta(tuple(result_terms)) + scale if result_terms else scale
-            return result.reduce(op, reduced_names - self.fresh)
+            return result.reduce(op, reduced_vars - self.fresh)
 
         if op is ops.add:
             raise NotImplementedError("TODO Implement ops.add to simulate .to_event().")

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -98,7 +98,7 @@ class Delta(Funsor, metaclass=DeltaMeta):
 
         output = Real
         fresh = frozenset(name for name, term in terms)
-        bound = frozenset()
+        bound = {}
         super(Delta, self).__init__(inputs, output, fresh, bound)
         self.terms = terms
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -120,7 +120,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
                                ', '.join('{}={}'.format(*kv) for kv in self.params.items()))
 
     def eager_reduce(self, op, reduced_vars):
-        if op is ops.logaddexp and isinstance(self.value, Variable) and self.value.name in reduced_vars:
+        if op is ops.logaddexp and isinstance(self.value, Variable) and self.value in reduced_vars:
             return Number(0.)  # distributions are normalized
         return super(Distribution, self).eager_reduce(op, reduced_vars)
 
@@ -686,7 +686,7 @@ def eager_beta_bernoulli(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_dirichlet_categorical(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
+    dirichlet_reduction = x.input_vars & reduced_vars
     if dirichlet_reduction:
         backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
         identity = Tensor(ops.new_eye(funsor.tensor.get_default_prototype(), x.concentration.shape))
@@ -698,7 +698,7 @@ def eager_dirichlet_categorical(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
-    dirichlet_reduction = frozenset(x.inputs).intersection(reduced_vars)
+    dirichlet_reduction = x.input_vars & reduced_vars
     if dirichlet_reduction:
         backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
         return backend_dist.DirichletMultinomial(concentration=x.concentration,
@@ -709,18 +709,18 @@ def eager_dirichlet_multinomial(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_plate_multinomial(op, x, reduced_vars):
-    if not reduced_vars.isdisjoint(x.probs.inputs):
+    if not reduced_vars.isdisjoint(x.probs.input_vars):
         return None
-    if not reduced_vars.issubset(x.value.inputs):
+    if not reduced_vars.issubset(x.value.input_vars):
         return None
 
     backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
     total_count = x.total_count
     for v in reduced_vars:
-        if v in total_count.inputs:
+        if v.name in total_count.inputs:
             total_count = total_count.reduce(ops.add, v)
         else:
-            total_count = total_count * x.inputs[v].size
+            total_count = total_count * v.output.size
     return backend_dist.Multinomial(total_count=total_count,
                                     probs=x.probs,
                                     value=x.value.reduce(ops.add, reduced_vars))
@@ -731,7 +731,7 @@ def _log_beta(x, y):
 
 
 def eager_gamma_gamma(red_op, bin_op, reduced_vars, x, y):
-    gamma_reduction = frozenset(x.inputs).intersection(reduced_vars)
+    gamma_reduction = x.input_vars & reduced_vars
     if gamma_reduction:
         unnormalized = (y.concentration - 1) * ops.log(y.value) \
             - (y.concentration + x.concentration) * ops.log(y.value + x.rate)
@@ -742,7 +742,7 @@ def eager_gamma_gamma(red_op, bin_op, reduced_vars, x, y):
 
 
 def eager_gamma_poisson(red_op, bin_op, reduced_vars, x, y):
-    gamma_reduction = frozenset(x.inputs).intersection(reduced_vars)
+    gamma_reduction = x.input_vars & reduced_vars
     if gamma_reduction:
         backend_dist = import_module(BACKEND_TO_DISTRIBUTIONS_BACKEND[get_backend()])
         return backend_dist.GammaPoisson(concentration=x.concentration,

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -120,7 +120,8 @@ class Distribution(Funsor, metaclass=DistributionMeta):
                                ', '.join('{}={}'.format(*kv) for kv in self.params.items()))
 
     def eager_reduce(self, op, reduced_vars):
-        if op is ops.logaddexp and isinstance(self.value, Variable) and self.value in reduced_vars:
+        assert reduced_vars.issubset(self.inputs)
+        if op is ops.logaddexp and isinstance(self.value, Variable) and self.value.name in reduced_vars:
             return Number(0.)  # distributions are normalized
         return super(Distribution, self).eager_reduce(op, reduced_vars)
 

--- a/funsor/einsum/__init__.py
+++ b/funsor/einsum/__init__.py
@@ -8,7 +8,7 @@ from funsor.cnf import Contraction
 from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer
 from funsor.sum_product import sum_product
-from funsor.terms import Funsor, lazy
+from funsor.terms import Funsor, Variable, lazy
 
 # TODO: add numpy einsum here
 BACKEND_OPS = {
@@ -50,7 +50,8 @@ def naive_contract_einsum(eqn, *terms, **kwargs):
     input_dims = frozenset(d for inp in inputs for d in inp)
     output_dims = frozenset(d for d in output)
     all_inputs = {k: v for term in terms for k, v in term.inputs.items()}
-    reduced_vars = {k: all_inputs[k] for k in input_dims - output_dims}
+    reduced_vars = frozenset(Variable(k, all_inputs[k])
+                             for k in input_dims - output_dims)
     return Contraction(sum_op, prod_op, reduced_vars, *terms)
 
 

--- a/funsor/einsum/__init__.py
+++ b/funsor/einsum/__init__.py
@@ -49,7 +49,8 @@ def naive_contract_einsum(eqn, *terms, **kwargs):
     assert len(output.split(',')) == 1
     input_dims = frozenset(d for inp in inputs for d in inp)
     output_dims = frozenset(d for d in output)
-    reduced_vars = input_dims - output_dims
+    all_inputs = {k: v for term in terms for k, v in term.inputs.items()}
+    reduced_vars = {k: all_inputs[k] for k in input_dims - output_dims}
     return Contraction(sum_op, prod_op, reduced_vars, *terms)
 
 

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -519,17 +519,17 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
         return Subs(result, remaining_subs) if remaining_subs else result
 
     def eager_reduce(self, op, reduced_vars):
+        assert reduced_vars.issubset(self.inputs)
         if op is ops.logaddexp:
             # Marginalize out real variables, but keep mixtures lazy.
-            assert reduced_vars.issubset(self.input_vars)
-            real_vars = frozenset(v for v in self.input_vars if v.dtype == "real")
+            assert all(v in self.inputs for v in reduced_vars)
+            real_vars = frozenset(k for k, d in self.inputs.items() if d.dtype == "real")
             reduced_reals = reduced_vars & real_vars
             reduced_ints = reduced_vars - real_vars
             if not reduced_reals:
                 return None  # defer to default implementation
 
-            reduced_names = frozenset(v.name for v in reduced_vars)
-            inputs = OrderedDict((k, d) for k, d in self.inputs.items() if k not in reduced_names)
+            inputs = OrderedDict((k, d) for k, d in self.inputs.items() if k not in reduced_reals)
             if reduced_reals == real_vars:
                 result = self.log_normalizer
             else:
@@ -540,7 +540,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
                 for key, domain in self.inputs.items():
                     if domain.dtype == 'real':
                         block = ops.new_arange(self.info_vec, offsets[key], offsets[key] + domain.num_elements, 1)
-                        (b if key in reduced_names else a).append(block)
+                        (b if key in reduced_vars else a).append(block)
                 a = ops.cat(-1, *a)
                 b = ops.cat(-1, *b)
                 prec_aa = self.precision[..., a[..., None], a]
@@ -565,14 +565,13 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
         elif op is ops.add:
             for v in reduced_vars:
-                if v.dtype == "real":
+                if self.inputs[v].dtype == 'real':
                     raise ValueError("Cannot sum along a real dimension: {}".format(repr(v)))
 
             # Fuse Gaussians along a plate. Compare to eager_add_gaussian_gaussian().
-            reduced_names = frozenset(v.name for v in reduced_vars)
             old_ints = OrderedDict((k, v) for k, v in self.inputs.items() if v.dtype != 'real')
-            new_ints = OrderedDict((k, v) for k, v in old_ints.items() if k not in reduced_names)
-            inputs = OrderedDict((k, v) for k, v in self.inputs.items() if k not in reduced_names)
+            new_ints = OrderedDict((k, v) for k, v in old_ints.items() if k not in reduced_vars)
+            inputs = OrderedDict((k, v) for k, v in self.inputs.items() if k not in reduced_vars)
 
             info_vec = Tensor(self.info_vec, old_ints).reduce(ops.add, reduced_vars)
             precision = Tensor(self.precision, old_ints).reduce(ops.add, reduced_vars)

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -275,7 +275,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
         output = Real
         fresh = frozenset(inputs.keys())
-        bound = frozenset()
+        bound = {}
         super(Gaussian, self).__init__(inputs, output, fresh, bound)
         self.info_vec = info_vec
         self.precision = precision

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -29,7 +29,9 @@ class IntegrateMeta(FunsorMeta):
     Wrapper to convert reduced_vars arg to a frozenset of str.
     """
     def __call__(cls, log_measure, integrand, reduced_vars):
-        reduced_vars = _convert_reduced_vars(reduced_vars)
+        inputs = log_measure.inputs.copy()
+        inputs.update(integrand.inputs)
+        reduced_vars = _convert_reduced_vars(reduced_vars, inputs)
         return super().__call__(log_measure, integrand, reduced_vars)
 
 
@@ -46,21 +48,23 @@ class Integrate(Funsor, metaclass=IntegrateMeta):
         assert isinstance(log_measure, Funsor)
         assert isinstance(integrand, Funsor)
         assert isinstance(reduced_vars, frozenset)
-        assert all(isinstance(v, str) for v in reduced_vars)
+        assert all(isinstance(v, Variable) for v in reduced_vars)
+        reduced_names = frozenset(v.name for v in reduced_vars)
         inputs = OrderedDict((k, d) for term in (log_measure, integrand)
                              for (k, d) in term.inputs.items()
-                             if k not in reduced_vars)
+                             if k not in reduced_names)
         output = integrand.output
         fresh = frozenset()
-        bound = reduced_vars
+        bound = {v.name: v.output for v in reduced_vars}
         super(Integrate, self).__init__(inputs, output, fresh, bound)
         self.log_measure = log_measure
         self.integrand = integrand
         self.reduced_vars = reduced_vars
 
     def _alpha_convert(self, alpha_subs):
-        assert self.bound.issuperset(alpha_subs)
-        reduced_vars = frozenset(alpha_subs.get(k, k) for k in self.reduced_vars)
+        assert set(self.bound).issuperset(alpha_subs)
+        reduced_vars = frozenset(Variable(alpha_subs.get(v.name, v.name), v.output)
+                                 for v in self.reduced_vars)
         alpha_subs = {k: to_funsor(v, self.integrand.inputs.get(k, self.log_measure.inputs.get(k)))
                       for k, v in alpha_subs.items()}
         log_measure = substitute(self.log_measure, alpha_subs)
@@ -77,11 +81,12 @@ def normalize_integrate(log_measure, integrand, reduced_vars):
                     Contraction[Union[ops.NullOp, ops.LogAddExpOp], ops.AddOp, frozenset, tuple],
                     Funsor, frozenset)
 def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
+    reduced_names = frozenset(v.name for v in reduced_vars)
     delta_terms = [t for t in log_measure.terms if isinstance(t, Delta)
-                   and t.fresh.intersection(reduced_vars, integrand.inputs)]
+                   and t.fresh.intersection(reduced_names, integrand.inputs)]
     for delta in delta_terms:
         integrand = integrand(**{name: point for name, (point, log_density) in delta.terms
-                                 if name in reduced_vars.intersection(integrand.inputs)})
+                                 if name in reduced_names.intersection(integrand.inputs)})
     return normalize_integrate(log_measure, integrand, reduced_vars)
 
 
@@ -89,8 +94,8 @@ def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
                 Unary[ops.ExpOp, Union[GaussianMixture, Delta, Gaussian, Number, Tensor]],
                 (Variable, Delta, Gaussian, Number, Tensor, GaussianMixture))
 def eager_contraction_binary_to_integrate(red_op, bin_op, reduced_vars, lhs, rhs):
-
-    if reduced_vars - reduced_vars.intersection(lhs.inputs, rhs.inputs):
+    reduced_names = frozenset(v.name for v in reduced_vars)
+    if not (reduced_names.issubset(lhs.inputs) and reduced_names.issubset(rhs.inputs)):
         args = red_op, bin_op, reduced_vars, (lhs, rhs)
         result = eager.dispatch(Contraction, *args)(*args)
         if result is not None:
@@ -106,7 +111,7 @@ def eager_contraction_binary_to_integrate(red_op, bin_op, reduced_vars, lhs, rhs
 
 @eager.register(Integrate, GaussianMixture, Funsor, frozenset)
 def eager_integrate_gaussianmixture(log_measure, integrand, reduced_vars):
-    real_vars = frozenset(k for k in reduced_vars if log_measure.inputs[k].dtype == 'real')
+    real_vars = frozenset(v for v in reduced_vars if v.dtype == "real")
     if reduced_vars <= real_vars:
         discrete, gaussian = log_measure.terms
         return discrete.exp() * Integrate(gaussian, integrand, reduced_vars)
@@ -119,13 +124,15 @@ def eager_integrate_gaussianmixture(log_measure, integrand, reduced_vars):
 
 @eager.register(Integrate, Delta, Funsor, frozenset)
 def eager_integrate(delta, integrand, reduced_vars):
-    if not reduced_vars & delta.fresh:
+    delta_fresh = frozenset(Variable(k, delta.inputs[k]) for k in delta.fresh)
+    if reduced_vars.isdisjoint(delta_fresh):
         return None
+    reduced_names = frozenset(v.name for v in reduced_vars)
     subs = tuple((name, point) for name, (point, log_density) in delta.terms
-                 if name in reduced_vars)
+                 if name in reduced_names)
     new_integrand = Subs(integrand, subs)
     new_log_measure = Subs(delta, subs)
-    result = Integrate(new_log_measure, new_integrand, reduced_vars - delta.fresh)
+    result = Integrate(new_log_measure, new_integrand, reduced_vars - delta_fresh)
     return result
 
 
@@ -135,8 +142,8 @@ def eager_integrate(delta, integrand, reduced_vars):
 
 @eager.register(Integrate, Gaussian, Variable, frozenset)
 def eager_integrate(log_measure, integrand, reduced_vars):
-    real_vars = frozenset(k for k in reduced_vars if log_measure.inputs[k].dtype == 'real')
-    if real_vars == frozenset([integrand.name]):
+    real_vars = frozenset(v for v in reduced_vars if v.dtype == "real")
+    if real_vars == frozenset([integrand]):
         loc = ops.cholesky_solve(ops.unsqueeze(log_measure.info_vec, -1), log_measure._precision_chol).squeeze(-1)
         data = loc * ops.unsqueeze(ops.exp(log_measure.log_normalizer.data), -1)
         data = data.reshape(loc.shape[:-1] + integrand.output.shape)
@@ -148,7 +155,8 @@ def eager_integrate(log_measure, integrand, reduced_vars):
 
 @eager.register(Integrate, Gaussian, Gaussian, frozenset)
 def eager_integrate(log_measure, integrand, reduced_vars):
-    real_vars = frozenset(k for k in reduced_vars if log_measure.inputs[k].dtype == 'real')
+    reduced_names = frozenset(v.name for v in reduced_vars)
+    real_vars = frozenset(v.name for v in reduced_vars if v.dtype == "real")
     if real_vars:
 
         lhs_reals = frozenset(k for k, d in log_measure.inputs.items() if d.dtype == 'real')
@@ -168,9 +176,9 @@ def eager_integrate(log_measure, integrand, reduced_vars):
             lhs_loc = ops.cholesky_solve(ops.unsqueeze(lhs.info_vec, -1), lhs._precision_chol).squeeze(-1)
             vmv_term = _vv(lhs_loc, rhs_info_vec - 0.5 * _mv(rhs_precision, lhs_loc))
             data = norm * (vmv_term - 0.5 * _trace_mm(rhs_precision, lhs_cov))
-            inputs = OrderedDict((k, d) for k, d in inputs.items() if k not in reduced_vars)
+            inputs = OrderedDict((k, d) for k, d in inputs.items() if k not in reduced_names)
             result = Tensor(data, inputs)
-            return result.reduce(ops.add, reduced_vars - real_vars)
+            return result.reduce(ops.add, reduced_names - real_vars)
 
         raise NotImplementedError('TODO implement partial integration')
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -32,7 +32,8 @@ def monte_carlo_integrate(state, log_measure, integrand, reduced_vars):
     sample = log_measure.sample(reduced_vars, state.sample_inputs, **sample_options)
     if sample is log_measure:
         return None  # cannot progress
-    reduced_vars |= frozenset(v for v in sample.input_vars if f.name in state.sample_inputs)
+    reduced_vars |= frozenset(v for v in sample.input_vars
+                              if v.name in state.sample_inputs)
     return Integrate(sample, integrand, reduced_vars)
 
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -32,7 +32,7 @@ def monte_carlo_integrate(state, log_measure, integrand, reduced_vars):
     sample = log_measure.sample(reduced_vars, state.sample_inputs, **sample_options)
     if sample is log_measure:
         return None  # cannot progress
-    reduced_vars |= frozenset(state.sample_inputs).intersection(sample.inputs)
+    reduced_vars |= frozenset(v for v in sample.input_vars if f.name in state.sample_inputs)
     return Integrate(sample, integrand, reduced_vars)
 
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -396,7 +396,8 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     drop = tuple("_drop_{}".format(i) for i in range(len(step)))
     prev_to_drop = dict(zip(step.keys(), drop))
     curr_to_drop = dict(zip(step.values(), drop))
-    drop = frozenset(drop)
+    drop = frozenset(Variable(v, trans.inputs[k])
+                     for k, v in curr_to_drop.items())
 
     time, duration = time.name, time.output.size
     while duration > 1:
@@ -629,7 +630,7 @@ class MarkovProduct(Funsor, metaclass=MarkovProductMeta):
                              if k != time.name)
         output = trans.output
         fresh = frozenset(step_names.values())
-        bound = {k: self.inputs[k] for k in step_names}
+        bound = {k: trans.inputs[k] for k in step_names}
         bound[time.name] = time.output
         super().__init__(inputs, output, fresh, bound)
         self.sum_op = sum_op
@@ -640,7 +641,7 @@ class MarkovProduct(Funsor, metaclass=MarkovProductMeta):
         self.step_names = step_names
 
     def _alpha_convert(self, alpha_subs):
-        assert self.bound.issuperset(alpha_subs)
+        assert set(alpha_subs).issubset(self.bound)
         time = Variable(alpha_subs.get(self.time.name, self.time.name),
                         self.time.output)
         step = frozenset((alpha_subs.get(k, k), alpha_subs.get(v, v))

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -385,7 +385,8 @@ class MarkovProduct(Funsor, metaclass=MarkovProductMeta):
                              if k != time.name)
         output = trans.output
         fresh = frozenset(step_names.values())
-        bound = frozenset(step_names.keys()) | {time.name}
+        bound = {k: self.inputs[k] for k in step_names}
+        bound[time.name] = time.output
         super().__init__(inputs, output, fresh, bound)
         self.sum_op = sum_op
         self.prod_op = prod_op

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -278,7 +278,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
         if op in REDUCE_OP_TO_NUMERIC:
             numeric_op = REDUCE_OP_TO_NUMERIC[op]
             assert isinstance(reduced_vars, frozenset)
-            self_vars = frozenset(self.inputs)
+            self_vars = frozenset(self.input_vars)
             reduced_vars = reduced_vars & self_vars
             if reduced_vars == self_vars and not self.output.shape:
                 return Tensor(numeric_op(self.data, None), dtype=self.dtype)
@@ -287,13 +287,14 @@ class Tensor(Funsor, metaclass=TensorMeta):
             data = self.data
             offset = 0
             for k, domain in self.inputs.items():
-                if k in reduced_vars:
+                var = Variable(k, domain)
+                if var in reduced_vars:
                     assert not domain.shape
                     data = numeric_op(data, offset)
                 else:
                     offset += 1
             inputs = OrderedDict((k, v) for k, v in self.inputs.items()
-                                 if k not in reduced_vars)
+                                 if Variable(k, v) not in reduced_vars)
             return Tensor(data, inputs, self.dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -123,7 +123,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
         inputs = OrderedDict(inputs)
         output = Array[dtype, data.shape[len(inputs):]]
         fresh = frozenset(inputs.keys())
-        bound = frozenset()
+        bound = {}
         super(Tensor, self).__init__(inputs, output, fresh, bound)
         self.data = data
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -278,7 +278,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
         if op in REDUCE_OP_TO_NUMERIC:
             numeric_op = REDUCE_OP_TO_NUMERIC[op]
             assert isinstance(reduced_vars, frozenset)
-            self_vars = frozenset(self.input_vars)
+            self_vars = frozenset(self.inputs)
             reduced_vars = reduced_vars & self_vars
             if reduced_vars == self_vars and not self.output.shape:
                 return Tensor(numeric_op(self.data, None), dtype=self.dtype)
@@ -287,14 +287,13 @@ class Tensor(Funsor, metaclass=TensorMeta):
             data = self.data
             offset = 0
             for k, domain in self.inputs.items():
-                var = Variable(k, domain)
-                if var in reduced_vars:
+                if k in reduced_vars:
                     assert not domain.shape
                     data = numeric_op(data, offset)
                 else:
                     offset += 1
             inputs = OrderedDict((k, v) for k, v in self.inputs.items()
-                                 if Variable(k, v) not in reduced_vars)
+                                 if k not in reduced_vars)
             return Tensor(data, inputs, self.dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -551,8 +551,11 @@ class Funsor(object, metaclass=FunsorMeta):
         factor_vars = reduced_vars - self.input_vars
         if factor_vars:
             reduced_vars = reduced_vars & self.input_vars
-            # FIXME this will fail when reducing over real values.
-            multiplicity = reduce(ops.mul, [v.output.size for v in factor_vars])
+            multiplicity = reduce(ops.mul, [
+                v.output.size ** v.output.num_elements
+                for v in factor_vars
+                if v.dtype != "real"
+            ])
             for add_op, mul_op in ops.DISTRIBUTIVE_OPS:
                 if add_op is op:
                     return mul_op(self, multiplicity).eager_reduce(op, reduced_vars)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1028,7 +1028,9 @@ class Reduce(Funsor):
         assert isinstance(arg, Funsor)
         assert isinstance(reduced_vars, frozenset)
         assert all(isinstance(v, Variable) for v in reduced_vars)
-        inputs = OrderedDict((k, v) for k, v in arg.inputs.items() if k not in reduced_vars)
+        reduced_names = frozenset(v.name for v in reduced_vars)
+        inputs = OrderedDict((k, v) for k, v in arg.inputs.items()
+                             if k not in reduced_names)
         output = arg.output
         fresh = frozenset()
         bound = {var.name: var.output for var in reduced_vars}

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -86,7 +86,7 @@ def test_bart(analytic_kl):
          'time_b4',
          'gate_rate_b3')
         p_prior = Contraction(ops.logaddexp, ops.add,
-         frozenset({'state(time=1)_b11', 'state_b10'}),
+         frozenset({Variable('state(time=1)_b11', Reals[2]), Variable('state_b10', Reals[2])}),
          (MarkovProduct(ops.logaddexp, ops.add,
            Contraction(ops.nullop, ops.add,
             frozenset(),
@@ -140,9 +140,9 @@ def test_bart(analytic_kl):
            (('value_b5',
              Variable('state_b10', Reals[2]),),)),))
         p_likelihood = Contraction(ops.add, ops.nullop,
-         frozenset({'time_b17', 'destin_b16', 'origin_b15'}),
+         frozenset({Variable('time_b17', Bint[2]), Variable('destin_b16', Bint[2]), Variable('origin_b15', Bint[2])}),
          (Contraction(ops.logaddexp, ops.add,
-           frozenset({'gated_b14'}),
+           frozenset({Variable('gated_b14', Bint[2])}),
            (dist.Categorical(
              Binary(ops.GetitemOp(0),
               Binary(ops.GetitemOp(0),

--- a/test/test_cnf.py
+++ b/test/test_cnf.py
@@ -95,7 +95,7 @@ def test_eager_contract_tensor_tensor(red_op, bin_op, x_inputs, x_shape, y_input
     y = random_tensor(y_inputs, Reals[y_shape])
 
     xy = bin_op(x, y)
-    all_vars = frozenset(x.inputs).union(y.inputs)
+    all_vars = x.input_vars | y.input_vars
     for n in range(len(all_vars)):
         for reduced_vars in map(frozenset, itertools.combinations(all_vars, n)):
             print("reduced_vars = {}".format(reduced_vars))

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -374,6 +374,12 @@ def test_reduce_constant():
     assert x.reduce(ops.add, i) == Number(4)
 
 
+def test_reduce_variable():
+    x = Variable("x", Real)
+    i = Variable("i", Bint[4])
+    assert x.reduce(ops.add, i) == x * 4
+
+
 def test_slice():
     t_slice = Slice("t", 10)
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -368,6 +368,12 @@ def test_reduce_syntactic_sugar():
     assert x.reduce(ops.add, frozenset([i])) is expected
 
 
+def test_reduce_constant():
+    x = Number(1)
+    i = Variable("i", Bint[4])
+    assert x.reduce(ops.add, i) == Number(4)
+
+
 def test_slice():
     t_slice = Slice("t", 10)
 

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -377,7 +377,7 @@ def test_reduce_constant():
 def test_reduce_variable():
     x = Variable("x", Real)
     i = Variable("i", Bint[4])
-    assert x.reduce(ops.add, i) == x * 4
+    assert x.reduce(ops.add, i) is x * 4
 
 
 def test_slice():


### PR DESCRIPTION
pair coded with @eb8680 and @fehiepsi 

## Sumary

- refactors `.bound` from a frozenset of names --> a dict mapping names to domains.
- refactors `Reduce.reduced_vars` to be a frozenset of variables.
- refactors `Contraction.reduced_vars` to be a frozenset of variables.
- refactors `Integrate.reduced_vars` to be a frozenset of variables.
- keeps `.eager_reduce(op, reduced_vars)` inputting a frozenset of names, but ensure those names are a subset of `.inputs`.

## Tested
- refactoring is covered by existing tests.
- added new unit tests for reducing variables not in `.inputs`.