### PR TITLE
Update modified_partial_sum_product to use MarkovProduct and add test

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -167,7 +167,7 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
                         raise ValueError("intractable!")
                 time_var = Variable(time, f.inputs[time])
                 group_step = {k: v for (k, v) in plate_to_step[time].items() if v in markov_vars}
-                f = sequential_sum_product(sum_op, prod_op, f, time_var, group_step)
+                f = MarkovProduct(sum_op, prod_op, f, time_var, group_step)
                 f = f.reduce(sum_op, frozenset(group_step.keys()) | frozenset(group_step.values()))
 
             remaining_sum_vars = sum_vars.intersection(f.inputs)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -210,7 +210,7 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2]
-    plate_to_step = dict({"time": {"x_prev": "x_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr"}}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -219,7 +219,7 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset()}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x"}})
+    markov_to_step = {"time": {"x"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -258,7 +258,7 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({"time": {"x_prev": "x_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr"}}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -267,7 +267,7 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset({"y_curr"})}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x"}})
+    markov_to_step = {"time": {"x"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -304,7 +304,7 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr", "y_prev": "y_curr"}}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -313,7 +313,7 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset()}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x", "y"}})
+    markov_to_step = {"time": {"x", "y"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -351,7 +351,7 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr", "y_prev": "y_curr"}}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -360,7 +360,7 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset()}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x", "y"}})
+    markov_to_step = {"time": {"x", "y"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -402,11 +402,11 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -415,7 +415,7 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset()}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x", "y"}})
+    markov_to_step = {"time": {"x", "y"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -464,12 +464,12 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "tones": {},
         "days": {"x_prev": "x_curr"},
         "weeks": {"y_prev": "y_curr"}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -478,7 +478,7 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"days": frozenset(), "weeks": frozenset()}
     local_markov_var_dict = {"days": frozenset(), "weeks": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"days": {"x"}, "weeks": {"y"}})
+    markov_to_step = {"days": {"x"}, "weeks": {"y"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -522,11 +522,11 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr"},
         "tones": {}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -535,7 +535,7 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset({"y_curr"})}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x"}})
+    markov_to_step = {"time": {"x"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -578,11 +578,11 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
-    })
+    }
 
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -636,11 +636,11 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -649,7 +649,7 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset({"y_curr"})}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x", "w"}})
+    markov_to_step = {"time": {"x", "w"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -658,7 +658,7 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
 
 
-@pytest.mark.parametrize("use_lazy", [False, True])
+@pytest.mark.parametrize("use_lazy", [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
      frozenset({"sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
@@ -703,11 +703,11 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
-    })
+    }
 
     with interpretation(lazy if use_lazy else eager):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -722,9 +722,9 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
         "time": frozenset(),
     }
     global_vars = frozenset()
-    markov_to_step = dict({
+    markov_to_step = {
         "time": {"x", "w"},
-    })
+    }
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -779,11 +779,11 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr"},
         "tones": {}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -796,9 +796,9 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
         "time": frozenset(),
     }
     global_vars = frozenset()
-    markov_to_step = dict({
+    markov_to_step = {
         "time": {"x"},
-    })
+    }
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -807,7 +807,7 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
 
 
-@pytest.mark.parametrize('use_lazy', [False, True])
+@pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
      frozenset({"a", "b", "sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
@@ -866,11 +866,11 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     factors = [f, g, h, i, j, k]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "w_prev": "w_curr"},
         "tones": {}
-    })
+    }
 
     with interpretation(lazy if use_lazy else eager):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -881,7 +881,7 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     local_var_dict = {"time": frozenset({"y_curr"})}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset({"a", "b"})
-    markov_to_step = dict({"time": {"x", "w"}})
+    markov_to_step = {"time": {"x", "w"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -936,11 +936,11 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3, f4]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {}
-    })
+    }
 
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -948,7 +948,7 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
         reduce(prod_op, factors2)
 
 
-@pytest.mark.parametrize('use_lazy', [False, True])
+@pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
      frozenset({"sequences", "w", "days", "tones", "x_prev", "x_curr", "weeks", "y_prev", "y_curr"})),
@@ -993,12 +993,12 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "tones": {},
         "days": {"x_prev": "x_curr"},
         "weeks": {"y_prev": "y_curr"}
-    })
+    }
 
     with interpretation(lazy if use_lazy else eager):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -1015,10 +1015,10 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
         "weeks": frozenset()
     }
     global_vars = frozenset({"w"})
-    markov_to_step = dict({
+    markov_to_step = {
         "days": {"x"},
         "weeks": {"y"},
-    })
+    }
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -1066,11 +1066,11 @@ def test_modified_partial_sum_product_14(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f, g, h]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr"},
         "tones": {"y_prev": "y_curr"}
-    })
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -1085,10 +1085,10 @@ def test_modified_partial_sum_product_14(sum_op, prod_op, vars1, vars2,
         "tones": frozenset()
     }
     global_vars = frozenset()
-    markov_to_step = dict({
+    markov_to_step = {
         "time": {"x"},
         "tones": {"y"},
-    })
+    }
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -1134,11 +1134,11 @@ def test_modified_partial_sum_product_15(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f, g, h]
-    plate_to_step = dict({
+    plate_to_step = {
         "sequences": {},
         "time": {"x_prev": "x_curr", "y_prev": "y_curr"},
         "tones": {"y_prev": "y_curr"}
-    })
+    }
 
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -1174,7 +1174,7 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = dict({"time": {"x_prev": "x_curr", "y_prev": "y_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr", "y_prev": "y_curr"}}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -1183,7 +1183,7 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     local_var_dict = {"time": frozenset()}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x", "y"}})
+    markov_to_step = {"time": {"x", "y"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,
@@ -1192,7 +1192,7 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
 
 
-@pytest.mark.parametrize('use_lazy', [True, False])
+@pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
      frozenset({"time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"})),
@@ -1240,7 +1240,7 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     factors = [f1, f2, f3_1, f3_2, f3_3]
-    plate_to_step = dict({"time": {"x_prev": "x_curr"}})
+    plate_to_step = {"time": {"x_prev": "x_curr"}}
 
     with interpretation(lazy if use_lazy else eager):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -1251,7 +1251,7 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     local_var_dict = {"time": frozenset({"y_curr", "z0", "z1", "z2"})}
     local_markov_var_dict = {"time": frozenset()}
     global_vars = frozenset()
-    markov_to_step = dict({"time": {"x"}})
+    markov_to_step = {"time": {"x"}}
 
     expected = _expected_modified_partial_sum_product(
         sum_op, prod_op, factors, plate_to_step, global_vars,


### PR DESCRIPTION
Addresses #293. ~~Blocked by #401.~~

This PR replaces `sequential_sum_product` in @ordabayevy's `funsor.sum_product.modified_partial_sum_product` from #398 with `MarkovProduct` and adds a test verifying that the result is compatible with `funsor.optimizer.apply_optimizer`.