### PR TITLE
Disable validation in VAE example

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -50,6 +50,10 @@ class Decoder(nn.Module):
 def main(args):
     funsor.set_backend("torch")
 
+    # XXX Temporary fix after https://github.com/pyro-ppl/pyro/pull/2701
+    import pyro
+    pyro.enable_validation(False)
+
     encoder = Encoder()
     decoder = Decoder()
 


### PR DESCRIPTION
Blocking all other PRs from being merged because it fixes a Travis failure.

The recent Pyro PR https://github.com/pyro-ppl/pyro/pull/2701 enabled validation (`pyro.enable_validation(True)`) by default. This change uncovered an error in the VAE example `examples/vae.py` (see traceback) caused by the inconsistent behavior of `torch.distributions.Bernoulli`, whose `.support` is apparently `Boolean`.

Ideally we would either fix `torch.distributions.Bernoulli` so its `.support` agrees with `.log_prob` or make `funsor.distributions.torch.Bernoulli` reflect the idiosyncrasies of PyTorch, but to unblock #400 this PR just disables validation in `examples/vae.py`.

Traceback from #400:
<details>
```
Traceback (most recent call last):

  File "examples/vae.py", line 113, in <module>

    main(args)

  File "examples/vae.py", line 95, in main

    loss = loss_function(data, subsample_scale)

  File "/opt/python/3.6.7/lib/python3.6/contextlib.py", line 52, in inner

    return func(*args, **kwds)

  File "examples/vae.py", line 73, in loss_function

    elbo = funsor.Integrate(q, p - q, 'z')

  File "/home/travis/build/pyro-ppl/funsor/funsor/integrate.py", line 33, in __call__

    return super().__call__(log_measure, integrand, reduced_vars)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 224, in __call__

    return interpret(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 364, in __call__

    return self.dispatch(cls, *args)(self, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/montecarlo.py", line 36, in monte_carlo_integrate

    return Integrate(sample, integrand, reduced_vars)

  File "/home/travis/build/pyro-ppl/funsor/funsor/integrate.py", line 33, in __call__

    return super().__call__(log_measure, integrand, reduced_vars)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 224, in __call__

    return interpret(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 119, in eager

    result = normalize.dispatch(cls, *args)(*args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/integrate.py", line 83, in normalize_integrate_contraction

    integrand = integrand(**{name: point for name, (point, log_density) in delta.terms

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 408, in __call__

    return Subs(self, tuple(subs.items()))

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 871, in __call__

    return super().__call__(arg, subs)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 224, in __call__

    return interpret(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 117, in eager

    result = eager.dispatch(cls, *args)(*args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 937, in eager_subs

    return substitute(arg, subs)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 41, in substitute

    return interpreter.reinterpret(expr)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 312, in reinterpret

    return recursion_reinterpret(x)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/functools.py", line 807, in wrapper

    return dispatch(args[0].__class__)(*args, **kw)

  File "/home/travis/build/pyro-ppl/funsor/funsor/cnf.py", line 184, in recursion_reinterpret_contraction

    return type(x)(*map(recursion_reinterpret, (x.red_op, x.bin_op, x.reduced_vars) + x.terms))

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/functools.py", line 807, in wrapper

    return dispatch(args[0].__class__)(*args, **kw)

  File "/home/travis/build/pyro-ppl/funsor/funsor/cnf.py", line 184, in recursion_reinterpret_contraction

    return type(x)(*map(recursion_reinterpret, (x.red_op, x.bin_op, x.reduced_vars) + x.terms))

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/functools.py", line 807, in wrapper

    return dispatch(args[0].__class__)(*args, **kw)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 144, in reinterpret_funsor

    return _INTERPRETATION(type(x), *map(recursion_reinterpret, x._ast_values))

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/opt/python/3.6.7/lib/python3.6/contextlib.py", line 52, in inner

    return func(*args, **kwds)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 34, in subs_interpreter

    expr = cls(*args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/distribution.py", line 66, in __call__

    return super(DistributionMeta, cls).__call__(*args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 224, in __call__

    return interpret(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/interpreter.py", line 318, in __call__

    result = interpreter(cls, *args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/terms.py", line 117, in eager

    result = eager.dispatch(cls, *args)(*args)

  File "/home/travis/build/pyro-ppl/funsor/funsor/distribution.py", line 106, in eager_log_prob

    data = cls.dist_class(**params).log_prob(value)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/torch/distributions/bernoulli.py", line 93, in log_prob

    self._validate_sample(value)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/torch/distributions/distribution.py", line 253, in _validate_sample

    raise ValueError('The value argument must be within the support')

ValueError: The value argument must be within the support
```
</details>