### PR TITLE
Update distribution shape inference to handle independent dims

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -453,9 +453,11 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
     for param_name, funsor_param in zip(funsor_dist._ast_fields, funsor_dist._ast_values[:-1]):
         param = to_data(funsor_param, name_to_dim=name_to_dim)
 
+        # infer the independent dimensions of each parameter separately, since we chose to keep them unbroadcasted
         param_event_shape = getattr(funsor_dist._infer_param_domain(param_name, funsor_param.output.shape), "shape", ())
         param_indep_shape = funsor_param.output.shape[:len(funsor_param.output.shape) - len(param_event_shape)]
         for i in range(max(0, len(indep_shape) - len(param_indep_shape))):
+            # add singleton event dimensions, leave broadcasting/expanding to backend
             param = ops.unsqueeze(param, -1 - len(funsor_param.output.shape))
 
         params.append(param)

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -16,7 +16,7 @@ import funsor.delta
 import funsor.ops as ops
 from funsor.affine import is_affine
 from funsor.cnf import Contraction, GaussianMixture
-from funsor.domains import Array, BintType, Real, Reals, RealsType
+from funsor.domains import Array, Real, Reals, RealsType
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import (Tensor, align_tensors, dummy_numeric_array, get_default_prototype,

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -163,7 +163,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         inputs = OrderedDict()
         for x in params[:-1] + (value,):
             inputs.update(x.inputs)
-        return log_prob.align(inputs)
+        return log_prob.align(tuple(inputs))
 
     def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
 
@@ -451,7 +451,7 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
     }, validate_args=False)
     event_shape = broadcast_shape(instance.event_shape, funsor_dist.value.output.shape)
     reinterpreted_batch_ndims = len(event_shape) - len(instance.event_shape)
-    assert reinterpreted_batch_ndims > 0  # XXX is this ever nonzero?
+    assert reinterpreted_batch_ndims >= 0  # XXX is this ever nonzero?
     indep_shape = broadcast_shape(instance.batch_shape, event_shape[:reinterpreted_batch_ndims])
 
     params = []

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -158,9 +158,9 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         name_to_dim.update({v: k for k, v in dim_to_name.items() if v not in name_to_dim})
         raw_log_prob = raw_dist.log_prob(to_data(value, name_to_dim=name_to_dim))
         log_prob = to_funsor(raw_log_prob, Real, dim_to_name=dim_to_name)
-        inputs = value.inputs.copy()
-        inputs.update(instance.inputs)
-        return log_prob.align(tuple(k for k, v in inputs.items() if k in log_prob.inputs and isinstance(v, BintType)))
+        # final align() ensures that the inputs have the canonical order
+        # implied by align_tensors, which is assumed pervasively in tests
+        return log_prob.align(tuple(align_tensors(*(params[:-1] + (value,)))[0]))
 
     def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -175,8 +175,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         sample_shape = tuple(v.size for v in sample_inputs.values())
         sample_args = (sample_shape,) if get_backend() == "torch" else (rng_key, sample_shape)
         if self.has_rsample:
-            # TODO fix this hack by adding rsample and has_rsample to Independent upstream in NumPyro
-            raw_value = getattr(raw_dist, "rsample", raw_dist.sample)(*sample_args)
+            raw_value = raw_dist.rsample(*sample_args)
         else:
             raw_value = ops.detach(raw_dist.sample(*sample_args))
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -436,14 +436,12 @@ def distribution_to_data(funsor_dist, name_to_dim=None):
     funsor_event_shape = funsor_dist.value.output.shape
     params = []
     for param_name, funsor_param in zip(funsor_dist._ast_fields, funsor_dist._ast_values[:-1]):
-        import pdb; pdb.set_trace()
         param = to_data(funsor_param, name_to_dim=name_to_dim)
         for i in range(max(0, len(funsor_event_shape) - len(funsor_param.output.shape))):
             param = param.unsqueeze(-1 - len(funsor_param.output.shape))
         params.append(param)
     pyro_dist = funsor_dist.dist_class(**dict(zip(funsor_dist._ast_fields[:-1], params)))
     pyro_dist = pyro_dist.to_event(max(len(funsor_event_shape) - len(pyro_dist.event_shape), 0))
-    import pdb; pdb.set_trace()
 
     # TODO get this working for all backends
     if not isinstance(funsor_dist.value, Variable):

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -173,7 +173,8 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         sample_shape = tuple(v.size for v in sample_inputs.values())
         sample_args = (sample_shape,) if get_backend() == "torch" else (rng_key, sample_shape)
         if self.has_rsample:
-            raw_value = raw_dist.rsample(*sample_args)
+            # TODO fix this hack by adding rsample and has_rsample to Independent upstream in NumPyro
+            raw_value = getattr(raw_dist, "rsample", raw_dist.sample)(*sample_args)
         else:
             raw_value = ops.detach(raw_dist.sample(*sample_args))
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -74,6 +74,8 @@ class DistributionMeta(FunsorMeta):
             # this avoids .expand-ing underlying parameter tensors
             if isinstance(v, Funsor) and isinstance(v.output, RealsType):
                 domains[k] = Reals[broadcast_shape(v.shape, domains[k].shape)]
+            elif ops.is_numeric_array(v):
+                domains[k] = Reals[broadcast_shape(v.shape, domains[k].shape)]
 
         # now use the broadcasted parameter shapes to infer the event_shape
         domains["value"] = cls._infer_value_domain(**domains)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -200,7 +200,7 @@ def _infer_param_domain(cls, name, raw_shape):
 
 
 ###########################################################
-# Converting distribution funsors to PyTorch distributions
+# Converting distribution funsors to NumPyro distributions
 ###########################################################
 
 # Convert Delta **distribution** to raw data
@@ -212,9 +212,10 @@ def deltadist_to_data(funsor_dist, name_to_dim=None):
 
 
 ###############################################
-# Converting PyTorch Distributions to funsors
+# Converting NumPyro Distributions to funsors
 ###############################################
 
+# TODO move these properties upstream to numpyro.distributions
 dist.Independent.has_rsample = property(lambda self: self.base_dist.has_rsample)
 dist.Independent.rsample = dist.Independent.sample
 dist.MaskedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -215,6 +215,13 @@ def deltadist_to_data(funsor_dist, name_to_dim=None):
 # Converting PyTorch Distributions to funsors
 ###############################################
 
+dist.Independent.has_rsample = property(lambda self: self.base_dist.has_rsample)
+dist.Independent.rsample = dist.Independent.sample
+dist.MaskedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
+dist.MaskedDistribution.rsample = dist.MaskedDistribution.sample
+dist.TransformedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
+dist.TransformedDistribution.rsample = dist.TransformedDistribution.sample
+
 to_funsor.register(dist.Independent)(indepdist_to_funsor)
 if hasattr(dist, "MaskedDistribution"):
     to_funsor.register(dist.MaskedDistribution)(maskeddist_to_funsor)

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -137,7 +137,7 @@ def _infer_value_domain(**kwargs):
 @functools.lru_cache(maxsize=5000)
 def _infer_value_domain(cls, **kwargs):
     instance = cls.dist_class(**{k: dummy_numeric_array(domain) for k, domain in kwargs.items()}, validate_args=False)
-    return Reals[instance.event_shape]
+    return Reals[instance.batch_shape + instance.event_shape]
 
 
 # TODO fix Delta.arg_constraints["v"] to be a

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -246,7 +246,7 @@ def test_dirichlet_density(batch_shape, event_shape):
     check_funsor(expected, inputs, Real)
     actual = dist.Dirichlet(concentration, value)
     check_funsor(actual, inputs, Real)
-    assert_close(actual, expected, atol=1e-3)
+    assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1144,7 +1144,8 @@ def test_normal_event_dim_conversion(batch_shape, event_shape):
     check_funsor(actual, expected_inputs, Real)
 
     name_to_dim = {batch_dim: -1-i for i, batch_dim in enumerate(batch_dims)}
-    data = actual.sample(frozenset(["value"])).terms[0][1][0]
+    rng_key = None if get_backend() == "torch" else np.array([0, 0], dtype=np.uint32)
+    data = actual.sample(frozenset(["value"]), rng_key=rng_key).terms[0][1][0]
 
     actual_log_prob = funsor.to_data(actual(value=data), name_to_dim=name_to_dim)
     expected_log_prob = funsor.to_data(actual, name_to_dim=name_to_dim).log_prob(
@@ -1172,7 +1173,8 @@ def test_mvnormal_event_dim_conversion(batch_shape, event_shape):
     check_funsor(actual, expected_inputs, Real)
 
     name_to_dim = {batch_dim: -1-i for i, batch_dim in enumerate(batch_dims)}
-    data = actual.sample(frozenset(["value"])).terms[0][1][0]
+    rng_key = None if get_backend() == "torch" else np.array([0, 0], dtype=np.uint32)
+    data = actual.sample(frozenset(["value"]), rng_key=rng_key).terms[0][1][0]
 
     actual_log_prob = funsor.to_data(actual(value=data), name_to_dim=name_to_dim)
     expected_log_prob = funsor.to_data(actual, name_to_dim=name_to_dim).log_prob(

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1127,7 +1127,8 @@ def test_gamma_poisson_conjugate(batch_shape):
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('event_shape', [(4,), (4, 7), (1, 4), (4, 1), (4, 1, 7)], ids=str)
-def test_normal_event_dim_conversion(batch_shape, event_shape):
+@pytest.mark.parametrize('use_raw_scale', [False, True])
+def test_normal_event_dim_conversion(batch_shape, event_shape, use_raw_scale):
 
     batch_dims = ('i', 'j', 'k')[:len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
@@ -1135,6 +1136,10 @@ def test_normal_event_dim_conversion(batch_shape, event_shape):
     value = Variable("value", Reals[event_shape])
     loc = Tensor(randn(batch_shape + event_shape), inputs)
     scale = Tensor(ops.exp(randn(batch_shape)), inputs)
+    if use_raw_scale:
+        if batch_shape:
+            pytest.xfail(reason="raw scale is underspecified for nonempty batch_shape")
+        scale = scale.data
 
     with interpretation(lazy):
         actual = dist.Normal(loc=loc, scale=scale, value=value)

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -246,7 +246,7 @@ def test_dirichlet_density(batch_shape, event_shape):
     check_funsor(expected, inputs, Real)
     actual = dist.Dirichlet(concentration, value)
     check_funsor(actual, inputs, Real)
-    assert_close(actual, expected)
+    assert_close(actual, expected, atol=1e-4)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -246,7 +246,7 @@ def test_dirichlet_density(batch_shape, event_shape):
     check_funsor(expected, inputs, Real)
     actual = dist.Dirichlet(concentration, value)
     check_funsor(actual, inputs, Real)
-    assert_close(actual, expected, atol=1e-4)
+    assert_close(actual, expected, atol=1e-3)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (5,), (2, 3)], ids=str)

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -496,8 +496,7 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    actual_logprob = funsor_dist(value=funsor_value)
-    assert_close(actual_logprob, expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
+    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -459,7 +459,6 @@ def test_generic_distribution_to_funsor(case):
         funsor_dist = [term for term in funsor_dist.terms
                        if isinstance(term, (funsor.distribution.Distribution, funsor.terms.Independent))][0]
 
-    import pdb; pdb.set_trace()
     actual_dist = to_data(funsor_dist, name_to_dim=name_to_dim)
 
     assert isinstance(actual_dist, backend_dist.Distribution)
@@ -497,7 +496,7 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    actual_logprob = funsor_dist(value=funsor_value).align(tuple(expected_logprob.inputs))
+    actual_logprob = funsor_dist(value=funsor_value)
     assert_close(actual_logprob, expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
 
 

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -459,6 +459,7 @@ def test_generic_distribution_to_funsor(case):
         funsor_dist = [term for term in funsor_dist.terms
                        if isinstance(term, (funsor.distribution.Distribution, funsor.terms.Independent))][0]
 
+    import pdb; pdb.set_trace()
     actual_dist = to_data(funsor_dist, name_to_dim=name_to_dim)
 
     assert isinstance(actual_dist, backend_dist.Distribution)
@@ -496,7 +497,8 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
+    actual_logprob = funsor_dist(value=funsor_value).align(tuple(expected_logprob.inputs))
+    assert_close(actual_logprob, expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)


### PR DESCRIPTION
Addresses #386, https://github.com/pyro-ppl/pyro/pull/2702

Consider the following snippet of Pyro code simplified from a test in https://github.com/pyro-ppl/pyro/pull/2702 :
```py
with pyro.plate("data", T, dim=-1):
    y = pyro.sample("y", dist.Normal(torch.ones(3), 1.).to_event(1))
    pyro.sample("z", dist.Normal(y, 1.).to_event(1), obs=data)
```
Attempting to wrap this in a `poutine.collapse()` context fails when `dist.Normal(y, 1)` is incorrectly converted to a Funsor. In particular, there is a mismatch between `y.output`, which is `Reals[3]` and the `.output` value `Real` expected for the `loc` param of `funsor.torch.distributions.Normal` given by `funsor.distribution.Distribution._infer_value_domain`.

In cases like the above, however, it is always possible to infer the correct parameter and value `.output` shapes generically using the broadcasting logic in the underlying backend distribution.  This PR implements this behavior in `funsor.distribution.DistributionMeta.__call__` and `distribution_to_data`.  

As a result, it is possible after this PR to represent `Independent` distributions without an intermediary `funsor.Independent` by passing a `Variable` with extra output dimensions as the `value`:
```py
# diagonal multivariate normal in pyro:
dist.Normal(zeros(3), 1.).to_event(1)

# funsor equivalent, after this PR - note Reals[3] for x
Normal(loc=zeros(3), scale=1., value=Variable("x", Reals[3]))
```
This should considerably simplify pattern-matching over `Independent` distributions.

To make this work, converting a `funsor.distribution.Distribution` to data via `funsor.to_data` will have to include a step handling nontrivial event shapes by calling `.to_event` and unsqueezing parameters.

More ambitiously, we could also attempt to handle `to_funsor` conversion of backend `Independent` distributions by substituting an appropriately shaped `Variable` for their value rather than resorting to lazy application of `funsor.terms.Independent`, which would make pattern-matching for `collapse`ing multivariate distributions much easier, but it's not clear yet whether this can be done generically, especially in the presence of transforms.  I have not attempted to do this in this PR.

Tasks:
- [x] Update `funsor.distribution.DistributionMeta`
- [x] Update `distribution_to_data`
- [x] Add tests
- [x] Fix `DirichletMultinomial` broadcasting errors