### PR TITLE
Allow empty tensor conversion

### DIFF
--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -454,7 +454,7 @@ def tensor_to_funsor(x, output=None, dim_to_name=None):
         packed_inputs = OrderedDict()
         for dim, size in zip(range(len(x.shape) - len(output.shape)), x.shape):
             name = dim_to_name.get(dim + len(output.shape) - len(x.shape), None)
-            if name is not None and size > 1:
+            if name is not None and size != 1:
                 packed_inputs[name] = Bint[size]
         shape = tuple(d.size for d in packed_inputs.values()) + output.shape
         if x.shape != shape:

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1058,3 +1058,7 @@ def test_diagonal_rename():
     yt = x(a=dt, b=dt)
     y = x(a=d, b=d)
     assert_close(y, yt)
+
+
+def test_empty_tensor_possible():
+    funsor.to_funsor(randn(3, 0), dim_to_name=OrderedDict([(-1, "a"), (-2, "b")]))


### PR DESCRIPTION
I'm not sure if funsor supports Bint[0] at all but this is needed when using `numpyro.factor` with `enum`. Under the hood, `factor` leverages a Unit site with empty size: `event_shape=(0,)`, but `to_funsor` couldn't convert the empty array to funsor.

I also added a smoke test, which fails without this change.