### PR TITLE
Defer has_rsample to raw_dist

### DIFF
--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -496,7 +496,7 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
+    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=2e-4 if use_lazy else 1e-3)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -496,7 +496,7 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=2e-4 if use_lazy else 1e-3)
+    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)


### PR DESCRIPTION
Fixes failing tests in #409. Currently, funsor Distribution assumes that `has_rsample` is a class attribute but in NumPyro (and derived classes such as TransformedDistribution, Independent, MaskedDistribution, ExpandedDistribution), it is a property. So `getattr(self.dist_class, "has_rsample", False)` will always return False.

I think we can also cache `has_rsample` or `has_enumerate_support` in `self._has_rsample` or `self._has_enumerate_support` when calling `_infer_value_domain`.