### PR TITLE
Support partial windows in sarkka_bilmes_product

### DIFF
--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -473,39 +473,44 @@ def mixed_sequential_sum_product(sum_op, prod_op, trans, time, step, num_segment
     return second_stage_result
 
 
+def _get_shift(name):
+    """helper function used internally in sarkka_bilmes_product"""
+    return len(re.search("^P*", name).group(0))
+
+
+def _shift_name(name, t):
+    """helper function used internally in sarkka_bilmes_product"""
+    return t * "P" + name
+
+
+def _shift_funsor(f, t, global_vars):
+    """helper function used internally in sarkka_bilmes_product"""
+    if t == 0:
+        return f
+    return f(**{name: _shift_name(name, t) for name in f.inputs if name not in global_vars})
+
+
 def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozenset()):
 
     assert isinstance(global_vars, frozenset)
 
     time = time_var.name
+    global_vars |= {time}
 
-    def get_shift(name):
-        return len(re.search("^P*", name).group(0))
-
-    def shift_name(name, t):
-        return t * "P" + name
-
-    def shift_funsor(f, t):
-        if t == 0:
-            return f
-        return f(**{name: shift_name(name, t) for name in f.inputs
-                    if name != time and name not in global_vars})
-
-    lags = {get_shift(name) for name in trans.inputs if name != time}
+    lags = {_get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
     if not lags:
         return naive_sequential_sum_product(sum_op, prod_op, trans, time_var, {})
 
     original_names = frozenset(name for name in trans.inputs
-                               if name != time and name not in global_vars
-                               and not name.startswith("P"))
+                               if name not in global_vars and not name.startswith("P"))
 
     duration = trans.inputs[time].size
 
     result = trans(**{time: duration - 1})
     for t in range(duration - 2, -1, -1):
-        result = prod_op(shift_funsor(trans(**{time: t}), duration - t - 1), result)
-        sum_vars = frozenset(shift_name(name, duration - t - 1) for name in original_names)
+        result = prod_op(_shift_funsor(trans(**{time: t}), duration - t - 1, global_vars), result)
+        sum_vars = frozenset(_shift_name(name, duration - t - 1) for name in original_names)
         result = result.reduce(sum_op, sum_vars)
 
     result = result(**{name: name.replace("P" * duration, "P") for name in result.inputs})
@@ -517,66 +522,58 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozense
     assert isinstance(global_vars, frozenset)
 
     time = time_var.name
+    global_vars |= {time}
 
-    def get_shift(name):
-        return len(re.search("^P*", name).group(0))
-
-    def shift_name(name, t):
-        if t < 0:
-            return name.replace("P" * -t, "", 1)
-        return t * "P" + name
-
-    def shift_funsor(f, t):
-        if t == 0:
-            return f
-        return f(**{name: shift_name(name, t) for name in f.inputs
-                    if name != time and name not in global_vars})
-
-    lags = {get_shift(name) for name in trans.inputs if name != time}
+    lags = {_get_shift(name) for name in trans.inputs if name != time}
     lags.discard(0)
     if not lags:
         return sequential_sum_product(sum_op, prod_op, trans, time_var, {})
 
     period = int(reduce(lambda a, b: a * b // gcd(a, b), list(lags)))
     original_names = frozenset(name for name in trans.inputs
-                               if name != time and name not in global_vars
-                               and not name.startswith("P"))
+                               if name not in global_vars and not name.startswith("P"))
     renamed_factors = []
     duration = trans.inputs[time].size
     if duration % period != 0:
         remaining_duration = duration % period
         truncated_duration = duration - remaining_duration
-        truncated_time_var = Variable(time, Bint[truncated_duration])
-        # chop off the rightmost set of complete chunks
-        truncated_trans = trans(**{time: Slice(time, remaining_duration, duration, 1, duration)})
-
-        # recursively call sarkka_bilmes_product on truncated factor
-        result = sarkka_bilmes_product(sum_op, prod_op, truncated_trans, truncated_time_var, global_vars, num_periods)
+        if truncated_duration == 0:
+            result = trans(**{time: remaining_duration - 1})
+            remaining_duration -= 1
+        else:
+            # chop off the rightmost set of complete chunks from trans,
+            # then recursively call sarkka_bilmes_product on truncated factor
+            result = sarkka_bilmes_product(
+                sum_op, prod_op,
+                trans(**{time: Slice(time, remaining_duration, duration, 1, duration)}),
+                Variable(time, Bint[truncated_duration]),
+                global_vars - {time}, num_periods
+            )
 
         # sequentially combine remaining pieces with result
         for t in reversed(range(remaining_duration)):
-            result = prod_op(shift_funsor(trans(**{time: t}), remaining_duration - t), result)
-            sum_vars = frozenset(shift_name(name, remaining_duration - t) for name in original_names)
+            result = prod_op(_shift_funsor(trans(**{time: t}), remaining_duration - t, global_vars), result)
+            sum_vars = frozenset(_shift_name(name, remaining_duration - t) for name in original_names)
             result = result.reduce(sum_op, sum_vars)
 
-        result = result(**{name: shift_name(name, -remaining_duration) for name in result.inputs})
+        result = result(**{name: name.replace("P" * remaining_duration, "", 1) for name in result.inputs})
         return result
 
     for t in range(period):
         slice_t = Slice(time, t, duration - period + t + 1, period, duration)
-        factor = shift_funsor(trans, period - t - 1)
+        factor = _shift_funsor(trans, period - t - 1, global_vars)
         factor = factor(**{time: slice_t})
         renamed_factors.append(factor)
 
     block_trans = reduce(prod_op, renamed_factors)
-    block_step = {shift_name(name, period): name for name in block_trans.inputs
-                  if name != time and name not in global_vars and get_shift(name) < period}
+    block_step = {_shift_name(name, period): name for name in block_trans.inputs
+                  if name not in global_vars and _get_shift(name) < period}
     block_time_var = Variable(time_var.name, Bint[duration // period])
     final_chunk = mixed_sequential_sum_product(
         sum_op, prod_op, block_trans, block_time_var, block_step,
         num_segments=max(1, duration // (period * num_periods)))
     final_sum_vars = frozenset(
-        shift_name(name, t) for name in original_names for t in range(1, period))
+        _shift_name(name, t) for name in original_names for t in range(1, period))
     result = final_chunk.reduce(sum_op, final_sum_vars)
     result = result(**{name: name.replace("P" * period, "P") for name in result.inputs})
     return result

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -480,7 +480,9 @@ def _get_shift(name):
 
 def _shift_name(name, t):
     """helper function used internally in sarkka_bilmes_product"""
-    return t * "P" + name
+    if t >= 0:
+        return t * "P" + name
+    return name.replace("P" * -t, "", 1)
 
 
 def _shift_funsor(f, t, global_vars):
@@ -513,7 +515,7 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=fr
         sum_vars = frozenset(_shift_name(name, duration - t - 1) for name in original_names)
         result = result.reduce(sum_op, sum_vars)
 
-    result = result(**{name: name.replace("P" * duration, "P") for name in result.inputs})
+    result = result(**{name: _shift_name(name, -duration + 1) for name in result.inputs})
     return result
 
 
@@ -556,7 +558,7 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozense
             sum_vars = frozenset(_shift_name(name, remaining_duration - t) for name in original_names)
             result = result.reduce(sum_op, sum_vars)
 
-        result = result(**{name: name.replace("P" * remaining_duration, "", 1) for name in result.inputs})
+        result = result(**{name: _shift_name(name, -remaining_duration) for name in result.inputs})
         return result
 
     for t in range(period):
@@ -575,7 +577,7 @@ def sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=frozense
     final_sum_vars = frozenset(
         _shift_name(name, t) for name in original_names for t in range(1, period))
     result = final_chunk.reduce(sum_op, final_sum_vars)
-    result = result(**{name: name.replace("P" * period, "P") for name in result.inputs})
+    result = result(**{name: _shift_name(name, -period + 1) for name in result.inputs})
     return result
 
 

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -496,7 +496,6 @@ def naive_sarkka_bilmes_product(sum_op, prod_op, trans, time_var, global_vars=fr
     if not lags:
         return naive_sequential_sum_product(sum_op, prod_op, trans, time_var, {})
 
-    period = int(reduce(lambda a, b: a * b // gcd(a, b), list(lags)))
     original_names = frozenset(name for name in trans.inputs
                                if name != time and name not in global_vars
                                and not name.startswith("P"))

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -1587,7 +1587,7 @@ def test_sarkka_bilmes_example_1(duration):
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
-@pytest.mark.parametrize("duration", [2, 4, 6, 8])
+@pytest.mark.parametrize("duration", [2, 3, 4, 5, 6, 7, 8])
 def test_sarkka_bilmes_example_2(duration):
 
     trans = random_tensor(OrderedDict({
@@ -1611,7 +1611,7 @@ def test_sarkka_bilmes_example_2(duration):
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
-@pytest.mark.parametrize("duration", [2, 4, 6, 8])
+@pytest.mark.parametrize("duration", [2, 3, 4, 5, 6, 7, 8])
 def test_sarkka_bilmes_example_3(duration):
 
     trans = random_tensor(OrderedDict({
@@ -1631,7 +1631,7 @@ def test_sarkka_bilmes_example_3(duration):
     _check_sarkka_bilmes(trans, expected_inputs, frozenset())
 
 
-@pytest.mark.parametrize("duration", [3, 6, 9])
+@pytest.mark.parametrize("duration", [3, 4, 5, 6, 7, 9])
 def test_sarkka_bilmes_example_4(duration):
 
     trans = random_tensor(OrderedDict({
@@ -1672,7 +1672,7 @@ def test_sarkka_bilmes_example_5(duration):
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
 
-@pytest.mark.parametrize("duration", [3, 6, 9])
+@pytest.mark.parametrize("duration", [3, 4, 5, 6, 7, 8, 9])
 def test_sarkka_bilmes_example_6(duration):
 
     trans = random_tensor(OrderedDict({

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -1696,7 +1696,7 @@ def test_sarkka_bilmes_example_6(duration):
     _check_sarkka_bilmes(trans, expected_inputs, global_vars)
 
 
-@pytest.mark.parametrize("time_input", [("time", Bint[t]) for t in range(2, 10)])
+@pytest.mark.parametrize("time_input", [("time", Bint[t]) for t in range(6, 11)])
 @pytest.mark.parametrize("global_inputs", [
     (),
     (("x", Bint[2]),),
@@ -1744,16 +1744,7 @@ def test_sarkka_bilmes_generic(time_input, global_inputs, local_inputs, num_peri
     else:
         trans = random_tensor(trans_inputs)
 
-    try:
-        _check_sarkka_bilmes(trans, expected_inputs, global_vars, num_periods)
-    except NotImplementedError as e:
-        partial_reasons = (
-            'TODO handle partial windows',
-        )
-        if any(reason in e.args[0] for reason in partial_reasons):
-            pytest.xfail(reason=e.args[0])
-        else:
-            raise
+    _check_sarkka_bilmes(trans, expected_inputs, global_vars, num_periods)
 
 
 @pytest.mark.parametrize("duration,num_segments", [(12, 1), (12, 2), (12, 3), (12, 4), (12, 6)])


### PR DESCRIPTION
Addresses #293, https://github.com/pyro-ppl/numpyro/pull/848

This PR adds support for partial windows in `funsor.sum_product.sarkka_bilmes_product`, i.e. for factors where `duration % period != 0`.  The algorithm now breaks the input funsor into two contiguous pieces: one containing the rightmost `duration - (duration % period)` slices and one containing the remaining slices on the left.  It then recursively calls `sarkka_bilmes_product` on the right piece and sequentially combines the result with slices from the left piece.

Tested:
- Added cases to existing `sarkka_bilmes_product` tests in `test_sum_product.py`