### PR TITLE
support ExpandedDistribution for jax backend

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -372,7 +372,7 @@ def expandeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
         if name == "value":
             continue
         raw_param = to_data(funsor_param, name_to_dim=name_to_dim)
-        raw_expanded_params[name] = raw_param.expand(backend_dist.batch_shape + funsor_param.shape)
+        raw_expanded_params[name] = ops.expand(raw_param, backend_dist.batch_shape + funsor_param.shape)
 
     raw_expanded_dist = type(backend_dist.base_dist)(**raw_expanded_params)
     return to_funsor(raw_expanded_dist, output, dim_to_name)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -30,6 +30,7 @@ from funsor.distribution import (  # noqa: F401
     eager_mvn,
     eager_normal,
     eager_plate_multinomial,
+    expandeddist_to_funsor,
     indepdist_to_funsor,
     make_dist,
     maskeddist_to_funsor,
@@ -211,6 +212,7 @@ if not hasattr(dist.TransformedDistribution, "has_rsample"):
     dist.TransformedDistribution.has_rsample = property(lambda self: self.base_dist.has_rsample)
     dist.TransformedDistribution.rsample = dist.TransformedDistribution.sample
 
+to_funsor.register(dist.ExpandedDistribution)(expandeddist_to_funsor)
 to_funsor.register(dist.Independent)(indepdist_to_funsor)
 if hasattr(dist, "MaskedDistribution"):
     to_funsor.register(dist.MaskedDistribution)(maskeddist_to_funsor)

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -44,6 +44,8 @@ if get_backend() == "jax":
     _expanded_dist_path = "backend_dist.ExpandedDistribution"
 elif get_backend() == "torch":
     _expanded_dist_path = "backend_dist.torch_distribution.ExpandedDistribution"
+else:
+    _expanded_dist_path = ""
 
 
 def normalize_with_subs(cls, *args):


### PR DESCRIPTION
Follow up #418.

Though we can eagerly expand distributions, as in https://github.com/pyro-ppl/numpyro/pull/809/files, it might be better to not have to think about doing so each time we want to use funsor. :D