### PR TITLE
Ensure alpha conversion always runs when a new variable is bound

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -41,19 +41,19 @@ def substitute(expr, subs):
         return interpreter.reinterpret(expr)
 
 
-def _alpha_mangle(expr):
+def _alpha_mangle(expr, identifier):
     """
     Rename bound variables in expr to avoid conflict with any free variables.
-
-    FIXME this does not avoid conflict with other bound variables.
+    Returns expr._ast_values with mangled names.
     """
-    alpha_subs = {name: interpreter.gensym(name + "__BOUND")
-                  for name in expr.bound if "__BOUND" not in name}
+    # how we know which variables to mangle: we assume variable names include
+    # constant-size information about the original binding context,
+    # in the form of a cons-hash key of the binding context.
+    alpha_subs = {name: name.split("__BOUND")[0] + "__BOUND_" + identifier
+                  for name in expr.bound if identifier not in name}
     if not alpha_subs:
-        return expr
-
-    ast_values = expr._alpha_convert(alpha_subs)
-    return reflect(type(expr), *ast_values)
+        return expr._ast_values
+    return expr._alpha_convert(alpha_subs)  # return mangled _ast_values
 
 
 def reflect(cls, *args, **kwargs):
@@ -81,8 +81,15 @@ def reflect(cls, *args, **kwargs):
     result = super(FunsorMeta, cls_specific).__call__(*args)
     result._ast_values = args
 
-    # alpha-convert eagerly upon binding any variable
-    result = _alpha_mangle(result)
+    # alpha-convert eagerly upon binding any variable.
+    # the identifier we use to reconcile alpha-conversion and cons-hashing
+    # is the string literal of hash() of the type and cons-hashing key:
+    alpha_mangled_args = _alpha_mangle(result, str(hash((cls_specific,) + cache_key)))
+    # TODO eliminate code duplication here...
+    result = super(FunsorMeta, cls_specific).__call__(*alpha_mangled_args)
+    result._ast_values = alpha_mangled_args
+    cache_key = tuple(id(arg) if type(arg).__name__ == "DeviceArray" or not isinstance(arg, Hashable)
+                      else arg for arg in alpha_mangled_args)
 
     cls._cons_cache[cache_key] = result
     return result

--- a/test/test_alpha_conversion.py
+++ b/test/test_alpha_conversion.py
@@ -115,3 +115,11 @@ def test_sample_independent():
     actual = Independent(f, 'x', 'i', 'x_i')
     assert actual.sample('i')
     assert actual.sample('j', {'i': 2})
+
+
+def test_subs_already_bound():
+    with interpretation(reflect):
+        x = Variable('x', Real)
+        y1 = (2 * x)(x=3)
+        y2 = y1.arg(4)
+    assert y1.bound != y2.bound


### PR DESCRIPTION
This PR fixes a longstanding alpha-conversion edge case by guaranteeing that newly bound variables are always alpha-renamed, which is currently not the case due to the way alpha-conversion interacts with cons-hashing.  For context, this issue turned out to be the root cause of some strange, difficult-to-debug errors that came up when I tested `funsor.adjoint` with `funsor.sum_product.modified_partial_sum_product`.  I imagine @ordabayevy will run into this at some point, so think of this PR as preemptive unblocking.

Recall that alpha conversion in Funsor is implemented with name-mangling of subexpressions in `reflect`: whenever a variable is newly bound in a Funsor expression, we append to its name a unique suffix of the form `f"__BOUND_{identifier}"`, where `identifier` is some short piece of information ensuring that the mangled name will not collide with bound variables elsewhere in the expression.  Right now, `identifier` is just a global counter incremented after each `funsor.interpreter.gensym()` call.  

However, to ensure that expressions that bind variables are cons-hashed, we have to avoid mangling names twice.  This is currently achieved by only mangling bound variables whose names do not already contain a `__BOUND_` suffix. Unfortunately, this heuristic can break down in cases where subexpressions with bound variables are (temporarily) exposed for further processing. One place where this can occur is in `funsor.adjoint`, especially in the nested `funsor.terms.Subs` expressions in `funsor.sum_product.sequential_sum_product`.

This PR replaces the global counter `identifier` with the (`hash()` of) the cons-hash key of the binding expression.  At the cost of slightly longer (but still constant-size) bound variable names, this change should guarantee that alpha-conversion always behaves as expected.

Tested:
- Added a simple regression test that fails on `master`
- Exercised explicitly by existing tests in `test_alpha_conversion.py` and implicitly in any test that compares identities of expressions with bound variables (`x1 is x2`)