### PR TITLE
Fix rsample not available in NumPyro

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -300,6 +300,8 @@ def make_dist(backend_dist_class, param_names=(), generate_eager=True, generate_
 
 FUNSOR_DIST_NAMES = [
     ('Beta', ('concentration1', 'concentration0')),
+    ("Cauchy", ()),
+    ("Chi2", ()),
     ('BernoulliProbs', ('probs',)),
     ('BernoulliLogits', ('logits',)),
     ('Binomial', ('total_count', 'probs')),
@@ -308,8 +310,15 @@ FUNSOR_DIST_NAMES = [
     ('Delta', ('v', 'log_density')),
     ('Dirichlet', ('concentration',)),
     ('DirichletMultinomial', ('concentration', 'total_count')),
+    ("Exponential", ()),
     ('Gamma', ('concentration', 'rate')),
     ('GammaPoisson', ('concentration', 'rate')),
+    ("Geometric", ("probs",)),
+    ("Gumbel", ()),
+    ("HalfCauchy", ()),
+    ("HalfNormal", ()),
+    ("Laplace", ()),
+    ("LowRankMultivariateNormal", ()),
     ('Multinomial', ('total_count', 'probs')),
     ('MultivariateNormal', ('loc', 'scale_tril')),
     ('NonreparameterizedBeta', ('concentration1', 'concentration0')),
@@ -317,6 +326,11 @@ FUNSOR_DIST_NAMES = [
     ('NonreparameterizedGamma', ('concentration', 'rate')),
     ('NonreparameterizedNormal', ('loc', 'scale')),
     ('Normal', ('loc', 'scale')),
+    ("Pareto", ()),
+    ("Poisson", ()),
+    ("StudentT", ()),
+    ("Uniform", ()),
+    ("VonMises", ()),
 ]
 
 

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -87,36 +87,21 @@ def _get_numpyro_dist(dist_name):
         return getattr(dist, dist_name, None)
 
 
-NUMPYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
-    ("Cauchy", ()),
-    ("Chi2", ()),
-    ("ContinuousBernoulli", ("logits",)),
-    ("Exponential", ()),
-    ("FisherSnedecor", ()),
-    ("Geometric", ("probs",)),
-    ("Gumbel", ()),
-    ("HalfCauchy", ()),
-    ("HalfNormal", ()),
-    ("Laplace", ()),
-    ("LowRankMultivariateNormal", ()),
-    ("Pareto", ()),
-    ("Poisson", ()),
-    ("StudentT", ()),
-    ("Uniform", ()),
-    ("VonMises", ()),
-]
-_HAS_RSAMPLE_DISTS = ['Beta', 'Dirichlet', 'Gamma', 'Normal', 'MultivariateNormal']
+NUMPYRO_DIST_NAMES = FUNSOR_DIST_NAMES
+# TODO: remove this after the next NumPyro release
+_HAS_RSAMPLE_DISTS = ['Beta', 'Cauchy', 'Chi2', 'Delta', 'Dirichlet', 'Exponential', 'Gamma',
+                      'MultivariateNormal', 'Normal', 'Pareto', 'StudentT', 'Uniform']
 
 
 for dist_name, param_names in NUMPYRO_DIST_NAMES:
     numpyro_dist = _get_numpyro_dist(dist_name)
     if numpyro_dist is not None:
-        # resolve numpyro distributions do not have `has_rsample` attributes
-        has_rsample = getattr(numpyro_dist, 'has_rsample',
-                              not getattr(numpyro_dist, "is_discrete", dist_name not in _HAS_RSAMPLE_DISTS))
-        if has_rsample:
-            numpyro_dist.has_rsample = True
-            numpyro_dist.rsample = numpyro_dist.sample
+        # TODO: remove this after the next NumPyro release
+        if not hasattr(numpyro_dist, "has_rsample"):
+            has_rsample = dist_name in _HAS_RSAMPLE_DISTS
+            numpyro_dist.has_rsample = has_rsample
+            if has_rsample:
+                numpyro_dist.rsample = numpyro_dist.sample
         locals()[dist_name] = make_dist(numpyro_dist, param_names)
 
 
@@ -216,12 +201,15 @@ def deltadist_to_data(funsor_dist, name_to_dim=None):
 ###############################################
 
 # TODO move these properties upstream to numpyro.distributions
-dist.Independent.has_rsample = property(lambda self: self.base_dist.has_rsample)
-dist.Independent.rsample = dist.Independent.sample
-dist.MaskedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
-dist.MaskedDistribution.rsample = dist.MaskedDistribution.sample
-dist.TransformedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
-dist.TransformedDistribution.rsample = dist.TransformedDistribution.sample
+if not hasattr(dist.Independent, "has_rsample"):
+    dist.Independent.has_rsample = property(lambda self: self.base_dist.has_rsample)
+    dist.Independent.rsample = dist.Independent.sample
+if not hasattr(dist.MaskedDistribution, "has_rsample"):
+    dist.MaskedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
+    dist.MaskedDistribution.rsample = dist.MaskedDistribution.sample
+if not hasattr(dist.TransformedDistribution, "has_rsample"):
+    dist.TransformedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
+    dist.TransformedDistribution.rsample = dist.TransformedDistribution.sample
 
 to_funsor.register(dist.Independent)(indepdist_to_funsor)
 if hasattr(dist, "MaskedDistribution"):

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -93,26 +93,12 @@ def _get_pyro_dist(dist_name):
 
 
 PYRO_DIST_NAMES = FUNSOR_DIST_NAMES + [
-    ("Cauchy", ()),
-    ("Chi2", ()),
     ("ContinuousBernoulli", ("logits",)),
-    ("Exponential", ()),
     ("FisherSnedecor", ()),
-    ("Geometric", ("probs",)),
-    ("Gumbel", ()),
-    ("HalfCauchy", ()),
-    ("HalfNormal", ()),
-    ("Laplace", ()),
     # ("LogisticNormal", ()),  # TODO handle as transformed dist
-    ("LowRankMultivariateNormal", ()),
     ("NegativeBinomial", ("total_count", "probs")),
     ("OneHotCategorical", ("probs",)),
-    ("Pareto", ()),
-    ("Poisson", ()),
     ("RelaxedBernoulli", ("temperature", "logits")),
-    ("StudentT", ()),
-    ("Uniform", ()),
-    ("VonMises", ()),
     ("Weibull", ()),
 ]
 


### PR DESCRIPTION
This unblocks https://github.com/pyro-ppl/numpyro/pull/844.

Currently, we checked if a numpyro dist has the attribute `has_rsample`. If it does, `has_rsample` will be True. That logic is incorrect because `has_rsample` can be a property or get the value False. This PR fixes that bug.