### PR TITLE
Update modified_partial_sum_product to sum over init factors

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -118,13 +118,7 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
                for chain in step)
     # process plate_to_step
     plate_to_step = plate_to_step.copy()
-    prev_to_init = {}
     for key, step in plate_to_step.items():
-        # map prev to init; works for any history > 0
-        for s in step:
-            init = s[:len(s)//2]
-            prev = s[len(s)//2:-1]
-            prev_to_init.update(zip(prev, init))
         # make a dict step e.g. {"x_prev": "x_curr"}; specific to history = 1
         plate_to_step[key] = {s[1]: s[2] for s in step}
 
@@ -144,7 +138,7 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
     plate_to_order = {}
     for plate, step in unrolled_plates.items():
         if step:
-            plate_to_order[plate] = len(var_to_ordinal[next(iter(step))])
+            plate_to_order[plate] = max(len(var_to_ordinal[s]) for s in step)
         else:
             plate_to_order[plate] = 0
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -106,7 +106,8 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
     to variable names for index ``i`` in the plate. For markov dimensions (history>0)
     unrolling operation removes the suffix for the j-th Markov variable name counted
     from the end for the tuple of names in the ``step`` (e.g., j=0 for "x_curr"
-    and j=1 for "x_prev") and then appends ``_{i+history-j}`` to the name for index ``i``.
+    and j=1 for "x_prev") and then appends ``_{i+history-j}`` to the name for index ``i``
+    (e.g., "x_prev"->"x_0" and "x_curr"->"x_1" for i=0).
     Markov vars are assumed to have names that follow ``var_suffix`` formatting
     (e.g., ``("x_0", "x_prev", "x_curr")`` for history=1).
 
@@ -215,7 +216,9 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
     in addition to plate dimensions. Markov dimensions in transition factors
     are eliminated efficiently using the parallel-scan algorithm in
     :func:`funsor.sum_product.sequential_sum_product`. The resulting factors are then
-    combined with the initial factors and final states are eliminated.
+    combined with the initial factors and final states are eliminated. Therefore,
+    when Markov dimension is eliminated ``factors`` has to contain a pairs of
+    initial factors and transition factors.
 
     :param ~funsor.ops.AssociativeOp sum_op: A semiring sum operation.
     :param ~funsor.ops.AssociativeOp prod_op: A semiring product operation.

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -226,12 +226,11 @@ def modified_partial_sum_product(sum_op, prod_op, factors,
     prev_to_init = {}
     for key, step in plate_to_step.items():
         # map prev to init; works for any history > 0
-        for s in step:
-            init = s[:len(s)//2]
-            prev = s[len(s)//2:-1]
+        for chain in step:
+            init, prev = chain[:len(chain)//2], chain[len(chain)//2:-1]
             prev_to_init.update(zip(prev, init))
-        # make a dict step e.g. {"x_prev": "x_curr"}; specific to history = 1
-        plate_to_step[key] = {s[1]: s[2] for s in step}
+        # convert step to dict type required for MarkovProduct
+        plate_to_step[key] = {chain[1]: chain[2] for chain in step}
 
     plates = frozenset(plate_to_step.keys())
     sum_vars = eliminate - plates

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -63,11 +63,11 @@ def _unroll_plate(factors, var_to_ordinal, sum_vars, plate, step):
     # unroll variables
     for var in plate_vars:
         sum_vars -= frozenset({var})
-        past_idx = {chain[::-1].index(var) for chain in step if var in chain}
-        if past_idx:
-            assert len(past_idx) == 1
-            past_idx = next(iter(past_idx))
-            new_var = frozenset({"{}_{}".format(var.split("_")[0], i+history-past_idx)
+        prev_idx = {chain[::-1].index(var) for chain in step if var in chain}
+        if prev_idx:
+            assert len(prev_idx) == 1
+            prev_idx = next(iter(prev_idx))
+            new_var = frozenset({"{}_{}".format(var.split("_")[0], i+history-prev_idx)
                                  for i in range(size)})
         else:
             new_var = frozenset({"{}_{}".format(var, i+history)
@@ -89,8 +89,8 @@ def _unroll_plate(factors, var_to_ordinal, sum_vars, plate, step):
             unrolled_factors.extend([factor(
                     **{plate: i},
                     **{var: "{}_{}".format(var, i+history) for var in nonmarkov_vars},
-                    **{var: "{}_{}".format(var.split("_")[0], i+history-past_idx)
-                       for chain in step for past_idx, var in enumerate(chain[:history-1:-1])}
+                    **{var: "{}_{}".format(var.split("_")[0], i+history-prev_idx)
+                       for chain in step for prev_idx, var in enumerate(chain[:history-1:-1])}
                 ) for i in range(size)])
         else:
             unrolled_factors.append(factor)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -63,11 +63,11 @@ def _unroll_plate(factors, var_to_ordinal, sum_vars, plate, step):
     # unroll variables
     for var in plate_vars:
         sum_vars -= frozenset({var})
-        if var in step.keys():
-            new_var = frozenset({"{}_{}".format(var.split("_")[0], i)
-                                 for i in range(size)})
-        elif var in step.values():
-            new_var = frozenset({"{}_{}".format(var.split("_")[0], i+history)
+        past_idx = {chain[::-1].index(var) for chain in step if var in chain}
+        if past_idx:
+            assert len(past_idx) == 1
+            past_idx = next(iter(past_idx))
+            new_var = frozenset({"{}_{}".format(var.split("_")[0], i+history-past_idx)
                                  for i in range(size)})
         else:
             new_var = frozenset({"{}_{}".format(var, i+history)
@@ -82,14 +82,15 @@ def _unroll_plate(factors, var_to_ordinal, sum_vars, plate, step):
     for factor in factors:
         if plate in factor.inputs:
             f_vars = plate_vars.intersection(factor.inputs)
-            prev_to_var = {key: key.split("_")[0] for key in step.keys()}
-            curr_to_var = {value: value.split("_")[0] for value in step.values()}
-            nonmarkov_vars = f_vars - set(step.keys()) - set(step.values())
+            if step:
+                nonmarkov_vars = f_vars - set.union(*[set(chain[history:]) for chain in step])
+            else:
+                nonmarkov_vars = f_vars
             unrolled_factors.extend([factor(
                     **{plate: i},
                     **{var: "{}_{}".format(var, i+history) for var in nonmarkov_vars},
-                    **{curr: "{}_{}".format(var, i+history) for curr, var in curr_to_var.items()},
-                    **{prev: "{}_{}".format(var, i) for prev, var in prev_to_var.items()},
+                    **{var: "{}_{}".format(var.split("_")[0], i+history-past_idx)
+                       for chain in step for past_idx, var in enumerate(chain[:history-1:-1])}
                 ) for i in range(size)])
         else:
             unrolled_factors.append(factor)
@@ -116,11 +117,6 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
     assert all(len(set(var.split("_")[0] for var in chain)) == 1
                for step in plate_to_step.values() if step
                for chain in step)
-    # process plate_to_step
-    plate_to_step = plate_to_step.copy()
-    for key, step in plate_to_step.items():
-        # make a dict step e.g. {"x_prev": "x_curr"}; specific to history = 1
-        plate_to_step[key] = {s[1]: s[2] for s in step}
 
     plates = frozenset(plate_to_step.keys())
     sum_vars = eliminate - plates
@@ -138,7 +134,7 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
     plate_to_order = {}
     for plate, step in unrolled_plates.items():
         if step:
-            plate_to_order[plate] = max(len(var_to_ordinal[s]) for s in step)
+            plate_to_order[plate] = max(len(var_to_ordinal[var]) for chain in step for var in chain)
         else:
             plate_to_order[plate] = 0
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -121,10 +121,10 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "time", "x_prev", "x_curr"})),
+     frozenset({"x_0", "time", "x_prev", "x_curr"})),
     (frozenset({"time", "x_prev", "x_curr"}),
-     frozenset({"x_time_0"})),
-    (frozenset({"x_time_0", "time", "x_prev", "x_curr"}),
+     frozenset({"x_0"})),
+    (frozenset({"x_0", "time", "x_prev", "x_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,time', [
@@ -137,7 +137,7 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
     f1 = random_tensor(OrderedDict({}))
 
     f2 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -147,7 +147,7 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2, f3]
-    plate_to_step = {"time": frozenset({("x_time_0", "x_prev", "x_curr")})}
+    plate_to_step = {"time": frozenset({("x_0", "x_prev", "x_curr")})}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -164,12 +164,12 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr", "y_curr"})),
+     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_curr"})),
     (frozenset({"y_curr"}),
-     frozenset({"x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr"})),
+     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr"})),
     (frozenset({"time", "x_prev", "x_curr", "y_curr"}),
-     frozenset({"x_time_0", "y_curr_time_0"})),
-    (frozenset({"x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr", "y_curr"}),
+     frozenset({"x_0", "y_0"})),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -182,7 +182,7 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     f1 = random_tensor(OrderedDict({}))
 
     f2_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f2 = random_tensor(OrderedDict({
@@ -192,8 +192,8 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     }))
 
     f3_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -203,7 +203,7 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
     }))
 
     factors = [f1, f2_0, f2, f3_0, f3]
-    plate_to_step = {"time": frozenset({("x_time_0", "x_prev", "x_curr")})}
+    plate_to_step = {"time": frozenset({("x_0", "x_prev", "x_curr")})}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -220,10 +220,10 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
+     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
     (frozenset({"time", "x_prev", "x_curr", "y_prev", "y_curr"}),
-     frozenset({"x_time_0", "y_time_0"})),
-    (frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"x_0", "y_0"})),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -236,7 +236,7 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     f1 = random_tensor(OrderedDict({}))
 
     f2 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -246,7 +246,7 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     }))
 
     f4 = random_tensor(OrderedDict({
-        "y_time_0": Bint[y_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -258,8 +258,8 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
     factors = [f1, f2, f3, f4, f5]
     plate_to_step = {
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr")})
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr")})
         }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -277,10 +277,10 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
+     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
     (frozenset({"time", "x_prev", "x_curr", "y_prev", "y_curr"}),
-     frozenset({"x_time_0", "y_time_0"})),
-    (frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"x_0", "y_0"})),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -293,7 +293,7 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     f1 = random_tensor(OrderedDict({}))
 
     f2 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -303,8 +303,8 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     }))
 
     f4 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
-        "y_time_0": Bint[y_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -317,8 +317,8 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
     factors = [f1, f2, f3, f4, f5]
     plate_to_step = {
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr")})
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr")})
         }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -336,12 +336,12 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
+     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
     # (frozenset({"time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
     #  frozenset({"sequences", "x_time_0", "y_time_0"})),
-    (frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -355,7 +355,7 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -368,7 +368,7 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "y_time_0": Bint[y_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -383,8 +383,8 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr")}),
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr")}),
         "tones": {}
         }
 
@@ -403,16 +403,16 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_days_0", "days", "tones", "x_prev", "x_curr",
-                "y_weeks_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"y_weeks_0", "weeks", "y_prev", "y_curr"}),
-     frozenset({"sequences", "x_days_0", "days", "tones", "x_prev", "x_curr"})),
-    (frozenset({"x_days_0", "days", "tones", "x_prev", "x_curr"}),
-     frozenset({"sequences", "y_weeks_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"x_days_0", "days", "tones", "x_prev", "x_curr", "y_weeks_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr",
+                "y_0", "weeks", "y_prev", "y_curr"})),
+    (frozenset({"y_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr"})),
+    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr"}),
+     frozenset({"sequences", "y_0", "weeks", "y_prev", "y_curr"})),
+    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_days_0", "days", "tones", "x_prev", "x_curr",
-                "y_weeks_0", "weeks", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr",
+                "y_0", "weeks", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,days,weeks,tones', [
@@ -430,7 +430,7 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "x_days_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -443,7 +443,7 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
 
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "y_weeks_0": Bint[y_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -457,8 +457,8 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "tones": {},
-        "days": frozenset({("x_days_0", "x_prev", "x_curr")}),
-        "weeks": frozenset({("y_weeks_0", "y_prev", "y_curr")}),
+        "days": frozenset({("x_0", "x_prev", "x_curr")}),
+        "weeks": frozenset({("y_0", "y_prev", "y_curr")}),
         }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -476,12 +476,12 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr", "tones", "y_curr"})),
+     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_curr"})),
     #  (frozenset({ "y_curr", "tones"}),
     #   frozenset({"sequences", "x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr", "tones", "y_curr"}),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_time_0", "y_curr_time_0", "time", "tones", "x_prev", "x_curr", "y_curr"}),
+    (frozenset({"sequences", "x_0", "y_0", "time", "tones", "x_prev", "x_curr", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -495,7 +495,7 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -508,8 +508,8 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -523,7 +523,7 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
     factors = [f1, f2, f3, f4, f5]
     plate_to_step = {
         "sequences": {},
-        "time": frozenset({("x_time_0", "x_prev", "x_curr")}),
+        "time": frozenset({("x_0", "x_prev", "x_curr")}),
         "tones": {}
         }
 
@@ -542,10 +542,10 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
-    (frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_time_0", "y_time_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -559,7 +559,7 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -572,8 +572,8 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "x_time_0": Bint[x_dim],
-        "y_time_0": Bint[y_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -589,8 +589,8 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr"),
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr"),
             }),
         "tones": {}
         }
@@ -603,14 +603,14 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_time_0", "w_time_0", "y_curr_time_0", "time",
+     frozenset({"sequences", "x_0", "w_0", "y_0", "time",
                 "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
     #  (frozenset({"tones", "y_curr"}),
     #   frozenset({"sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"x_time_0", "w_time_0", "y_curr_time_0", "time", "w_prev",
+    (frozenset({"x_0", "w_0", "y_0", "time", "w_prev",
                 "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_time_0", "w_time_0", "y_curr_time_0", "time",
+    (frozenset({"sequences", "x_0", "w_0", "y_0", "time",
                 "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset()),
 ])
@@ -628,7 +628,7 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_time_0": Bint[w_dim],
+        "w_0": Bint[w_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -640,7 +640,7 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
 
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -653,9 +653,9 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     f6 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f7 = random_tensor(OrderedDict({
@@ -671,8 +671,8 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("w_time_0", "w_prev", "w_curr"),
+            ("x_0", "x_prev", "x_curr"),
+            ("w_0", "w_prev", "w_curr"),
             }),
         "tones": {}
     }
@@ -693,14 +693,14 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize("use_lazy", [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_time_0", "w_time_0", "y_curr_time_0", "time",
+     frozenset({"sequences", "x_0", "w_0", "y_0", "time",
                 "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
     #  (frozenset({"tones", "y_curr"}),
     #   frozenset({"sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"x_time_0", "w_time_0", "y_curr_time_0", "time", "w_prev",
+    (frozenset({"x_0", "w_0", "y_0", "time", "w_prev",
                 "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_time_0", "w_time_0", "y_curr_time_0", "time",
+    (frozenset({"sequences", "x_0", "w_0", "y_0", "time",
                 "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset()),
 ])
@@ -715,7 +715,7 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_time_0": Bint[w_dim],
+        "w_0": Bint[w_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -727,8 +727,8 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
 
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -742,9 +742,9 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
     f6 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f7 = random_tensor(OrderedDict({
@@ -760,8 +760,8 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("w_time_0", "w_prev", "w_curr"),
+            ("x_0", "x_prev", "x_curr"),
+            ("w_0", "w_prev", "w_curr"),
             }),
         "tones": {}
     }
@@ -783,12 +783,12 @@ def test_modified_partial_sum_product_9(use_lazy, sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "time", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
-    (frozenset({"tones", "y_curr"}),
-     frozenset({"sequences", "time", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"time", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_curr", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"})),
+    (frozenset({"tones", "y_0", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_curr", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "w_0", "w_curr", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "time", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+    (frozenset({"sequences", "time", "w_0", "w_curr", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('w_dim,x_dim,y_dim,sequences,time,tones', [
@@ -805,7 +805,7 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_curr_time_0": Bint[w_dim],
+        "w_0": Bint[w_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -816,8 +816,8 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_curr_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -831,9 +831,9 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
     f6 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_curr_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f7 = random_tensor(OrderedDict({
@@ -848,7 +848,7 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
     factors = [f1, f2, f3, f4, f5, f6, f7]
     plate_to_step = {
         "sequences": {},
-        "time": frozenset({("x_time_0", "x_prev", "x_curr")}),
+        "time": frozenset({("x_0", "x_prev", "x_curr")}),
         "tones": {}
     }
 
@@ -868,14 +868,14 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"a", "b", "sequences", "w_time_0", "x_time_0", "y_curr_time_0",
+     frozenset({"a", "b", "sequences", "w_0", "x_0", "y_0",
                 "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
     #  (frozenset({"tones", "y_curr"}),
     #   frozenset({"a", "b", "sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"w_time_0", "x_time_0", "y_curr_time_0", "time", "w_prev",
+    (frozenset({"w_0", "x_0", "y_0", "time", "w_prev",
                 "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset({"a", "b", "sequences"})),
-    (frozenset({"a", "b", "sequences", "w_time_0", "x_time_0", "y_curr_time_0",
+    (frozenset({"a", "b", "sequences", "w_0", "x_0", "y_0",
                 "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
      frozenset()),
 ])
@@ -903,7 +903,7 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     i_0 = random_tensor(OrderedDict({
         "a": Bint[a_dim],
         "sequences": Bint[sequences],
-        "w_time_0": Bint[w_dim],
+        "w_0": Bint[w_dim],
     }))
 
     i = random_tensor(OrderedDict({
@@ -917,8 +917,8 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     j_0 = random_tensor(OrderedDict({
         "b": Bint[b_dim],
         "sequences": Bint[sequences],
-        "w_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
     }))
 
     j = random_tensor(OrderedDict({
@@ -933,9 +933,9 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     k_0 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     k = random_tensor(OrderedDict({
@@ -951,8 +951,8 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("w_time_0", "w_prev", "w_curr")
+            ("x_0", "x_prev", "x_curr"),
+            ("w_0", "w_prev", "w_curr")
             }),
         "tones": {}
     }
@@ -974,12 +974,12 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "w_curr_time_0", "x_time_0", "y_time_0", "time",
+     frozenset({"sequences", "w_0", "x_0", "y_0", "time",
                 "w_curr", "tones", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"w_curr_time_0", "x_time_0", "y_time_0", "time", "w_curr",
+    (frozenset({"w_0", "x_0", "y_0", "time", "w_curr",
                 "tones", "x_prev", "x_curr", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "w_curr_time_0", "x_time_0", "y_time_0",
+    (frozenset({"sequences", "w_0", "x_0", "y_0",
                 "time", "w_curr", "tones", "x_prev", "x_curr", "y_prev", "y_curr"}),
      frozenset()),
 ])
@@ -997,7 +997,7 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
 
     f2 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
-        "w_curr_time_0": Bint[w_dim],
+        "w_0": Bint[w_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -1009,8 +1009,8 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     f4 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_curr_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -1025,9 +1025,9 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     f6 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "w_curr_time_0": Bint[w_dim],
-        "x_time_0": Bint[x_dim],
-        "y_time_0": Bint[y_dim],
+        "w_0": Bint[w_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f7 = random_tensor(OrderedDict({
@@ -1044,8 +1044,8 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr")
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr")
             }),
         "tones": {}
     }
@@ -1059,18 +1059,18 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "w", "x_days_0", "days", "tones",
-                "x_prev", "x_curr", "y_weeks_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"y_weeks_0", "weeks", "y_prev", "y_curr"}),
-     frozenset({"sequences", "w", "x_days_0", "days", "tones", "x_prev", "x_curr"})),
-    (frozenset({"x_days_0", "days", "tones", "x_prev", "x_curr"}),
-     frozenset({"sequences", "w", "y_weeks_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"x_days_0", "days", "tones", "x_prev", "x_curr", "y_weeks_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "w", "x_0", "days", "tones",
+                "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"})),
+    (frozenset({"y_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "w", "x_0", "days", "tones", "x_prev", "x_curr"})),
+    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr"}),
+     frozenset({"sequences", "w", "y_0", "weeks", "y_prev", "y_curr"})),
+    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
      frozenset({"sequences", "w"})),
-    (frozenset({"sequences", "w", "x_days_0", "days", "tones",
-                "x_prev", "x_curr", "y_weeks_0", "weeks", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "w", "x_0", "days", "tones",
+                "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
      frozenset()),
-    (frozenset({"w", "x_days_0", "days", "tones", "x_prev", "x_curr", "y_weeks_0", "weeks", "y_prev", "y_curr"}),
+    (frozenset({"w", "x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
 ])
 @pytest.mark.parametrize('w_dim,x_dim, y_dim, sequences, days, weeks, tones', [
@@ -1089,7 +1089,7 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
         "w": Bint[w_dim],
         "sequences": Bint[sequences],
         "tones": Bint[tones],
-        "x_days_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -1104,7 +1104,7 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
     f4 = random_tensor(OrderedDict({
         "w": Bint[w_dim],
         "sequences": Bint[sequences],
-        "y_weeks_0": Bint[y_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -1119,8 +1119,8 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
     plate_to_step = {
         "sequences": {},
         "tones": {},
-        "days": frozenset({("x_days_0", "x_prev", "x_curr")}),
-        "weeks": frozenset({("y_weeks_0", "y_prev", "y_curr")}),
+        "days": frozenset({("x_0", "x_prev", "x_curr")}),
+        "weeks": frozenset({("y_0", "y_prev", "y_curr")}),
     }
 
     with interpretation(lazy if use_lazy else eager):
@@ -1198,8 +1198,8 @@ def test_modified_partial_sum_product_14(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"x_time_0", "y_time_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
+    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -1212,7 +1212,7 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     f1 = random_tensor(OrderedDict({}))
 
     f2 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f3 = random_tensor(OrderedDict({
@@ -1222,7 +1222,7 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     }))
 
     f4 = random_tensor(OrderedDict({
-        "y_time_0": Bint[y_dim],
+        "y_0": Bint[y_dim],
     }))
 
     f5 = random_tensor(OrderedDict({
@@ -1234,8 +1234,8 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
     factors = [f1, f2, f3, f4, f5]
     plate_to_step = {
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr"),
-            ("y_time_0", "y_prev", "y_curr"),
+            ("x_0", "x_prev", "x_curr"),
+            ("y_0", "y_prev", "y_curr"),
             }),
         }
 
@@ -1255,13 +1255,13 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_time_0", "y_curr_time_0", "z0_time_0", "z1_time_0", "z2_time_0",
+     frozenset({"x_0", "y_0", "z0_0", "z1_0", "z2_0",
                 "time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"})),
     (frozenset({"y_curr", "z0", "z1", "z2"}),
-     frozenset({"x_time_0", "y_curr_time_0", "z0_time_0", "z1_time_0",
-                "z2_time_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"x_time_0", "y_curr_time_0", "z0_time_0", "z1_time_0",
-                "z2_time_0", "time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"}),
+     frozenset({"x_0", "y_0", "z0_0", "z1_0",
+                "z2_0", "time", "x_prev", "x_curr"})),
+    (frozenset({"x_0", "y_0", "z0_0", "z1_0",
+                "z2_0", "time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,z_dim,time', [
@@ -1274,7 +1274,7 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     f1 = random_tensor(OrderedDict({}))
 
     f2_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
+        "x_0": Bint[x_dim],
     }))
 
     f2 = random_tensor(OrderedDict({
@@ -1284,10 +1284,10 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     f3_1_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
-        "z0_time_0": Bint[z_dim],
-        "z1_time_0": Bint[z_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
+        "z0_0": Bint[z_dim],
+        "z1_0": Bint[z_dim],
     }))
 
     f3_1 = random_tensor(OrderedDict({
@@ -1299,10 +1299,10 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     f3_2_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
-        "z1_time_0": Bint[z_dim],
-        "z2_time_0": Bint[z_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
+        "z1_0": Bint[z_dim],
+        "z2_0": Bint[z_dim],
     }))
 
     f3_2 = random_tensor(OrderedDict({
@@ -1314,9 +1314,9 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     }))
 
     f3_3_0 = random_tensor(OrderedDict({
-        "x_time_0": Bint[x_dim],
-        "y_curr_time_0": Bint[y_dim],
-        "z2_time_0": Bint[z_dim],
+        "x_0": Bint[x_dim],
+        "y_0": Bint[y_dim],
+        "z2_0": Bint[z_dim],
     }))
 
     f3_3 = random_tensor(OrderedDict({
@@ -1329,7 +1329,7 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
     factors = [f1, f2_0, f2, f3_1_0, f3_1, f3_2_0, f3_2, f3_3_0, f3_3]
     plate_to_step = {
         "time": frozenset({
-            ("x_time_0", "x_prev", "x_curr")
+            ("x_0", "x_prev", "x_curr")
             }),
         }
 

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -122,8 +122,6 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
      frozenset({"x_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"time", "x_prev", "x_curr"}),
-     frozenset({"x_0"})),
     (frozenset({"x_0", "time", "x_prev", "x_curr"}),
      frozenset()),
 ])
@@ -164,12 +162,10 @@ def test_modified_partial_sum_product_0(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_curr"})),
-    (frozenset({"y_curr"}),
-     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"time", "x_prev", "x_curr", "y_curr"}),
-     frozenset({"x_0", "y_0"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_curr"})),
+    (frozenset({"y_0", "y_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -181,28 +177,28 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
 
     f1 = random_tensor(OrderedDict({}))
 
-    f2_0 = random_tensor(OrderedDict({
+    f2 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
     }))
 
-    f2 = random_tensor(OrderedDict({
+    f3 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_prev": Bint[x_dim],
         "x_curr": Bint[x_dim],
     }))
 
-    f3_0 = random_tensor(OrderedDict({
+    f4 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
         "y_0": Bint[y_dim],
     }))
 
-    f3 = random_tensor(OrderedDict({
+    f5 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_curr": Bint[x_dim],
         "y_curr": Bint[y_dim],
     }))
 
-    factors = [f1, f2_0, f2, f3_0, f3]
+    factors = [f1, f2, f3, f4, f5]
     plate_to_step = {"time": frozenset({("x_0", "x_prev", "x_curr")})}
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -220,10 +216,8 @@ def test_modified_partial_sum_product_1(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"time", "x_prev", "x_curr", "y_prev", "y_curr"}),
-     frozenset({"x_0", "y_0"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -277,10 +271,8 @@ def test_modified_partial_sum_product_2(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"time", "x_prev", "x_curr", "y_prev", "y_curr"}),
-     frozenset({"x_0", "y_0"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -336,12 +328,10 @@ def test_modified_partial_sum_product_3(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
-    # (frozenset({"time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
-    #  frozenset({"sequences", "x_time_0", "y_time_0"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -403,16 +393,17 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr",
-                "y_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"y_0", "weeks", "y_prev", "y_curr"}),
-     frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr"}),
-     frozenset({"sequences", "y_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"weeks", "y_0", "y_prev", "y_curr"}),
+     frozenset({"sequences", "days", "tones", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"days", "tones", "x_0", "x_prev", "x_curr"}),
+     frozenset({"sequences", "weeks", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "days", "tones", "x_prev", "x_curr",
-                "y_0", "weeks", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,days,weeks,tones', [
@@ -476,12 +467,12 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_curr"})),
-    #  (frozenset({ "y_curr", "tones"}),
-    #   frozenset({"sequences", "x_time_0", "y_curr_time_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"})),
+    (frozenset({"tones", "y_0", "y_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "y_0", "time", "tones", "x_prev", "x_curr", "y_curr"}),
+    (frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -542,10 +533,10 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "y_0", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "time", "x_0", "x_prev", "x_curr", "tones", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -603,15 +594,15 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "w_0", "y_0", "time",
-                "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
-    #  (frozenset({"tones", "y_curr"}),
-    #   frozenset({"sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "w_0", "y_0", "time", "w_prev",
-                "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"})),
+    (frozenset({"tones", "y_0", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_prev", "w_curr", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "w_0", "y_0", "time",
-                "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+    (frozenset({"sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('w_dim,x_dim,y_dim,sequences,time,tones', [
@@ -693,15 +684,15 @@ def test_modified_partial_sum_product_8(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize("use_lazy", [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "x_0", "w_0", "y_0", "time",
-                "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
-    #  (frozenset({"tones", "y_curr"}),
-    #   frozenset({"sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "w_0", "y_0", "time", "w_prev",
-                "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"})),
+    (frozenset({"tones", "y_0", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_prev", "w_curr", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "x_0", "w_0", "y_0", "time",
-                "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+    (frozenset({"sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('w_dim,x_dim,y_dim,sequences,time,tones', [
@@ -868,15 +859,15 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"a", "b", "sequences", "w_0", "x_0", "y_0",
-                "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"})),
-    #  (frozenset({"tones", "y_curr"}),
-    #   frozenset({"a", "b", "sequences", "time", "w_prev", "w_curr", "x_prev", "x_curr"})),
-    (frozenset({"w_0", "x_0", "y_0", "time", "w_prev",
-                "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+     frozenset({"a", "b", "sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"})),
+    (frozenset({"tones", "y_0", "y_curr"}),
+     frozenset({"a", "b", "sequences", "time", "w_0", "w_prev", "w_curr", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset({"a", "b", "sequences"})),
-    (frozenset({"a", "b", "sequences", "w_0", "x_0", "y_0",
-                "time", "w_prev", "w_curr", "x_prev", "x_curr", "tones", "y_curr"}),
+    (frozenset({"a", "b", "sequences", "time", "w_0", "w_prev", "w_curr",
+                "x_0", "x_prev", "x_curr", "tones", "y_0", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('a_dim,b_dim,w_dim,x_dim,y_dim,sequences,time,tones', [
@@ -889,24 +880,24 @@ def test_modified_partial_sum_product_10(sum_op, prod_op, vars1, vars2,
 def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2,
                                          a_dim, b_dim, w_dim, x_dim, y_dim, sequences, time, tones):
 
-    f = random_tensor(OrderedDict({}))
+    f1 = random_tensor(OrderedDict({}))
 
-    g = random_tensor(OrderedDict({
+    f2 = random_tensor(OrderedDict({
         "a": Bint[a_dim],
     }))
 
-    h = random_tensor(OrderedDict({
+    f3 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "b": Bint[b_dim],
     }))
 
-    i_0 = random_tensor(OrderedDict({
+    f4 = random_tensor(OrderedDict({
         "a": Bint[a_dim],
         "sequences": Bint[sequences],
         "w_0": Bint[w_dim],
     }))
 
-    i = random_tensor(OrderedDict({
+    f5 = random_tensor(OrderedDict({
         "a": Bint[a_dim],
         "sequences": Bint[sequences],
         "time": Bint[time],
@@ -914,14 +905,14 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
         "w_curr": Bint[w_dim],
     }))
 
-    j_0 = random_tensor(OrderedDict({
+    f6 = random_tensor(OrderedDict({
         "b": Bint[b_dim],
         "sequences": Bint[sequences],
         "w_0": Bint[w_dim],
         "x_0": Bint[x_dim],
     }))
 
-    j = random_tensor(OrderedDict({
+    f7 = random_tensor(OrderedDict({
         "b": Bint[b_dim],
         "sequences": Bint[sequences],
         "time": Bint[time],
@@ -930,7 +921,7 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
         "x_curr": Bint[x_dim],
     }))
 
-    k_0 = random_tensor(OrderedDict({
+    f8 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "tones": Bint[tones],
         "w_0": Bint[w_dim],
@@ -938,7 +929,7 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
         "y_0": Bint[y_dim],
     }))
 
-    k = random_tensor(OrderedDict({
+    f9 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "time": Bint[time],
         "tones": Bint[tones],
@@ -947,7 +938,7 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
         "y_curr": Bint[y_dim],
     }))
 
-    factors = [f, g, h, i_0, i, j_0, j, k_0, k]
+    factors = [f1, f2, f3, f4, f5, f6, f7, f8, f9]
     plate_to_step = {
         "sequences": {},
         "time": frozenset({
@@ -974,13 +965,13 @@ def test_modified_partial_sum_product_11(use_lazy, sum_op, prod_op, vars1, vars2
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "w_0", "x_0", "y_0", "time",
-                "w_curr", "tones", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"w_0", "x_0", "y_0", "time", "w_curr",
-                "tones", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"sequences", "time", "w_0", "w_curr",
+                "tones", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "w_0", "w_curr",
+                "tones", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "w_0", "x_0", "y_0",
-                "time", "w_curr", "tones", "x_prev", "x_curr", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "time", "w_0", "w_curr",
+                "tones", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('w_dim,x_dim,y_dim,sequences,time,tones', [
@@ -1059,19 +1050,20 @@ def test_modified_partial_sum_product_12(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "w", "x_0", "days", "tones",
-                "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"y_0", "weeks", "y_prev", "y_curr"}),
-     frozenset({"sequences", "w", "x_0", "days", "tones", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr"}),
-     frozenset({"sequences", "w", "y_0", "weeks", "y_prev", "y_curr"})),
-    (frozenset({"x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
+     frozenset({"sequences", "w", "days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"weeks", "y_0", "y_prev", "y_curr"}),
+     frozenset({"sequences", "w", "days", "tones", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"days", "tones", "x_0", "x_prev", "x_curr"}),
+     frozenset({"sequences", "w", "weeks", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"days", "tones", "x_0", "x_prev", "x_curr", "weeks", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences", "w"})),
-    (frozenset({"sequences", "w", "x_0", "days", "tones",
-                "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
-     frozenset()),
-    (frozenset({"w", "x_0", "days", "tones", "x_prev", "x_curr", "y_0", "weeks", "y_prev", "y_curr"}),
+    (frozenset({"w", "days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"}),
      frozenset({"sequences"})),
+    (frozenset({"sequences", "w", "days", "tones", "x_0", "x_prev", "x_curr",
+                "weeks", "y_0", "y_prev", "y_curr"}),
+     frozenset()),
 ])
 @pytest.mark.parametrize('w_dim,x_dim, y_dim, sequences, days, weeks, tones', [
     (3, 2, 3, 2, 5, 4, 3),
@@ -1140,12 +1132,15 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"sequences", "time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"})),
-    (frozenset({"tones", "y_prev", "y_curr"}),
-     frozenset({"sequences", "time", "x_prev", "x_curr"})),
-    (frozenset({"time", "x_prev", "x_curr", "tones", "y_prev", "y_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr",
+                "tones", "y0_0", "y0_prev", "y0_curr", "ycurr_0", "ycurr_prev", "ycurr_curr"})),
+    (frozenset({"tones", "y0_0", "y0_prev", "y0_curr", "ycurr_0", "ycurr_prev", "ycurr_curr"}),
+     frozenset({"sequences", "time", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr",
+                "tones", "y0_0", "y0_prev", "y0_curr", "ycurr_0", "ycurr_prev", "ycurr_curr"}),
      frozenset({"sequences"})),
-    (frozenset({"sequences", "time", "tones", "x_prev", "x_curr", "y_prev", "y_curr"}),
+    (frozenset({"sequences", "time", "x_0", "x_prev", "x_curr",
+                "tones", "y0_0", "y0_prev", "y0_curr", "ycurr_0", "ycurr_prev", "ycurr_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,sequences,time,tones', [
@@ -1158,29 +1153,58 @@ def test_modified_partial_sum_product_13(use_lazy, sum_op, prod_op, vars1, vars2
 def test_modified_partial_sum_product_14(sum_op, prod_op, vars1, vars2,
                                          x_dim, y_dim, sequences, time, tones):
 
-    f = random_tensor(OrderedDict({}))
+    f1 = random_tensor(OrderedDict({}))
 
-    g = random_tensor(OrderedDict({
+    f2 = random_tensor(OrderedDict({
+        "sequences": Bint[sequences],
+        "x_0": Bint[x_dim],
+    }))
+
+    f3 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "time": Bint[time],
         "x_prev": Bint[x_dim],
         "x_curr": Bint[x_dim],
     }))
 
-    h = random_tensor(OrderedDict({
+    f4 = random_tensor(OrderedDict({
+        "sequences": Bint[sequences],
+        "x_0": Bint[x_dim],
+        "y0_0": Bint[y_dim],
+    }))
+
+    f5 = random_tensor(OrderedDict({
+        "sequences": Bint[sequences],
+        "tones": Bint[tones],
+        "x_0": Bint[x_dim],
+        "y0_prev": Bint[y_dim],
+        "y0_curr": Bint[y_dim],
+    }))
+
+    f6 = random_tensor(OrderedDict({
+        "sequences": Bint[sequences],
+        "time": Bint[time],
+        "x_curr": Bint[x_dim],
+        "ycurr_0": Bint[y_dim],
+    }))
+
+    f7 = random_tensor(OrderedDict({
         "sequences": Bint[sequences],
         "time": Bint[time],
         "tones": Bint[tones],
         "x_curr": Bint[x_dim],
-        "y_prev": Bint[y_dim],
-        "y_curr": Bint[y_dim],
+        "ycurr_prev": Bint[y_dim],
+        "ycurr_curr": Bint[y_dim],
     }))
 
-    factors = [f, g, h]
+    factors = [f1, f2, f3, f4, f5, f6, f7]
     plate_to_step = {
         "sequences": {},
-        "time": {"x_prev": "x_curr"},
-        "tones": {"y_prev": "y_curr"}
+        "time": frozenset({("x_0", "x_prev", "x_curr")}),
+        "tones": frozenset({
+            ("y0_0", "y0_prev", "y0_curr"),
+            ("ycurr_0", "ycurr_prev", "ycurr_curr"),
+        })
     }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
@@ -1198,8 +1222,8 @@ def test_modified_partial_sum_product_14(sum_op, prod_op, vars1, vars2,
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"})),
-    (frozenset({"x_0", "y_0", "time", "x_prev", "x_curr", "y_prev", "y_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr", "y_0", "y_prev", "y_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,time', [
@@ -1255,13 +1279,12 @@ def test_modified_partial_sum_product_16(sum_op, prod_op, vars1, vars2,
 @pytest.mark.parametrize('use_lazy', [False, True], ids=["eager", "lazy"])
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "y_0", "z0_0", "z1_0", "z2_0",
-                "time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"})),
-    (frozenset({"y_curr", "z0", "z1", "z2"}),
-     frozenset({"x_0", "y_0", "z0_0", "z1_0",
-                "z2_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "y_0", "z0_0", "z1_0",
-                "z2_0", "time", "x_prev", "x_curr", "y_curr", "z0", "z1", "z2"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr",
+                "y_0", "y_curr", "z0_0", "z0", "z1_0", "z1", "z2_0", "z2"})),
+    (frozenset({"y_0", "y_curr", "z0_0", "z0", "z1_0", "z1", "z2_0", "z2"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr",
+                "y_0", "y_curr", "z0_0", "z0", "z1_0", "z1", "z2_0", "z2"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,y_dim,z_dim,time', [
@@ -1273,24 +1296,24 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
 
     f1 = random_tensor(OrderedDict({}))
 
-    f2_0 = random_tensor(OrderedDict({
+    f2 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
     }))
 
-    f2 = random_tensor(OrderedDict({
+    f3 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_prev": Bint[x_dim],
         "x_curr": Bint[x_dim],
     }))
 
-    f3_1_0 = random_tensor(OrderedDict({
+    f4 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
         "y_0": Bint[y_dim],
         "z0_0": Bint[z_dim],
         "z1_0": Bint[z_dim],
     }))
 
-    f3_1 = random_tensor(OrderedDict({
+    f5 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_curr": Bint[x_dim],
         "y_curr": Bint[y_dim],
@@ -1298,14 +1321,14 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
         "z1": Bint[z_dim],
     }))
 
-    f3_2_0 = random_tensor(OrderedDict({
+    f6 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
         "y_0": Bint[y_dim],
         "z1_0": Bint[z_dim],
         "z2_0": Bint[z_dim],
     }))
 
-    f3_2 = random_tensor(OrderedDict({
+    f7 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_curr": Bint[x_dim],
         "y_curr": Bint[y_dim],
@@ -1313,20 +1336,20 @@ def test_modified_partial_sum_product_17(use_lazy, sum_op, prod_op, vars1, vars2
         "z2": Bint[z_dim],
     }))
 
-    f3_3_0 = random_tensor(OrderedDict({
+    f8 = random_tensor(OrderedDict({
         "x_0": Bint[x_dim],
         "y_0": Bint[y_dim],
         "z2_0": Bint[z_dim],
     }))
 
-    f3_3 = random_tensor(OrderedDict({
+    f9 = random_tensor(OrderedDict({
         "time": Bint[time],
         "x_curr": Bint[x_dim],
         "y_curr": Bint[y_dim],
         "z2": Bint[z_dim],
     }))
 
-    factors = [f1, f2_0, f2, f3_1_0, f3_1, f3_2_0, f3_2, f3_3_0, f3_3]
+    factors = [f1, f2, f3, f4, f5, f6, f7, f8, f9]
     plate_to_step = {
         "time": frozenset({
             ("x_0", "x_prev", "x_curr")

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -121,8 +121,8 @@ def test_partial_sum_product(impl, sum_op, prod_op, inputs, plates, vars1, vars2
 
 @pytest.mark.parametrize('vars1,vars2', [
     (frozenset(),
-     frozenset({"x_0", "time", "x_prev", "x_curr"})),
-    (frozenset({"x_0", "time", "x_prev", "x_curr"}),
+     frozenset({"time", "x_0", "x_prev", "x_curr"})),
+    (frozenset({"time", "x_0", "x_prev", "x_curr"}),
      frozenset()),
 ])
 @pytest.mark.parametrize('x_dim,time', [

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -376,7 +376,7 @@ def test_modified_partial_sum_product_4(sum_op, prod_op, vars1, vars2,
             ("x_0", "x_prev", "x_curr"),
             ("y_0", "y_prev", "y_curr")}),
         "tones": {}
-        }
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -450,7 +450,7 @@ def test_modified_partial_sum_product_5(sum_op, prod_op, vars1, vars2,
         "tones": {},
         "days": frozenset({("x_0", "x_prev", "x_curr")}),
         "weeks": frozenset({("y_0", "y_prev", "y_curr")}),
-        }
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -516,7 +516,7 @@ def test_modified_partial_sum_product_6(sum_op, prod_op, vars1, vars2,
         "sequences": {},
         "time": frozenset({("x_0", "x_prev", "x_curr")}),
         "tones": {}
-        }
+    }
 
     factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)
     factors2 = modified_partial_sum_product(sum_op, prod_op, factors1, vars2, plate_to_step)
@@ -584,7 +584,7 @@ def test_modified_partial_sum_product_7(sum_op, prod_op, vars1, vars2,
             ("y_0", "y_prev", "y_curr"),
             }),
         "tones": {}
-        }
+    }
 
     with pytest.raises(ValueError, match="intractable!"):
         factors1 = modified_partial_sum_product(sum_op, prod_op, factors, vars1, plate_to_step)


### PR DESCRIPTION
In this PR:
- Update `modified_partial_sum_product` to eliminate `init` factors as well
- Change `step` from a dict to a set of tuples in `modified_partial_sum_product` and `partial_unroll`
- Add `init` factors in the tests
- Remove `test_modified_partial_sum_product_15` because the new `step` only works for markov vars that depend only one markov dimension.