### PR TITLE
Partial unrolling of plated factor graphs to standard factor graphs

### DIFF
--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -81,9 +81,9 @@ def test_partition(inputs, dims, expected_num_components):
 @pytest.mark.parametrize('sum_op,prod_op', [(ops.add, ops.mul), (ops.logaddexp, ops.add)])
 @pytest.mark.parametrize('inputs,plates', [('a,abi,bcij', 'ij')])
 @pytest.mark.parametrize('vars1,vars2', [
-    ('cj', 'abi'),
     ('', 'abcij'),
     ('c', 'abij'),
+    ('cj', 'abi'),
     ('bcj', 'ai'),
     ('bcij', 'a'),
     ('abcij', ''),

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -111,9 +111,9 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
     assert_close(actual, expected)
 
     unrolled_factors1, unrolled_vars1, remaining_plates = \
-            partial_unroll(factors, vars1, frozenset(plates))
+        partial_unroll(factors, vars1, frozenset(plates))
     unrolled_factors2, unrolled_vars2, _ = \
-            partial_unroll(unrolled_factors1, vars2 | unrolled_vars1, remaining_plates)
+        partial_unroll(unrolled_factors1, vars2 | unrolled_vars1, remaining_plates)
     unrolled_expected = reduce(prod_op, unrolled_factors2).reduce(sum_op, unrolled_vars2)
     assert_close(actual, unrolled_expected)
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -15,6 +15,7 @@ from funsor.optimizer import apply_optimizer
 from funsor.sum_product import (
     MarkovProduct,
     _partition,
+    partial_unroll,
     mixed_sequential_sum_product,
     naive_sarkka_bilmes_product,
     naive_sequential_sum_product,
@@ -108,6 +109,11 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 
     expected = sum_product(sum_op, prod_op, factors, vars1 | vars2, frozenset(plates))
     assert_close(actual, expected)
+
+    unrolled_factors1, _ = partial_unroll(factors, vars1 & frozenset(plates))
+    unrolled_factors2, reduce_vars = partial_unroll(unrolled_factors1, vars2 & frozenset(plates))
+    unrolled_expected = reduce(prod_op, unrolled_factors2).reduce(sum_op, reduce_vars)
+    assert_close(actual, unrolled_expected)
 
 
 def _expected_modified_partial_sum_product(


### PR DESCRIPTION
`partial_unroll` function performs partial unrolling operation described in [the TVE paper](https://arxiv.org/abs/1902.03210). This will be helpful after it gets updated to unroll markov dims (in future PR) to facilitate testing of the `modified_partial_sum_product` algorithm.