### PR TITLE
Generalize sequential_sum_product to window size > 1 [WIP]

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -231,7 +231,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step=frozenset
     assert isinstance(window, int)
     assert all(len(s) == window + 1 for s in step)
 
-    if duration % window:
+    if window > 1 and duration % window:
         raise NotImplementedError("TODO handle partial windows")
 
     # create a new funsor of the length duration // window
@@ -252,7 +252,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step=frozenset
             new_trans = new_trans + trans(**{time: Slice(time, w, duration, window)}, **old_to_new)
         duration, trans, step = new_duration, new_trans, new_step
 
-    # variable renaming
+    # positional variable renaming
     # TODO optimize the code
     drop = tuple("_drop_{}_window_{}".format(i, w) for w in range(window) for i in range(len(step)))
     prev = tuple(s[w] for w in range(window) for s in step)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -134,7 +134,7 @@ def modified_partial_sum_product(
                 for k, v in step.items():
                     group_vars -= frozenset(k) | frozenset(v)
                 f = reduce(prod_op, group_factors).reduce(sum_op, group_vars)
-                f = modified_sequential_sum_product(sum_op, prod_op, f, Variable(time, f.inputs[time]), step)
+                f = modified_sequential_sum_product(sum_op, prod_op, f, time, step)
                 f = f.reduce(sum_op, frozenset(step.values()))
                 f = f.reduce(sum_op, frozenset(step.keys()))
             else:
@@ -243,19 +243,29 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
     return trans(**{time: 0})
 
 
-def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1):
+def modified_sequential_sum_product(sum_op, prod_op, trans, time, step=frozenset(), window=1):
     """
-    For a funsor ``trans`` with dimensions ``time``, ``prev`` and ``curr``,
-    computes a recursion equivalent to::
+    Parallel-scan algorithm. For :math:`\bigotimes` consists of
+    positional renaming of variables and contraction operations.
+    
+    .. math::
 
-        tail_time = 1 + arange("time", trans.inputs["time"].size - 1)
-        tail = sequential_sum_product(sum_op, prod_op,
-                                      trans(time=tail_time),
-                                      time, {"prev": "curr"})
-        return prod_op(trans(time=0)(curr="drop"), tail(prev="drop")) \
-           .reduce(sum_op, "drop")
+       a_{i} = f^{x_{wi-w+1} \dots x_{wi}}_{x_{wi-2w+1} \dots x_{wi-w}}
 
-    but does so efficiently in parallel in O(log(time)).
+       a_{i} \bigotimes a_{j} = f^{x_{wj-w+1} \dots x_{wj}}_{x_{wi-2w+1} \dots x_{wi-w}}
+
+       a_{t} \bigotimes a_{t+1} = f^{x_{wt+1} \dots x_{wt+w}}_{x_{wt-2w+1} \dots x_{wt-w}}
+
+    For `window == 1`:
+
+    .. math::
+
+       a_{i} = f^{x_{i}}_{x_{i-1}}
+
+       a_{i} \bigotimes a_{j} = f^{(x_{i},x_{j-1})}_{x_{i-1}} f^{x_{j}}_{(x_{i},x_{j-1})} = f^{x_{j}}_{x_{i-1}}
+
+       a_{t} \bigotimes a_{t+1} = f^{x_{t}}_{x_{t-1}} f^{x_{t+1}}_{x_{t}} = f^{x_{t+1}}_{x_{t-1}}
+    
 
     :param ~funsor.ops.AssociativeOp sum_op: A semiring sum operation.
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.
@@ -267,38 +277,44 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     assert isinstance(sum_op, AssociativeOp)
     assert isinstance(prod_op, AssociativeOp)
     assert isinstance(trans, Funsor)
-    assert isinstance(time, Variable)
+    # for compatibility with sequential_sum_product interface
+    if isinstance(time, Variable):
+        time, duration = time.name, time.output.size
+        if time in trans.inputs:
+            assert duration == trans.inputs[time].size
+    else:
+        duration = trans.inputs[time].size
     if isinstance(step, dict):
-        step = tuple(step.items())
+        step = frozenset(step.items())
+    assert isinstance(time, str)
+    assert isinstance(step, frozenset)
     assert isinstance(window, int)
     assert all(len(s) == window + 1 for s in step)
-    if time.name in trans.inputs:
-        assert time.output == trans.inputs[time.name]
-
-    time, duration = time.name, time.output.size
 
     if duration % window:
         raise NotImplementedError("TODO handle partial windows")
 
+    # create a new funsor of the length duration // window
     if window > 1:
         new_duration = duration // window
         new_trans = Number(0., 'real')
+        new_step = frozenset()
+        new_to_old = {}
+        for seq in step:
+            new_seq = tuple(''.join(seq[max(0, i+1-window):i+1]) for i in range(window*2))
+            new_step |= frozenset({new_seq})
+            new_to_old.update(zip(new_seq, seq))
         for w in range(window):
             old_to_new = {}
             for values in step:
                 for i, v in enumerate(values):
                     old_to_new[v] = ''.join(values[max(0, i+w+1-window):i+w+1])
             new_trans = new_trans + trans(**{time: Slice(time, w, duration, window)}, **old_to_new)
-        new_step = []
-        for s in step:
-            new_step.append(tuple(''.join(s[max(0, i+1-window):i+1]) for i in range(window*2)))
-        new_to_old = {}
-        for (new, old) in zip(new_step, step):
-            new_to_old.update(zip(new, old))
         duration = new_duration
         trans = new_trans
         step = new_step
 
+    # variable renaming
     drop = tuple("_drop_{}_window_{}".format(i, w) for w in range(window) for i in range(len(step)))
     prev = tuple(s[w] for w in range(window) for s in step)
     curr = tuple(s[window+w] for w in range(window) for s in step)
@@ -306,6 +322,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     curr_to_drop = dict(zip(curr, drop))
     drop = frozenset(prev_to_drop.values())
 
+    # parallel-scan contraction
     while duration > 1:
         even_duration = duration // 2 * 2
         x = trans(**{time: Slice(time, 0, even_duration, 2, duration)}, **curr_to_drop)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -282,7 +282,7 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
 
     if window > 1:
         new_duration = duration // window
-        new_trans = Number(0., 'real') 
+        new_trans = Number(0., 'real')
         for w in range(window):
             old_to_new = {}
             for values in step:

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -290,19 +290,19 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
 
     if window > 1:
         new_duration = duration // window
-        new_trans = Number(0., 'real') 
+        new_trans = Number(0., 'real')
         for w in range(window):
             old_to_new = {}
             for values in step:
                 for i, v in enumerate(values):
-                    old_to_new[v] = ''.join(values[max(0,i+w+1-window):i+w+1])
+                    old_to_new[v] = ''.join(values[max(0, i+w+1-window):i+w+1])
             new_trans = new_trans + trans(**{time: Slice(time, w, duration, window)}, **old_to_new)
         new_step = []
         for s in step:
-            new_step.append(tuple(''.join(s[max(0,i+1-window):i+1]) for i in range(window*2)))
+            new_step.append(tuple(''.join(s[max(0, i+1-window):i+1]) for i in range(window*2)))
         new_to_old = {}
         for (new, old) in zip(new_step, step):
-            new_to_old.update(zip(new,old))
+            new_to_old.update(zip(new, old))
         duration = new_duration
         trans = new_trans
         step = new_step
@@ -313,7 +313,6 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
     prev_to_drop = dict(zip(prev, drop))
     curr_to_drop = dict(zip(curr, drop))
     drop = frozenset(prev_to_drop.values())
-
 
     while duration > 1:
         even_duration = duration // 2 * 2
@@ -326,7 +325,9 @@ def modified_sequential_sum_product(sum_op, prod_op, trans, time, step, window=1
             contracted = Cat(time, (contracted, extra))
         trans = contracted
         duration = (duration + 1) // 2
-    curr_to_drop = frozenset(key for (key,value) in curr_to_drop.items() if not value.endswith('_window_{}'.format(window-1)))
+    curr_to_drop = frozenset(
+            key for (key, value) in curr_to_drop.items()
+            if not value.endswith('_window_{}'.format(window-1)))
     trans = trans.reduce(sum_op, curr_to_drop)
     if window > 1:
         trans = trans(**new_to_old)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -184,10 +184,10 @@ def sequential_sum_product(sum_op, prod_op, trans, time, step):
 
 
 def modified_sequential_sum_product(sum_op, prod_op, trans, time, step=frozenset(), window=1):
-    """
+    r"""
     Parallel-scan algorithm. For :math:`\bigotimes` consisting of
     positional renaming of variables and contraction operations.
-    
+
     .. math::
 
        a_{i} = f^{x_{wi-w+1} \dots x_{wi}}_{x_{wi-2w+1} \dots x_{wi-w}}

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -404,7 +404,7 @@ def _check_modified_sequential(trans, expected_inputs, global_vars, step, window
     duration = trans.inputs["time"].dtype
     time_var = Variable("time", Bint[duration])
 
-    actual = modified_sequential_sum_product(sum_op, prod_op, trans, time_var, step, window)
+    actual = modified_sequential_sum_product(sum_op, prod_op, trans, "time", step, window)
 
     expected = naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars)
     assert dict(expected.inputs) == expected_inputs
@@ -446,7 +446,7 @@ def test_sarkka_bilmes_example_1(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('Pa', 'a'), ('Pb', 'b'))
+    step = frozenset({('Pa', 'a'), ('Pb', 'b')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 1)
 
 
@@ -473,7 +473,7 @@ def test_sarkka_bilmes_example_2(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c'))
+    step = frozenset({('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -496,7 +496,7 @@ def test_sarkka_bilmes_example_3(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c'))
+    step = frozenset({('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -519,7 +519,7 @@ def test_sarkka_bilmes_example_4(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPPa', 'PPa', 'Pa', 'a'),)
+    step = frozenset({('PPPa', 'PPa', 'Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 3)
 
 
@@ -543,7 +543,7 @@ def test_sarkka_bilmes_example_5(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('Pa', 'a'),)
+    step = frozenset({('Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 1)
 
 
@@ -570,7 +570,7 @@ def test_sarkka_bilmes_example_6(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('PPPa', 'PPa', 'Pa', 'a'),)
+    step = frozenset({('PPPa', 'PPa', 'Pa', 'a')})
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 3)
 
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -195,7 +195,7 @@ def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time,
                 unrolled_factors.append(f(**arg_to_time))
         else:
             unrolled_factors.append(f)
-            # unrolled_plates |= I
+
     unrolled_vars = frozenset()
     for f in unrolled_factors:
         unrolled_vars |= frozenset(f.inputs)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -325,6 +325,9 @@ def test_sarkka_bilmes_example_0(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
+    step = frozenset({('a')})
+    _check_modified_sequential(trans, expected_inputs, frozenset(), step, 0)
+
 
 @pytest.mark.parametrize("duration", [2, 3, 4, 5, 6])
 def test_sarkka_bilmes_example_1(duration):

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -118,7 +118,7 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 ])
 def test_markov_partial_sum_product(sum_op, prod_op, inputs, plates, time, step, vars1, vars2):
     inputs = inputs.split(',')
-    factors = [random_tensor(OrderedDict((d, Bint[2]) if d!='t' else (d, Bint[10]) for d in ds)) for ds in inputs]
+    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[10]) for d in ds)) for ds in inputs]
     plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)
@@ -166,7 +166,7 @@ def test_markov_partial_sum_product(sum_op, prod_op, inputs, plates, time, step,
 ])
 def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time, step, vars1, vars2):
     inputs = inputs.split(',')
-    factors = [random_tensor(OrderedDict((d, Bint[2]) if d!='t' else (d, Bint[10]) for d in ds)) for ds in inputs]
+    factors = [random_tensor(OrderedDict((d, Bint[2]) if d != 't' else (d, Bint[10]) for d in ds)) for ds in inputs]
     plates = frozenset(plates)
     vars1 = frozenset(vars1)
     vars2 = frozenset(vars2)
@@ -202,6 +202,7 @@ def test_markov_partial_sum_product_multi(sum_op, prod_op, inputs, plates, time,
     expected = sum_product(sum_op, prod_op, unrolled_factors, unrolled_vars, unrolled_plates)
 
     assert_close(actual, expected)
+
 
 @pytest.mark.parametrize('num_steps', [None] + list(range(1, 13)))
 @pytest.mark.parametrize('sum_op,prod_op,state_domain', [
@@ -445,7 +446,7 @@ def test_sarkka_bilmes_example_1(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('Pa','a'),('Pb','b'))
+    step = (('Pa', 'a'), ('Pb', 'b'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 1)
 
 
@@ -472,7 +473,7 @@ def test_sarkka_bilmes_example_2(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa','Pa','a'),('PPb','Pb','b'),('PPc','Pc','c'))
+    step = (('PPa', 'Pa', 'a'), ('PPb', 'Pb', 'b'), ('PPc', 'Pc', 'c'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -495,7 +496,7 @@ def test_sarkka_bilmes_example_3(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPa','Pa','a'),('PPc','Pc','c'))
+    step = (('PPa', 'Pa', 'a'), ('PPc', 'Pc', 'c'))
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 2)
 
 
@@ -518,7 +519,7 @@ def test_sarkka_bilmes_example_4(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
-    step = (('PPPa','PPa','Pa','a'),)
+    step = (('PPPa', 'PPa', 'Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, frozenset(), step, 3)
 
 
@@ -542,8 +543,9 @@ def test_sarkka_bilmes_example_5(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('Pa','a'),)
+    step = (('Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 1)
+
 
 @pytest.mark.parametrize("duration", [3, 6, 9])
 def test_sarkka_bilmes_example_6(duration):
@@ -568,7 +570,7 @@ def test_sarkka_bilmes_example_6(duration):
 
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
-    step = (('PPPa','PPa','Pa','a'),)
+    step = (('PPPa', 'PPa', 'Pa', 'a'),)
     _check_modified_sequential(trans, expected_inputs, global_vars, step, 3)
 
 


### PR DESCRIPTION
`modified_sequential_sum_product` that generalizes `sequential_sum_product` to window size > 1; splitting from #398. This should be analogous to `sarkka_bilmes_product` (?) with a benefit of having an interface compatible with `sequential_sum_product`. Potentially might be useful to generalize #398 to higher order markov models.

**Interface**

- Backward compatible with `sequential_sum_product` interface
- Accepts `time` as str or Variable
- Accepts `step` as dict or frozenset({time-ordered sequence of names for a markov site})
- Variable names in `step` can be arbitrary

**Tests**

- [x] `test_sarkka_bilmes_example_[0-6]`
- [ ] `test_sarkka_bilmes_generic`

**Useful links**

- pyro-ppl/funsor#167
- pyro-ppl/funsor#293 
- pyro-ppl/numpyro#686