### PR TITLE
Unify op-caching metaclasses

### DIFF
--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op
+from .op import DISTRIBUTIVE_OPS, Op, OpCacheMeta
 
 _builtin_all = all
 _builtin_any = any
@@ -66,20 +66,7 @@ logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
 sample = SampleOp(_logaddexp, name="sample")
 
 
-class ReshapeMeta(type):
-    _cache = {}
-
-    def __call__(cls, shape):
-        shape = tuple(shape)
-        try:
-            return ReshapeMeta._cache[shape]
-        except KeyError:
-            instance = super().__call__(shape)
-            ReshapeMeta._cache[shape] = instance
-            return instance
-
-
-class ReshapeOp(Op, metaclass=ReshapeMeta):
+class ReshapeOp(Op, metaclass=OpCacheMeta):
     def __init__(self, shape):
         self.shape = shape
         super().__init__(self._default)

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op, OpCacheMeta
+from .op import DISTRIBUTIVE_OPS, Op, CachedOpMeta
 
 _builtin_all = all
 _builtin_any = any
@@ -66,7 +66,13 @@ logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
 sample = SampleOp(_logaddexp, name="sample")
 
 
-class ReshapeOp(Op, metaclass=OpCacheMeta):
+class ReshapeMeta(CachedOpMeta):
+    def __call__(cls, shape):
+        shape = tuple(shape)  # necessary to convert torch.Size to tuple
+        return super().__call__(shape)
+
+
+class ReshapeOp(Op, metaclass=ReshapeMeta):
     def __init__(self, shape):
         self.shape = shape
         super().__init__(self._default)

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -5,7 +5,7 @@ import math
 import operator
 from numbers import Number
 
-from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, TransformOp
+from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, OpCacheMeta, TransformOp
 
 _builtin_abs = abs
 _builtin_max = max
@@ -53,19 +53,7 @@ def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
 
 
-class GetitemMeta(type):
-    _cache = {}
-
-    def __call__(cls, offset):
-        try:
-            return GetitemMeta._cache[offset]
-        except KeyError:
-            instance = super(GetitemMeta, cls).__call__(offset)
-            GetitemMeta._cache[offset] = instance
-            return instance
-
-
-class GetitemOp(Op, metaclass=GetitemMeta):
+class GetitemOp(Op, metaclass=OpCacheMeta):
     """
     Op encoding an index into one dimension, e.g. ``x[:,:,y]`` for offset of 2.
     """

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -5,7 +5,7 @@ import math
 import operator
 from numbers import Number
 
-from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, OpCacheMeta, TransformOp
+from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, CachedOpMeta, TransformOp
 
 _builtin_abs = abs
 _builtin_max = max
@@ -53,7 +53,7 @@ def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
 
 
-class GetitemOp(Op, metaclass=OpCacheMeta):
+class GetitemOp(Op, metaclass=CachedOpMeta):
     """
     Op encoding an index into one dimension, e.g. ``x[:,:,y]`` for offset of 2.
     """

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -4,6 +4,19 @@
 from multipledispatch import Dispatcher
 
 
+class OpCacheMeta(type):
+    """
+    Metaclass for caching op instance construction.
+    """
+    _cache = {}
+
+    def __call__(cls, *args, **kwargs):
+        key = (cls,) + tuple(args) + tuple(kwargs.items())
+        if key not in OpCacheMeta._cache:
+            OpCacheMeta._cache[key] = super(OpCacheMeta, cls).__call__(*args, **kwargs)
+        return OpCacheMeta._cache[key]
+
+
 class Op(Dispatcher):
     def __init__(self, fn, *, name=None):
         if isinstance(fn, str):
@@ -69,6 +82,7 @@ PRODUCT_INVERSES = {}     # op -> inverse op
 __all__ = [
     'DISTRIBUTIVE_OPS',
     'Op',
+    'OpCacheMeta',
     'PRODUCT_INVERSES',
     'TransformOp',
     'UNITS',


### PR DESCRIPTION
Addresses #351. ~~Blocked by #420.~~

Some ops, such as `ops.reshape` and `ops.getitem`, take non-Funsor arguments in their constructors, and make use of custom metaclasses to memoize class creation.  This PR replaces those metaclasses with a single metaclass `funsor.ops.op.OpCacheMeta`.

The motivation for this PR is that the plan in #351 includes adding a `Finitary` funsor term representing lazy op application and refactoring `funsor.function` to generate new op classes and type inference rules on the fly, and we will want to generate these classes with something like `OpCacheMeta` to ensure that they are compatible with Funsor cons-hashing.

`OpCacheMeta` will also be useful for extending support for lazy evaluation on funsors to more ops, and for refactoring some funsor terms that are conceptually closer to an op than a first-class funsor.  For example, as part of #351 we will want to replace the Funsor term `funsor.tensor.Einsum` with an op class `EinsumOp` parametrized by `equation`, similar to how `ops.reshape` is parametrized by the target shape.

Tested:
- Exercised by existing tests of `reshape` and `getitem`