### PR TITLE
Generalize partial sum product to Markov models

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -120,10 +120,10 @@ def modified_partial_sum_product(
     assert isinstance(plates, frozenset)
     assert isinstance(time, str)
     assert isinstance(step, dict)
-    sum_vars = eliminate - plates
     time_plate = frozenset({time})
     plates |= time_plate
-    all_markov_vars = time_plate | frozenset(step.keys()) | frozenset(step.values())
+    sum_vars = eliminate - plates
+    all_markov_vars = frozenset(step.keys()) | frozenset(step.values())
 
     var_to_ordinal = {}
     ordinal_to_factors = defaultdict(list)
@@ -143,14 +143,18 @@ def modified_partial_sum_product(
         leaf_factors = ordinal_to_factors.pop(leaf)
         leaf_reduce_vars = ordinal_to_vars[leaf]
         for (group_factors, group_vars) in _partition(leaf_factors, leaf_reduce_vars):
+            #breakpoint()
             nonmarkov_vars = group_vars - all_markov_vars
             markov_vars = group_vars.intersection(all_markov_vars)
             # contract non markov vars
             f = reduce(prod_op, group_factors).reduce(sum_op, nonmarkov_vars)
-            if markov_vars and var_to_ordinal[time] == leaf:
-                # contract markov vars
+            if markov_vars:
+            # contract markov vars
+                if all_markov_vars.intersection(f.inputs) != markov_vars:
+                    raise ValueError("intractable!")
+                group_step = {k: v for (k, v) in step.items() if v in markov_vars}
                 time_var = Variable(time, f.inputs[time])
-                f = sequential_sum_product(sum_op, prod_op, f, time_var, step)
+                f = sequential_sum_product(sum_op, prod_op, f, time_var, group_step)
                 f = f.reduce(sum_op, markov_vars - time_plate)
 
             remaining_sum_vars = sum_vars.intersection(f.inputs)
@@ -160,45 +164,10 @@ def modified_partial_sum_product(
             else:
                 new_plates = frozenset().union(
                     *(var_to_ordinal[v] for v in remaining_sum_vars))
-                if new_plates != leaf:
-                    f = f.reduce(prod_op, leaf - new_plates - time_plate)
-                    ordinal_to_factors[new_plates].append(f)
-                else:
-                    if markov_vars.isdisjoint(remaining_sum_vars):
-                        raise ValueError("intractable!")
-
-                    # unroll local plates
-                    local_plates = frozenset().union(
-                        *(var_to_ordinal[v] for v in remaining_sum_vars - markov_vars))
-                    factors = [f]
-                    for plate in (leaf - local_plates - time_plate):
-                        unrolled_factors = []
-                        for factor in factors:
-                            slice_factors = [factor(
-                                **{plate: i},
-                                **{var: '{}_{}_{}'.format(var, plate, i) for var in markov_vars},
-                            ) for i in range(factor.inputs[plate].size)]
-                            unrolled_factors.extend(slice_factors)
-
-                        unrolled_step = {}
-                        for k, v in step.items():
-                            if k in markov_vars:
-                                unrolled_step.update(
-                                    {'{}_{}_{}'.format(k, plate, i): '{}_{}_{}'.format(v, plate, i)
-                                     for i in range(f.inputs[plate].size)}
-                                )
-                            else:
-                                unrolled_step[k] = v
-
-                        unrolled_markov_vars = frozenset(
-                            ('{}_{}_{}'.format(var, plate, i) for
-                             var in markov_vars for i in range(f.inputs[plate].size))
-                        )
-                        all_markov_vars = (all_markov_vars - markov_vars) | unrolled_markov_vars
-                        factors = unrolled_factors
-                        step = unrolled_step
-                    ordinal_to_factors[local_plates].extend(factors)
-                    ordinal_to_vars[local_plates] |= unrolled_markov_vars
+                if new_plates == leaf:
+                    raise ValueError("intractable!")
+                f = f.reduce(prod_op, leaf - new_plates - time_plate)
+                ordinal_to_factors[new_plates].append(f)
 
     return results
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -134,13 +134,13 @@ def modified_partial_sum_product(
         leaf_factors = ordinal_to_factors.pop(leaf)
         leaf_reduce_vars = ordinal_to_vars[leaf]
         for (group_factors, group_vars) in _partition(leaf_factors, leaf_reduce_vars):
-            #breakpoint()
+            # breakpoint()
             nonmarkov_vars = group_vars - all_markov_vars
             markov_vars = group_vars.intersection(all_markov_vars)
             f = reduce(prod_op, group_factors).reduce(sum_op, nonmarkov_vars)
             if markov_vars:
-                local_step = {k: v for (k, v) in step.items() if k in markov_vars}
-                f = sequential_sum_product(sum_op, prod_op, f, Variable(time, f.inputs[time]), local_step)
+                # local_step = {k: v for (k, v) in step.items() if k in markov_vars}
+                f = sequential_sum_product(sum_op, prod_op, f, Variable(time, f.inputs[time]), step)
                 f = f.reduce(sum_op, markov_vars)
             # bug
             remaining_sum_vars = sum_vars.intersection(f.inputs)
@@ -151,7 +151,7 @@ def modified_partial_sum_product(
                     *(var_to_ordinal[v] for v in remaining_sum_vars))
                 if new_plates == leaf:
                     raise ValueError("intractable!")
-                f = f.reduce(prod_op, leaf - new_plates)
+                f = f.reduce(prod_op, leaf - new_plates - frozenset({time}))
                 ordinal_to_factors[new_plates].append(f)
 
     return results

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -127,11 +127,11 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
         markov_sum_vars |= frozenset(step.keys()) | frozenset(step.values())
     markov_sum_vars &= sum_vars
     markov_prod_vars = frozenset(k for k, v in plate_to_step.items() if v and k in eliminate)
-    markov_sum_to_prod = {}
+    markov_sum_to_prod = defaultdict(set) 
     for markov_prod in markov_prod_vars:
         for k, v in plate_to_step[markov_prod].items():
-            markov_sum_to_prod[k] = markov_prod
-            markov_sum_to_prod[v] = markov_prod
+            markov_sum_to_prod[k].add(markov_prod)
+            markov_sum_to_prod[v].add(markov_prod)
 
     var_to_ordinal = {}
     ordinal_to_factors = defaultdict(list)
@@ -159,9 +159,10 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
             if markov_vars:
                 markov_prod_var = [markov_sum_to_prod[var] for var in markov_vars]
                 assert all(p == markov_prod_var[0] for p in markov_prod_var)
-                time = markov_prod_var[0]
-                # if not len(markov_prod_vars.intersection(f.inputs)) == 1:
-                #     raise ValueError("intractable!")
+                if len(markov_prod_var[0]) != 1:
+                     raise ValueError("intractable!")
+                else:
+                    time = next(iter(markov_prod_var[0]))
                 for v in sum_vars.intersection(f.inputs):
                     if time in var_to_ordinal[v] and var_to_ordinal[v] < leaf:
                         raise ValueError("intractable!")

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -118,6 +118,8 @@ def modified_partial_sum_product(
     assert all(isinstance(f, Funsor) for f in factors)
     assert isinstance(eliminate, frozenset)
     assert isinstance(plates, frozenset)
+    assert isinstance(time, str)
+    assert isinstance(step, dict)
     sum_vars = eliminate - plates
     time_plate = frozenset({time})
     plates |= time_plate

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -153,17 +153,17 @@ def modified_partial_sum_product(
                 f = sequential_sum_product(sum_op, prod_op, f, time_var, step)
                 f = f.reduce(sum_op, markov_vars - time_plate)
 
-            remaining_sum_vars = sum_vars.intersection(f.inputs) - markov_vars
+            remaining_sum_vars = sum_vars.intersection(f.inputs)
 
             if not remaining_sum_vars:
                 results.append(f.reduce(prod_op, leaf & eliminate - time_plate))
             else:
                 new_plates = frozenset().union(
-                    *(var_to_ordinal[v] for v in remaining_sum_vars))
+                    *(var_to_ordinal[v] for v in remaining_sum_vars - markov_vars))
                 if new_plates == leaf:
                     raise ValueError("intractable!")
 
-                if not markov_vars or var_to_ordinal[time] == leaf:
+                if not markov_vars.intersection(remaining_sum_vars):
                     # if no markov vars left then eliminate plates
                     f = f.reduce(prod_op, leaf - new_plates - time_plate)
                     ordinal_to_factors[new_plates].append(f)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -127,7 +127,7 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
         markov_sum_vars |= frozenset(step.keys()) | frozenset(step.values())
     markov_sum_vars &= sum_vars
     markov_prod_vars = frozenset(k for k, v in plate_to_step.items() if v and k in eliminate)
-    markov_sum_to_prod = defaultdict(set) 
+    markov_sum_to_prod = defaultdict(set)
     for markov_prod in markov_prod_vars:
         for k, v in plate_to_step[markov_prod].items():
             markov_sum_to_prod[k].add(markov_prod)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -99,9 +99,6 @@ def modified_partial_sum_product(
     """
     Modified partial sum-product that supports contraction of markov sites.
 
-    :return: a single contracted Funsor.
-    :rtype: :class:`~funsor.terms.Funsor`
-
     :param ~funsor.ops.AssociativeOp sum_op: A semiring sum operation.
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.
     :param factors: A collection of funsors.

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -151,6 +151,8 @@ def modified_partial_sum_product(
             markov_vars = group_vars.intersection(markov_sum_vars)
             if markov_vars:
                 time = markov_prod_vars.intersection(f.inputs)
+                if not len(time) == 1:
+                    raise ValueError("intractable!")
                 for v in sum_vars.intersection(f.inputs):
                     if time.issubset(var_to_ordinal[v]) and var_to_ordinal[v] < leaf:
                         raise ValueError("intractable!")

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -134,7 +134,7 @@ def modified_partial_sum_product(
                 for k, v in step.items():
                     group_vars -= frozenset(k) | frozenset(v)
                 f = reduce(prod_op, group_factors).reduce(sum_op, group_vars)
-                f = modified_sequential_sum_product(sum_op, prod_op, f, Variable(time, f.inputs[time]), step)
+                f = modified_sequential_sum_product(sum_op, prod_op, f, time, step)
                 f = f.reduce(sum_op, frozenset(step.values()))
                 f = f.reduce(sum_op, frozenset(step.keys()))
             else:
@@ -243,19 +243,29 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     return trans(**{time: 0})
 
 
-def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1):
+def modified_sequential_sum_product(sum_op, prod_op, trans, time, step=frozenset(), window=1):
     """
-    For a funsor ``trans`` with dimensions ``time``, ``prev`` and ``curr``,
-    computes a recursion equivalent to::
+    Parallel-scan algorithm. For :math:`\bigotimes` consists of
+    positional renaming of variables and contraction operations.
+    
+    .. math::
 
-        tail_time = 1 + arange("time", trans.inputs["time"].size - 1)
-        tail = sequential_sum_product(sum_op, prod_op,
-                                      trans(time=tail_time),
-                                      time, {"prev": "curr"})
-        return prod_op(trans(time=0)(curr="drop"), tail(prev="drop")) \
-           .reduce(sum_op, "drop")
+       a_{i} = f^{x_{wi-w+1} \dots x_{wi}}_{x_{wi-2w+1} \dots x_{wi-w}}
 
-    but does so efficiently in parallel in O(log(time)).
+       a_{i} \bigotimes a_{j} = f^{x_{wj-w+1} \dots x_{wj}}_{x_{wi-2w+1} \dots x_{wi-w}}
+
+       a_{t} \bigotimes a_{t+1} = f^{x_{wt+1} \dots x_{wt+w}}_{x_{wt-2w+1} \dots x_{wt-w}}
+
+    For `window == 1`:
+
+    .. math::
+
+       a_{i} = f^{x_{i}}_{x_{i-1}}
+
+       a_{i} \bigotimes a_{j} = f^{(x_{i},x_{j-1})}_{x_{i-1}} f^{x_{j}}_{(x_{i},x_{j-1})} = f^{x_{j}}_{x_{i-1}}
+
+       a_{t} \bigotimes a_{t+1} = f^{x_{t}}_{x_{t-1}} f^{x_{t+1}}_{x_{t}} = f^{x_{t+1}}_{x_{t-1}}
+    
 
     :param ~funsor.ops.AssociativeOp sum_op: A semiring sum operation.
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.
@@ -267,38 +277,44 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     assert isinstance(sum_op, AssociativeOp)
     assert isinstance(prod_op, AssociativeOp)
     assert isinstance(trans, Funsor)
-    assert isinstance(time, Variable)
+    # for compatibility with sequential_sum_product interface
+    if isinstance(time, Variable):
+        time, duration = time.name, time.output.size
+        if time in trans.inputs:
+            assert duration == trans.inputs[time].size
+    else:
+        duration = trans.inputs[time].size
     if isinstance(step, dict):
-        step = tuple(step.items())
+        step = frozenset(step.items())
+    assert isinstance(time, str)
+    assert isinstance(step, frozenset)
     assert isinstance(window, int)
     assert all(len(s) == window + 1 for s in step)
-    if time.name in trans.inputs:
-        assert time.output == trans.inputs[time.name]
-
-    time, duration = time.name, time.output.size
 
     if duration % window:
         raise NotImplementedError("TODO handle partial windows")
 
+    # create a new funsor of the length duration // window
     if window > 1:
         new_duration = duration // window
         new_trans = Number(0., 'real')
+        new_step = frozenset()
+        new_to_old = {}
+        for seq in step:
+            new_seq = tuple(''.join(seq[max(0, i+1-window):i+1]) for i in range(window*2))
+            new_step |= frozenset({new_seq})
+            new_to_old.update(zip(new_seq, seq))
         for w in range(window):
             old_to_new = {}
             for values in step:
                 for i, v in enumerate(values):
                     old_to_new[v] = ''.join(values[max(0, i+w+1-window):i+w+1])
             new_trans = new_trans + trans(**{time: Slice(time, w, duration, window)}, **old_to_new)
-        new_step = []
-        for s in step:
-            new_step.append(tuple(''.join(s[max(0, i+1-window):i+1]) for i in range(window*2)))
-        new_to_old = {}
-        for (new, old) in zip(new_step, step):
-            new_to_old.update(zip(new, old))
         duration = new_duration
         trans = new_trans
         step = new_step
 
+    # variable renaming
     drop = tuple("_drop_{}_window_{}".format(i, w) for w in range(window) for i in range(len(step)))
     prev = tuple(s[w] for w in range(window) for s in step)
     curr = tuple(s[window+w] for w in range(window) for s in step)
@@ -306,6 +322,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     curr_to_drop = dict(zip(curr, drop))
     drop = frozenset(prev_to_drop.values())
 
+    # parallel-scan contraction
     while duration > 1:
         even_duration = duration // 2 * 2
         x = trans(**{time: Slice(time, 0, even_duration, 2, duration)}, **curr_to_drop)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -109,7 +109,7 @@ def modified_partial_sum_product(
     assert isinstance(eliminate, frozenset)
     assert isinstance(plates, frozenset)
     sum_vars = eliminate - plates
-    plates |= frozenset(time)
+    plates |= frozenset({time})
 
     var_to_ordinal = {}
     ordinal_to_factors = defaultdict(list)
@@ -132,22 +132,23 @@ def modified_partial_sum_product(
             if plates.intersection(group_vars):
                 group_vars = group_vars - plates
                 for k, v in step.items():
-                    group_vars -= frozenset(k) | frozenset(v)
+                    group_vars -= frozenset({k}) | frozenset({v})
                 f = reduce(prod_op, group_factors).reduce(sum_op, group_vars)
                 f = sequential_sum_product(sum_op, prod_op, f, Variable(time, f.inputs[time]), step)
                 f = f.reduce(sum_op, frozenset(step.values()))
                 f = f.reduce(sum_op, frozenset(step.keys()))
             else:
                 f = reduce(prod_op, group_factors).reduce(sum_op, group_vars)
+            # bug
             remaining_sum_vars = sum_vars.intersection(f.inputs)
             if not remaining_sum_vars:
-                results.append(f.reduce(prod_op, leaf & eliminate - frozenset(time)))
+                results.append(f.reduce(prod_op, leaf & eliminate - frozenset({time})))
             else:
                 new_plates = frozenset().union(
                     *(var_to_ordinal[v] for v in remaining_sum_vars))
                 if new_plates == leaf:
                     raise ValueError("intractable!")
-                f = f.reduce(prod_op, leaf - new_plates - frozenset(time))
+                f = f.reduce(prod_op, leaf - new_plates - frozenset({time}))
                 ordinal_to_factors[new_plates].append(f)
 
     return results

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -282,7 +282,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
 
     if window > 1:
         new_duration = duration // window
-        new_trans = Number(0., 'real') 
+        new_trans = Number(0., 'real')
         for w in range(window):
             old_to_new = {}
             for values in step:

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -150,9 +150,9 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
         leaf = max(ordinal_to_factors, key=len)
         leaf_factors = ordinal_to_factors.pop(leaf)
         leaf_reduce_vars = ordinal_to_vars[leaf]
-        for (group_factors, group_vars) in _partition(leaf_factors, leaf_reduce_vars):
+        for (group_factors, group_vars) in _partition(leaf_factors, leaf_reduce_vars | markov_prod_vars):
             # eliminate non markov vars
-            nonmarkov_vars = group_vars - markov_sum_vars
+            nonmarkov_vars = group_vars - markov_sum_vars - markov_prod_vars
             f = reduce(prod_op, group_factors).reduce(sum_op, nonmarkov_vars)
             # eliminate markov vars
             markov_vars = group_vars.intersection(markov_sum_vars)
@@ -160,9 +160,8 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
                 markov_prod_var = [markov_sum_to_prod[var] for var in markov_vars]
                 assert all(p == markov_prod_var[0] for p in markov_prod_var)
                 if len(markov_prod_var[0]) != 1:
-                     raise ValueError("intractable!")
-                else:
-                    time = next(iter(markov_prod_var[0]))
+                    raise ValueError("intractable!")
+                time = next(iter(markov_prod_var[0]))
                 for v in sum_vars.intersection(f.inputs):
                     if time in var_to_ordinal[v] and var_to_ordinal[v] < leaf:
                         raise ValueError("intractable!")

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -290,19 +290,19 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
 
     if window > 1:
         new_duration = duration // window
-        new_trans = Number(0., 'real') 
+        new_trans = Number(0., 'real')
         for w in range(window):
             old_to_new = {}
             for values in step:
                 for i, v in enumerate(values):
-                    old_to_new[v] = ''.join(values[max(0,i+w+1-window):i+w+1])
+                    old_to_new[v] = ''.join(values[max(0, i+w+1-window):i+w+1])
             new_trans = new_trans + trans(**{time: Slice(time, w, duration, window)}, **old_to_new)
         new_step = []
         for s in step:
-            new_step.append(tuple(''.join(s[max(0,i+1-window):i+1]) for i in range(window*2)))
+            new_step.append(tuple(''.join(s[max(0, i+1-window):i+1]) for i in range(window*2)))
         new_to_old = {}
         for (new, old) in zip(new_step, step):
-            new_to_old.update(zip(new,old))
+            new_to_old.update(zip(new, old))
         duration = new_duration
         trans = new_trans
         step = new_step
@@ -313,7 +313,6 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     prev_to_drop = dict(zip(prev, drop))
     curr_to_drop = dict(zip(curr, drop))
     drop = frozenset(prev_to_drop.values())
-
 
     while duration > 1:
         even_duration = duration // 2 * 2
@@ -326,7 +325,9 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
             contracted = Cat(time, (contracted, extra))
         trans = contracted
         duration = (duration + 1) // 2
-    curr_to_drop = frozenset(key for (key,value) in curr_to_drop.items() if not value.endswith('_window_{}'.format(window-1)))
+    curr_to_drop = frozenset(
+            key for (key, value) in curr_to_drop.items()
+            if not value.endswith('_window_{}'.format(window-1)))
     trans = trans.reduce(sum_op, curr_to_drop)
     if window > 1:
         trans = trans(**new_to_old)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -404,7 +404,7 @@ def _check_modified_sequential(trans, expected_inputs, global_vars, step, window
     duration = trans.inputs["time"].dtype
     time_var = Variable("time", Bint[duration])
 
-    actual = modified_sequential_sum_product(sum_op, prod_op, trans, time_var, step, window)
+    actual = modified_sequential_sum_product(sum_op, prod_op, trans, "time", step, window)
 
     expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars)
     assert dict(expected.inputs) == expected_inputs
@@ -446,7 +446,7 @@ def test_sarkka_bilmes_example_1(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('Pa', 'a'), ('Pb', 'b'))
+    step = frozenset({('Pa', 'a'), ('Pb', 'b')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 1)
 
 
@@ -473,7 +473,7 @@ def test_sarkka_bilmes_example_2(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c'))
+    step = frozenset({('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -496,7 +496,7 @@ def test_sarkka_bilmes_example_3(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c'))
+    step = frozenset({('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -519,7 +519,7 @@ def test_sarkka_bilmes_example_4(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPPa', 'PPa', 'Pa', 'a'),)
+    step = frozenset({('PPPa', 'PPa', 'Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 3)
 
 
@@ -543,7 +543,7 @@ def test_sarkka_bilmes_example_5(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('Pa', 'a'),)
+    step = frozenset({('Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 1)
 
 
@@ -570,7 +570,7 @@ def test_sarkka_bilmes_example_6(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('PPPa', 'PPa', 'Pa', 'a'),)
+    step = frozenset({('PPPa', 'PPa', 'Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 3)
 
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -94,7 +94,6 @@ def test_partition(inputs, dims, expected_num_components):
 def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2):
     inputs = inputs.split(',')
     factors = [random_tensor(OrderedDict((d, Bint[2]) for d in ds)) for ds in inputs]
-    # plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)
 
@@ -158,26 +157,24 @@ def _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
 
 
 @pytest.mark.parametrize('vars1,vars2', [
-    (frozenset({"time", "x_prev", "x_curr", "y_curr"}),
-     frozenset()),
-    (frozenset({"y_curr"}),
-     frozenset({"time", "x_prev", "x_curr"})),
     (frozenset(),
      frozenset({"time", "x_prev", "x_curr", "y_curr"})),
+    (frozenset({"y_curr"}),
+     frozenset({"time", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_prev", "x_curr", "y_curr"}),
+     frozenset()),
 ])
-@pytest.mark.parametrize('x_dim,time_duration', [
+@pytest.mark.parametrize('x_dim,time', [
     (3, 1), (1, 5), (3, 5),
 ])
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
 def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
-                                        x_dim, time_duration):
-    x_dim = 2
-    time_duration = 5
+                                        x_dim, time):
 
     f1 = random_tensor(OrderedDict({}))
 
     f2 = random_tensor(OrderedDict({
-        "time": Bint[time_duration],
+        "time": Bint[time],
         "x_prev": Bint[x_dim],
         "x_curr": Bint[x_dim],
     }))
@@ -338,7 +335,7 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     (frozenset({"sequences", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
      frozenset()),
 ])
-@pytest.mark.parametrize('x_dim,y_dim,sequences, time, tones', [
+@pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
     (2, 3, 2, 5, 4), (1, 3, 2, 5, 4), (2, 1, 2, 5, 4), (2, 3, 2, 1, 4),
 ])
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
@@ -536,7 +533,7 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
         factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
-        actual = reduce(prod_op, factors2)
+        reduce(prod_op, factors2)
 
 
 @pytest.mark.parametrize('vars1,vars2', [
@@ -679,7 +676,7 @@ def test_modified_partial_sum_product_9(sum_op, prod_op, vars1, vars2,
 ])
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
 def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
-                                        w_dim, x_dim, y_dim, sequences, time, tones):
+                                         w_dim, x_dim, y_dim, sequences, time, tones):
 
     f1 = random_tensor(OrderedDict({}))
 
@@ -744,7 +741,7 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 ])
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
 def test_modified_partial_sum_product_11(sum_op, prod_op, vars1, vars2,
-                                        a_dim, b_dim, w_dim, x_dim, y_dim, sequences, time, tones):
+                                         a_dim, b_dim, w_dim, x_dim, y_dim, sequences, time, tones):
 
     f1 = random_tensor(OrderedDict({}))
 
@@ -816,7 +813,7 @@ def test_modified_partial_sum_product_11(sum_op, prod_op, vars1, vars2,
 ])
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
 def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
-                                        w_dim, x_dim, y_dim, sequences, time, tones):
+                                         w_dim, x_dim, y_dim, sequences, time, tones):
 
     f1 = random_tensor(OrderedDict({}))
 
@@ -855,7 +852,7 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
         factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
-        actual = reduce(prod_op, factors2)
+        reduce(prod_op, factors2)
 
 
 @pytest.mark.parametrize('num_steps', [None] + list(range(1, 13)))

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -195,7 +195,7 @@ def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time,
                 unrolled_factors.append(f(**arg_to_time))
         else:
             unrolled_factors.append(f)
-            # unrolled_plates |= I
+
     unrolled_vars = frozenset()
     for f in unrolled_factors:
         unrolled_vars |= frozenset(f.inputs)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -599,7 +599,7 @@ def test_partial_sum_product_hmm_example_9(sum_op, prod_op, vars1, vars2):
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.logaddexp, ops.add), (ops.add, ops.mul)])
 def test_partial_sum_product_hmm_example_10(sum_op, prod_op, vars1, vars2):
     x_dim, y_dim, w_dim = 2, 2, 3
-    sequences, duration, tones = 2, 5, 3
+    sequences, duration, tones = 2, 4, 2
 
     probs_x = random_tensor(OrderedDict({}))
     probs_y = random_tensor(OrderedDict({}))

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -131,7 +131,7 @@ def _expected_hmm_example(sum_op, prod_op, factors, plates, global_vars, local_v
     for factor in factors:
         if time in factor.inputs:
             slice_factors = [factor(
-                time=t,
+                **{time: t},
                 **{var: '{}_{}'.format(var, t+1) for var in local_vars},
                 **{var: '{}_{}'.format(curr_to_drop[var], t+1) for var in curr_to_drop.keys()},
                 **{var: '{}_{}'.format(prev_to_drop[var], t) for var in prev_to_drop.keys()}

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -110,18 +110,18 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
     assert_close(actual, expected)
 
 
-def _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+def _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                           global_vars, local_var_dict):
 
-    markov_plate_dict = {k: v for (k, v) in plate_dict.items() if v}
-    plates = frozenset({k for (k, v) in plate_dict.items() if not v})
+    markov_plate_to_step = {k: v for (k, v) in plate_to_step.items() if v}
+    plates = frozenset({k for (k, v) in plate_to_step.items() if not v})
     reduce_vars = global_vars | plates
 
     # unroll markov plates
     unrolled_factors = []
     for factor in factors:
-        if frozenset(factor.inputs).intersection(markov_plate_dict.keys()):
-            for markov_plate, step in markov_plate_dict.items():
+        if frozenset(factor.inputs).intersection(markov_plate_to_step.keys()):
+            for markov_plate, step in markov_plate_to_step.items():
                 if markov_plate in factor.inputs:
                     local_vars = local_var_dict[markov_plate]
                     step = OrderedDict(sorted(step.items()))
@@ -180,16 +180,16 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2]
-    plate_dict = dict({"time": {"x_prev": "x_curr"}})
+    plate_to_step = dict({"time": {"x_prev": "x_curr"}})
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset()}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -225,16 +225,16 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({"time": {"x_prev": "x_curr"}})
+    plate_to_step = dict({"time": {"x_prev": "x_curr"}})
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"y_curr"})}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -268,16 +268,16 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
+    plate_to_step = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset()}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -312,16 +312,16 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
+    plate_to_step = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset()}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -360,20 +360,20 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset()}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -416,21 +416,21 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "tones": {},
         "days": {"x_prev": "x_curr"},
         "weeks": {"y_prev": "y_curr"}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"days": frozenset(), "weeks": frozenset()}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -471,20 +471,20 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"y_curr"})}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -524,15 +524,15 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
     })
 
     with pytest.raises(ValueError, match="intractable!"):
-        factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-        factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+        factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+        factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
         reduce(prod_op, factors2)
 
 
@@ -579,20 +579,20 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"y_curr"})}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -642,20 +642,20 @@ def test_modified_partial_sum_product_9(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"y_curr"})}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -704,20 +704,20 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"w_curr", "y_curr"})}
     global_vars = frozenset()
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -781,20 +781,20 @@ def test_modified_partial_sum_product_11(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4, f5, f6]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
     })
 
-    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+    factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+    factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
     actual = reduce(prod_op, factors2)
 
     local_var_dict = {"time": frozenset({"y_curr"})}
     global_vars = frozenset({"a", "b"})
 
-    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_dict,
+    expected = _expected_hmm_example(sum_op, prod_op, factors, plate_to_step,
                                      global_vars, local_var_dict)
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -843,15 +843,15 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_dict = dict({
+    plate_to_step = dict({
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
     })
 
     with pytest.raises(ValueError, match="intractable!"):
-        factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_dict)
-        factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_dict)
+        factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
+        factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
         reduce(prod_op, factors2)
 
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -118,7 +118,7 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 ])
 def test_markov_partial_sum_product(sum_op, prod_op, inputs, plates, time, step, vars1, vars2):
     inputs = inputs.split(',')
-    factors = [random_tensor(OrderedDict((d, Bint[2]) if d!='t' else (d, Bint[10]) for d in ds)) for ds in inputs]
+    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[10]) for d in ds)) for ds in inputs]
     plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)
@@ -166,7 +166,7 @@ def test_markov_partial_sum_product(sum_op, prod_op, inputs, plates, time, step,
 ])
 def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time, step, vars1, vars2):
     inputs = inputs.split(',')
-    factors = [random_tensor(OrderedDict((d, Bint[2]) if d!='t' else (d, Bint[10]) for d in ds)) for ds in inputs]
+    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[10]) for d in ds)) for ds in inputs]
     plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)
@@ -202,6 +202,7 @@ def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time,
     expected = sum_product(sum_op, prod_op, unrolled_factors, unrolled_vars, unrolled_plates)
 
     assert_close(actual, expected)
+
 
 @pytest.mark.parametrize('num_steps', [None] + list(range(1, 13)))
 @pytest.mark.parametrize('sum_op,prod_op,state_domain', [
@@ -445,7 +446,7 @@ def test_sarkka_bilmes_example_1(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('Pa','a'),('Pb','b'))
+    step = (('Pa', 'a'), ('Pb', 'b'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 1)
 
 
@@ -472,7 +473,7 @@ def test_sarkka_bilmes_example_2(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa','Pa','a'),('PPb','Pb','b'),('PPc','Pc','c'))
+    step = (('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -495,7 +496,7 @@ def test_sarkka_bilmes_example_3(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa','Pa','a'),('PPc','Pc','c'))
+    step = (('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -518,7 +519,7 @@ def test_sarkka_bilmes_example_4(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPPa','PPa','Pa','a'),)
+    step = (('PPPa', 'PPa', 'Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 3)
 
 
@@ -542,8 +543,9 @@ def test_sarkka_bilmes_example_5(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('Pa','a'),)
+    step = (('Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 1)
+
 
 @pytest.mark.parametrize("duration", [3, 6, 9])
 def test_sarkka_bilmes_example_6(duration):
@@ -568,7 +570,7 @@ def test_sarkka_bilmes_example_6(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('PPPa','PPa','Pa','a'),)
+    step = (('PPPa', 'PPa', 'Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 3)
 
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -165,7 +165,7 @@ def test_markov_partial_sum_product(sum_op, prod_op, inputs, plates, time, step,
 ])
 def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time, step, vars1, vars2):
     inputs = inputs.split(',')
-    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[10]) for d in ds)) for ds in inputs]
+    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[5]) for d in ds)) for ds in inputs]
     plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)


### PR DESCRIPTION
This attempts to generalize `partial_sum_product` to support elimination of markov variables following discussion with @eb8680 and @fritzo at pyro-ppl/pyro#2687.

**TODO**
- [x] `modified_partial_sum_product` that eliminates first-order markov variables using parallel-scan algorithm.
- [x] Add more tests
- [ ] <s>Rename `modified_partial_sum_product` or replace `partial_sum_product` by it?</s>

**Tests**
- [x] `_expected_modified_partial_sum_product` unrolls one markov  dim at a time
- [x] `test_modified_partial_sum_product_0`
- [x] `test_modified_partial_sum_product_1`
- [x] `test_modified_partial_sum_product_2`
- [x] `test_modified_partial_sum_product_3`
- [x] `test_modified_partial_sum_product_4`
- [x] `test_modified_partial_sum_product_5`
- [x] `test_modified_partial_sum_product_6`
- [x] `test_modified_partial_sum_product_7`: xfail `x` and `y` markov vars with different ordinals
- [x] `test_modified_partial_sum_product_8`
- [x] `test_modified_partial_sum_product_9`
- [x] `test_modified_partial_sum_product_10`
- [x] `test_modified_partial_sum_product_11`
- [x] `test_modified_partial_sum_product_12`: xfail `w_curr` in time plate but lower ordinal than `y` and `x` markov vars
- [x] `test_modified_partial_sum_product_13`
- [x] `test_modified_partial_sum_product_14`
- [x] `test_modified_partial_sum_product_15`: xfail `y` depends on two time dims `time` and `tones`
- [x] `test_modified_partial_sum_product_16`: `x_prev->y_curr` and `y_prev->x_curr`

**Note**
- Markov sites cannot be within local plates inside (see tests 2 and 10)

**Update**
- Added unrolling of markov vars in local plates to handle tests 2 and 10

**Useful links**
- pyro-ppl/funsor#167
- pyro-ppl/funsor#204
- pyro-ppl/funsor#293 
- pyro-ppl/numpyro#686
- pyro-ppl/funsor#399