### PR TITLE
Break up type inference rules in find_domain into op-level patterns

### DIFF
--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -256,7 +256,7 @@ def _scatter(src, res, subs):
     return Tensor(data, inputs, res.dtype)
 
 
-@adjoint_ops.register(Subs, ops.LogAddExpOp, ops.AddOp, GaussianMixture, GaussianMixture, tuple)
+@adjoint_ops.register(Subs, ops.LogaddexpOp, ops.AddOp, GaussianMixture, GaussianMixture, tuple)
 def adjoint_subs_gaussianmixture_gaussianmixture(adj_redop, adj_binop, out_adj, arg, subs):
 
     if any(v.dtype == 'real' and not isinstance(v, Variable) for k, v in subs):
@@ -301,7 +301,7 @@ def adjoint_subs_gaussianmixture_gaussianmixture(adj_redop, adj_binop, out_adj, 
     return {arg: in_adj}
 
 
-@adjoint_ops.register(Subs, ops.LogAddExpOp, ops.AddOp, Gaussian, GaussianMixture, tuple)
+@adjoint_ops.register(Subs, ops.LogaddexpOp, ops.AddOp, Gaussian, GaussianMixture, tuple)
 def adjoint_subs_gaussianmixture_discrete(adj_redop, adj_binop, out_adj, arg, subs):
 
     if any(v.dtype == 'real' and not isinstance(v, Variable) for k, v in subs):
@@ -312,7 +312,7 @@ def adjoint_subs_gaussianmixture_discrete(adj_redop, adj_binop, out_adj, arg, su
     return {arg: adjoint_ops(Subs, adj_redop, adj_binop, out_adj_, arg, subs)[arg]}
 
 
-@adjoint_ops.register(Subs, ops.LogAddExpOp, ops.AddOp, (GaussianMixture, Gaussian), Gaussian, tuple)
+@adjoint_ops.register(Subs, ops.LogaddexpOp, ops.AddOp, (GaussianMixture, Gaussian), Gaussian, tuple)
 def adjoint_subs_gaussian_gaussian(adj_redop, adj_binop, out_adj, arg, subs):
 
     if any(v.dtype == 'real' and not isinstance(v, Variable) for k, v in subs):
@@ -323,7 +323,7 @@ def adjoint_subs_gaussian_gaussian(adj_redop, adj_binop, out_adj, arg, subs):
     return {arg: adjoint_ops(Subs, adj_redop, adj_binop, out_adj, arg_, subs)[arg_]}
 
 
-@adjoint_ops.register(Subs, ops.LogAddExpOp, ops.AddOp, (Number, Tensor), GaussianMixture, tuple)
+@adjoint_ops.register(Subs, ops.LogaddexpOp, ops.AddOp, (Number, Tensor), GaussianMixture, tuple)
 def adjoint_subs_gaussianmixture_discrete(adj_redop, adj_binop, out_adj, arg, subs):
 
     if any(v.dtype == 'real' and not isinstance(v, Variable) for k, v in subs):

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -160,7 +160,7 @@ class Contraction(Funsor):
         return red_op, bin_op, reduced_vars, terms
 
 
-GaussianMixture = Contraction[Union[ops.LogAddExpOp, NullOp], ops.AddOp, frozenset,
+GaussianMixture = Contraction[Union[ops.LogaddexpOp, NullOp], ops.AddOp, frozenset,
                               Tuple[Union[Tensor, Number], Gaussian]]
 
 
@@ -259,7 +259,7 @@ def eager_contraction_tensor(red_op, bin_op, reduced_vars, *terms):
     return _eager_contract_tensors(reduced_vars, terms, backend=backend)
 
 
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Tensor, Tensor)
+@eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Tensor, Tensor)
 def eager_contraction_tensor(red_op, bin_op, reduced_vars, *terms):
     if not all(term.dtype == "real" for term in terms):
         raise NotImplementedError('TODO')
@@ -306,7 +306,7 @@ def _eager_contract_tensors(reduced_vars, terms, backend):
 # TODO(https://github.com/pyro-ppl/funsor/issues/238) Use a port of
 # Pyro's gaussian_tensordot() here. Until then we must eagerly add the
 # possibly-rank-deficient terms before reducing to avoid Cholesky errors.
-@eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset,
+@eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset,
                 GaussianMixture, GaussianMixture)
 def eager_contraction_gaussian(red_op, bin_op, reduced_vars, x, y):
     return (x + y).reduce(red_op, reduced_vars)
@@ -455,7 +455,7 @@ def binary_subtract(op, lhs, rhs):
     return lhs + -rhs
 
 
-@normalize.register(Binary, ops.DivOp, Funsor, Funsor)
+@normalize.register(Binary, ops.TruedivOp, Funsor, Funsor)
 def binary_divide(op, lhs, rhs):
     return lhs * Unary(ops.reciprocal, rhs)
 

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -254,7 +254,7 @@ def _find_domain_associative_generic(op, *domains):
     assert 1 <= len(domains) <= 2
 
     if len(domains) == 1:
-        return Array[domains[0].dtype, domains[0].shape]
+        return Array[domains[0].dtype, ()]
 
     lhs, rhs = domains
     if lhs.dtype == 'real' or rhs.dtype == 'real':

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -191,6 +191,8 @@ def find_domain(op, *domains):
     raise NotImplementedError
 
 
+@find_domain.register(ops.Op)  # TODO this is too general, register all ops
+@find_domain.register(ops.TransformOp)  # TODO too general, may be wrong for some
 @find_domain.register(ops.ReciprocalOp)
 @find_domain.register(ops.SigmoidOp)
 @find_domain.register(ops.TanhOp)
@@ -199,7 +201,7 @@ def find_domain(op, *domains):
 @find_domain.register(ops.ExpOp)
 def _find_domain_pointwise_unary_transform(op, domain):
     if isinstance(domain, ArrayType):
-        return Array['real', domain.shape]
+        return Array[domain.dtype, domain.shape]
     raise NotImplementedError
 
 
@@ -215,13 +217,20 @@ def _find_domain_getitem(op, lhs, rhs):
     return Array[dtype, shape]
 
 
+@find_domain.register(ops.EqOp)
+@find_domain.register(ops.GeOp)
+@find_domain.register(ops.GtOp)
+@find_domain.register(ops.LeOp)
+@find_domain.register(ops.LtOp)
+@find_domain.register(ops.NeOp)
 @find_domain.register(ops.PowOp)
 @find_domain.register(ops.SubOp)
 @find_domain.register(ops.DivOp)
 def _find_domain_pointwise_binary_generic(op, lhs, rhs):
-    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):
+    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType) and \
+            lhs.dtype == rhs.dtype:
         return Array[lhs.dtype, broadcast_shape(lhs.shape, rhs.shape)]
-    raise NotImplementedError
+    raise NotImplementedError("TODO")
 
 
 @find_domain.register(ops.MatmulOp)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copyreg
+import functools
 import operator
 import warnings
 from functools import reduce

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -197,12 +197,16 @@ def find_domain(op, *domains):
 @find_domain.register(ops.SigmoidOp)
 @find_domain.register(ops.TanhOp)
 @find_domain.register(ops.AtanhOp)
-@find_domain.register(ops.LogOp)
-@find_domain.register(ops.ExpOp)
 def _find_domain_pointwise_unary_transform(op, domain):
     if isinstance(domain, ArrayType):
         return Array[domain.dtype, domain.shape]
     raise NotImplementedError
+
+
+@find_domain.register(ops.LogOp)
+@find_domain.register(ops.ExpOp)
+def _find_domain_log_exp(op, domain):
+    return Array['real', domain.shape]
 
 
 @find_domain.register(ops.ReshapeOp)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -225,7 +225,7 @@ def _find_domain_getitem(op, lhs, rhs):
 @find_domain.register(ops.NeOp)
 @find_domain.register(ops.PowOp)
 @find_domain.register(ops.SubOp)
-@find_domain.register(ops.DivOp)
+@find_domain.register(ops.TruedivOp)
 def _find_domain_pointwise_binary_generic(op, lhs, rhs):
     if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType) and \
             lhs.dtype == rhs.dtype:

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -214,7 +214,7 @@ def _find_domain_getitem(op, lhs, rhs):
     return Array[dtype, shape]
 
 
-# @find_domain.register(ops.PowOp)
+@find_domain.register(ops.PowOp)
 @find_domain.register(ops.SubOp)
 @find_domain.register(ops.DivOp)
 def _find_domain_pointwise_binary_generic(op, lhs, rhs):

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -180,43 +180,73 @@ def _(arg, indent, out):
     out.append((indent, repr(arg)))
 
 
+@functools.singledispatch
 def find_domain(op, *domains):
     r"""
     Finds the :class:`Domain` resulting when applying ``op`` to ``domains``.
     :param callable op: An operation.
     :param Domain \*domains: One or more input domains.
     """
-    assert callable(op), op
-    assert all(isinstance(arg, Domain) for arg in domains)
+    raise NotImplementedError
+
+
+@find_domain.register(ops.ReciprocalOp)
+@find_domain.register(ops.SigmoidOp)
+@find_domain.register(ops.TanhOp)
+@find_domain.register(ops.AtanhOp)
+@find_domain.register(ops.LogOp)
+@find_domain.register(ops.ExpOp)
+def _find_domain_pointwise_unary_transform(op, domain):
+    if isinstance(domain, ArrayType):
+        return Array['real', domain.shape]
+    raise NotImplementedError
+
+
+@find_domain.register(ops.ReshapeOp)
+def _find_domain_reshape(op, domain):
+    return Array[domain.dtype, op.shape]
+
+
+@find_domain.register(ops.GetitemOp)
+def _find_domain_getitem(op, lhs, rhs):
+    dtype = lhs.dtype
+    shape = lhs.shape[:op.offset] + lhs.shape[1 + op.offset:]
+    return Array[dtype, shape]
+
+
+# @find_domain.register(ops.PowOp)
+@find_domain.register(ops.SubOp)
+@find_domain.register(ops.DivOp)
+def _find_domain_pointwise_binary_generic(op, lhs, rhs):
+    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):
+        return Array[lhs.dtype, broadcast_shape(lhs.shape, rhs.shape)]
+    raise NotImplementedError
+
+
+@find_domain.register(ops.MatmulOp)
+def _find_domain_matmul(op, lhs, rhs):
+    assert lhs.shape and rhs.shape
+    if len(rhs.shape) == 1:
+        assert lhs.shape[-1] == rhs.shape[-1]
+        shape = lhs.shape[:-1]
+    elif len(lhs.shape) == 1:
+        assert lhs.shape[-1] == rhs.shape[-2]
+        shape = rhs.shape[:-2] + rhs.shape[-1:]
+    else:
+        assert lhs.shape[-1] == rhs.shape[-2]
+        shape = broadcast_shape(lhs.shape[:-1], rhs.shape[:-2] + (1,)) + rhs.shape[-1:]
+    return Reals[shape]
+
+
+@find_domain.register(ops.AssociativeOp)
+def _find_domain_associative_generic(op, *domains):
+
+    assert 1 <= len(domains) <= 2
+
     if len(domains) == 1:
-        dtype = domains[0].dtype
-        shape = domains[0].shape
-        if op is ops.log or op is ops.exp:
-            dtype = 'real'
-        elif isinstance(op, ops.ReshapeOp):
-            shape = op.shape
-        elif isinstance(op, ops.AssociativeOp):
-            shape = ()
-        return Array[dtype, shape]
+        return Array[domains[0].dtype, domains[0].shape]
 
     lhs, rhs = domains
-    if isinstance(op, ops.GetitemOp):
-        dtype = lhs.dtype
-        shape = lhs.shape[:op.offset] + lhs.shape[1 + op.offset:]
-        return Array[dtype, shape]
-    elif op == ops.matmul:
-        assert lhs.shape and rhs.shape
-        if len(rhs.shape) == 1:
-            assert lhs.shape[-1] == rhs.shape[-1]
-            shape = lhs.shape[:-1]
-        elif len(lhs.shape) == 1:
-            assert lhs.shape[-1] == rhs.shape[-2]
-            shape = rhs.shape[:-2] + rhs.shape[-1:]
-        else:
-            assert lhs.shape[-1] == rhs.shape[-2]
-            shape = broadcast_shape(lhs.shape[:-1], rhs.shape[:-2] + (1,)) + rhs.shape[-1:]
-        return Reals[shape]
-
     if lhs.dtype == 'real' or rhs.dtype == 'real':
         dtype = 'real'
     elif op in (ops.add, ops.mul, ops.pow, ops.max, ops.min):
@@ -228,10 +258,7 @@ def find_domain(op, *domains):
     else:
         raise NotImplementedError('TODO')
 
-    if lhs.shape == rhs.shape:
-        shape = lhs.shape
-    else:
-        shape = broadcast_shape(lhs.shape, rhs.shape)
+    shape = broadcast_shape(lhs.shape, rhs.shape)
     return Array[dtype, shape]
 
 

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -78,7 +78,7 @@ def normalize_integrate(log_measure, integrand, reduced_vars):
 
 
 @normalize.register(Integrate,
-                    Contraction[Union[ops.NullOp, ops.LogAddExpOp], ops.AddOp, frozenset, tuple],
+                    Contraction[Union[ops.NullOp, ops.LogaddexpOp], ops.AddOp, frozenset, tuple],
                     Funsor, frozenset)
 def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
     reduced_names = frozenset(v.name for v in reduced_vars)

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -259,7 +259,7 @@ def deltadist_to_funsor(pyro_dist, output=None, dim_to_name=None):
 
 
 JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
+    Union[ops.LogaddexpOp, ops.NullOp],
     ops.AddOp,
     frozenset,
     Tuple[Dirichlet, Multinomial],  # noqa: F821
@@ -278,15 +278,15 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
     eager_beta_bernoulli)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Categorical)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, Categorical)(  # noqa: F821
     eager_dirichlet_categorical)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
     eager_dirichlet_multinomial)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Gamma)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Gamma, Gamma)(  # noqa: F821
     eager_gamma_gamma)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisson)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Gamma, Poisson)(  # noqa: F821
     eager_gamma_poisson)
 if hasattr(dist, "DirichletMultinomial"):
     eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821

--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -80,7 +80,7 @@ def moment_matching_contract_default(*args):
     return None
 
 
-@moment_matching.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, (Number, Tensor), Gaussian)
+@moment_matching.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, (Number, Tensor), Gaussian)
 def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gaussian):
 
     approx_vars = frozenset(v for v in reduced_vars

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op
+from .op import DISTRIBUTIVE_OPS, Op, OpCacheMeta
 
 _builtin_all = all
 _builtin_any = any
@@ -66,20 +66,7 @@ logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
 sample = SampleOp(_logaddexp, name="sample")
 
 
-class ReshapeMeta(type):
-    _cache = {}
-
-    def __call__(cls, shape):
-        shape = tuple(shape)
-        try:
-            return ReshapeMeta._cache[shape]
-        except KeyError:
-            instance = super().__call__(shape)
-            ReshapeMeta._cache[shape] = instance
-            return instance
-
-
-class ReshapeOp(Op, metaclass=ReshapeMeta):
+class ReshapeOp(Op, metaclass=OpCacheMeta):
     def __init__(self, shape):
         self.shape = shape
         super().__init__(self._default)

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op, CachedOpMeta
+from .op import DISTRIBUTIVE_OPS, Op, CachedOpMeta, make_op_and_type
 
 _builtin_all = all
 _builtin_any = any
@@ -37,14 +37,6 @@ tanh.register(array)(np.tanh)
 atanh.register(array)(np.arctanh)
 
 
-class LogAddExpOp(AssociativeOp):
-    pass
-
-
-class SampleOp(LogAddExpOp):
-    pass
-
-
 @log.register(array)
 def _log(x):
     if x.dtype == 'bool':
@@ -62,8 +54,8 @@ def _logaddexp(x, y):
     return log(exp(x - shift) + exp(y - shift)) + shift
 
 
-logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
-sample = SampleOp(_logaddexp, name="sample")
+logaddexp, LogAddExpOp = make_op_and_type(_logaddexp, AssociativeOp, name="logaddexp")
+sample, SampleOp = make_op_and_type(_logaddexp, LogAddExpOp, name="sample")
 
 
 class ReshapeMeta(CachedOpMeta):

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op, OpCacheMeta
+from .op import DISTRIBUTIVE_OPS, Op, CachedOpMeta
 
 _builtin_all = all
 _builtin_any = any
@@ -66,7 +66,13 @@ logaddexp = LogAddExpOp(_logaddexp, name="logaddexp")
 sample = SampleOp(_logaddexp, name="sample")
 
 
-class ReshapeOp(Op, metaclass=OpCacheMeta):
+class ReshapeMeta(CachedOpMeta):
+    def __call__(cls, shape):
+        shape = tuple(shape)  # necessary to convert torch.Size to tuple
+        return super().__call__(shape)
+
+
+class ReshapeOp(Op, metaclass=ReshapeMeta):
     def __init__(self, shape):
         self.shape = shape
         super().__init__(self._default)

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 
 from .builtin import AssociativeOp, add, atanh, exp, log, log1p, max, min, reciprocal, safediv, safesub, sqrt, tanh
-from .op import DISTRIBUTIVE_OPS, Op, CachedOpMeta, make_op_and_type
+from .op import DISTRIBUTIVE_OPS, CachedOpMeta, Op, declare_op_types, make_op
 
 _builtin_all = all
 _builtin_any = any
@@ -14,21 +14,21 @@ _builtin_any = any
 # This is used only for pattern matching.
 array = (np.ndarray, np.generic)
 
-all = Op(np.all)
-amax = Op(np.amax)
-amin = Op(np.amin)
-any = Op(np.any)
-astype = Op("astype")
-cat = Op("cat")
-clamp = Op("clamp")
-diagonal = Op("diagonal")
-einsum = Op("einsum")
-full_like = Op(np.full_like)
-isnan = Op(np.isnan)
-prod = Op(np.prod)
-stack = Op("stack")
-sum = Op(np.sum)
-transpose = Op("transpose")
+all = make_op(np.all)
+amax = make_op(np.amax)
+amin = make_op(np.amin)
+any = make_op(np.any)
+astype = make_op("astype")
+cat = make_op("cat")
+clamp = make_op("clamp")
+diagonal = make_op("diagonal")
+einsum = make_op("einsum")
+full_like = make_op(np.full_like)
+isnan = make_op(np.isnan)
+prod = make_op(np.prod)
+stack = make_op("stack")
+sum = make_op(np.sum)
+transpose = make_op("transpose")
 
 sqrt.register(array)(np.sqrt)
 exp.register(array)(np.exp)
@@ -54,8 +54,8 @@ def _logaddexp(x, y):
     return log(exp(x - shift) + exp(y - shift)) + shift
 
 
-logaddexp, LogAddExpOp = make_op_and_type(_logaddexp, AssociativeOp, name="logaddexp")
-sample, SampleOp = make_op_and_type(_logaddexp, LogAddExpOp, name="sample")
+logaddexp = make_op(_logaddexp, AssociativeOp, name="logaddexp")
+sample = make_op(_logaddexp, type(logaddexp), name="sample")
 
 
 class ReshapeMeta(CachedOpMeta):
@@ -265,9 +265,6 @@ DISTRIBUTIVE_OPS.add((sample, add))
 
 
 __all__ = [
-    'LogAddExpOp',
-    'ReshapeOp',
-    'SampleOp',
     'all',
     'amax',
     'amin',
@@ -301,6 +298,7 @@ __all__ = [
     'unsqueeze',
 ]
 
+declare_op_types(globals(), __all__, __name__)
 
 __doc__ = "\n".join(".. autodata:: {}\n".format(_name)
                     for _name in __all__ if isinstance(globals()[_name], Op))

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -5,7 +5,7 @@ import math
 import operator
 from numbers import Number
 
-from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, CachedOpMeta, TransformOp, make_op_and_type
+from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, CachedOpMeta, Op, TransformOp, declare_op_types, make_op
 
 _builtin_abs = abs
 _builtin_max = max
@@ -79,53 +79,54 @@ class GetitemOp(Op, metaclass=CachedOpMeta):
 
 
 getitem = GetitemOp(0)
-abs, AbsOp = make_op_and_type(_builtin_abs, Op)
-eq, EqOp = make_op_and_type(operator.eq, Op)
-ge, GeOp = make_op_and_type(operator.ge, Op)
-gt, GtOp = make_op_and_type(operator.gt, Op)
-invert, InvertOp = make_op_and_type(operator.invert, Op)
-le, LeOp = make_op_and_type(operator.le, Op)
-lt, LtOp = make_op_and_type(operator.lt, Op)
-ne, NeOp = make_op_and_type(operator.ne, Op)
-neg, NegOp = make_op_and_type(operator.neg, Op)
-pow, PowOp = make_op_and_type(operator.pow, Op)
-sub, SubOp = make_op_and_type(operator.sub, Op)
-truediv, DivOp = make_op_and_type(operator.truediv, Op)
+abs = make_op(_builtin_abs, Op)
+abs = make_op(_builtin_abs, Op)
+eq = make_op(operator.eq, Op)
+ge = make_op(operator.ge, Op)
+gt = make_op(operator.gt, Op)
+invert = make_op(operator.invert, Op)
+le = make_op(operator.le, Op)
+lt = make_op(operator.lt, Op)
+ne = make_op(operator.ne, Op)
+neg = make_op(operator.neg, Op)
+pow = make_op(operator.pow, Op)
+sub = make_op(operator.sub, Op)
+truediv = make_op(operator.truediv, Op)
 
-add, AddOp = make_op_and_type(operator.add, AssociativeOp)
-and_, AndOp = make_op_and_type(operator.and_, AssociativeOp)
-mul, MulOp = make_op_and_type(operator.mul, AssociativeOp)
-matmul, MatmulOp = make_op_and_type(operator.matmul, Op)
-or_, OrOp = make_op_and_type(operator.or_, AssociativeOp)
-xor, XorOp = make_op_and_type(operator.xor, AssociativeOp)
-max, MaxOp = make_op_and_type(max, AssociativeOp)
-min, MinOp = make_op_and_type(min, AssociativeOp)
+add = make_op(operator.add, AssociativeOp)
+and_ = make_op(operator.and_, AssociativeOp)
+mul = make_op(operator.mul, AssociativeOp)
+matmul = make_op(operator.matmul, Op)
+or_ = make_op(operator.or_, AssociativeOp)
+xor = make_op(operator.xor, AssociativeOp)
+max = make_op(max, AssociativeOp)
+min = make_op(min, AssociativeOp)
 
-lgamma, LgammaOp = make_op_and_type(math.lgamma, Op)
-log1p, Log1pOp = make_op_and_type(math.log1p, Op)
-sqrt, SqrtOp = make_op_and_type(math.sqrt, Op)
+lgamma = make_op(math.lgamma, Op)
+log1p = make_op(math.log1p, Op)
+sqrt = make_op(math.sqrt, Op)
 
-reciprocal, ReciprocalOp = make_op_and_type(reciprocal, Op)
-softplus, SoftplusOp = make_op_and_type(softplus, Op)
+reciprocal = make_op(reciprocal, Op)
+softplus = make_op(softplus, Op)
 
-exp, ExpOp = make_op_and_type(math.exp, TransformOp)
-log, LogOp = make_op_and_type(lambda x: math.log(x) if x > 0 else -math.inf,
-                              parent=TransformOp, name="log")
-tanh, TanhOp = make_op_and_type(math.tanh, TransformOp)
-atanh, AtanhOp = make_op_and_type(math.atanh, TransformOp)
-sigmoid, SigmoidOp = make_op_and_type(sigmoid, TransformOp)
+exp = make_op(math.exp, TransformOp)
+log = make_op(lambda x: math.log(x) if x > 0 else -math.inf,
+              parent=TransformOp, name="log")
+tanh = make_op(math.tanh, TransformOp)
+atanh = make_op(math.atanh, TransformOp)
+sigmoid = make_op(sigmoid, TransformOp)
 
 
-@SubOp
+@make_op(parent=type(sub))
 def safesub(x, y):
     if isinstance(y, Number):
         return sub(x, y)
 
 
-@DivOp
+@make_op(parent=type(truediv))
 def safediv(x, y):
     if isinstance(y, Number):
-        return truediv(x, y)
+        return operator.truediv(x, y)
 
 
 @add.register(object)
@@ -190,28 +191,6 @@ PRODUCT_INVERSES[mul] = safediv
 PRODUCT_INVERSES[add] = safesub
 
 __all__ = [
-    'AddOp',
-    'AssociativeOp',
-    'AtanhOp',
-    'DivOp',
-    'ExpOp',
-    'EqOp',
-    'GeOp',
-    'GtOp',
-    'LeOp',
-    'LtOp',
-    'NeOp',
-    'GetitemOp',
-    'LogOp',
-    'MatmulOp',
-    'MulOp',
-    'NegOp',
-    'NullOp',
-    'PowOp',
-    'ReciprocalOp',
-    'SigmoidOp',
-    'SubOp',
-    'TanhOp',
     'abs',
     'add',
     'and_',
@@ -246,6 +225,8 @@ __all__ = [
     'truediv',
     'xor',
 ]
+
+declare_op_types(globals(), __all__, __name__)
 
 __doc__ = "\n".join(".. autodata:: {}\n".format(_name)
                     for _name in __all__ if isinstance(globals()[_name], Op))

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -90,7 +90,7 @@ ne, NeOp = make_op_and_type(operator.ne, Op)
 neg, NegOp = make_op_and_type(operator.neg, Op)
 pow, PowOp = make_op_and_type(operator.pow, Op)
 sub, SubOp = make_op_and_type(operator.sub, Op)
-truediv, TruedivOp = make_op_and_type(operator.truediv, DivOp)
+truediv, DivOp = make_op_and_type(operator.truediv, DivOp)
 
 add, AddOp = make_op_and_type(operator.add, AssociativeOp)
 and_, AndOp = make_op_and_type(operator.and_, AssociativeOp)

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -5,7 +5,7 @@ import math
 import operator
 from numbers import Number
 
-from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, TransformOp
+from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, OpCacheMeta, TransformOp
 
 _builtin_abs = abs
 _builtin_max = max
@@ -53,19 +53,7 @@ def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
 
 
-class GetitemMeta(type):
-    _cache = {}
-
-    def __call__(cls, offset):
-        try:
-            return GetitemMeta._cache[offset]
-        except KeyError:
-            instance = super(GetitemMeta, cls).__call__(offset)
-            GetitemMeta._cache[offset] = instance
-            return instance
-
-
-class GetitemOp(Op, metaclass=GetitemMeta):
+class GetitemOp(Op, metaclass=OpCacheMeta):
     """
     Op encoding an index into one dimension, e.g. ``x[:,:,y]`` for offset of 2.
     """

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -103,9 +103,10 @@ min, MinOp = make_op_and_type(min, AssociativeOp)
 
 lgamma, LgammaOp = make_op_and_type(math.lgamma, Op)
 log1p, Log1pOp = make_op_and_type(math.log1p, Op)
+sqrt, SqrtOp = make_op_and_type(math.sqrt, Op)
+
 reciprocal, ReciprocalOp = make_op_and_type(reciprocal, Op)
 softplus, SoftplusOp = make_op_and_type(softplus, Op)
-sqrt, SqrtOp = make_op_and_type(math.sqrt, Op)
 
 exp, ExpOp = make_op_and_type(math.exp, TransformOp)
 log, LogOp = make_op_and_type(lambda x: math.log(x) if x > 0 else -math.inf,

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -90,7 +90,7 @@ ne, NeOp = make_op_and_type(operator.ne, Op)
 neg, NegOp = make_op_and_type(operator.neg, Op)
 pow, PowOp = make_op_and_type(operator.pow, Op)
 sub, SubOp = make_op_and_type(operator.sub, Op)
-truediv, DivOp = make_op_and_type(operator.truediv, DivOp)
+truediv, DivOp = make_op_and_type(operator.truediv, Op)
 
 add, AddOp = make_op_and_type(operator.add, AssociativeOp)
 and_, AndOp = make_op_and_type(operator.and_, AssociativeOp)
@@ -98,21 +98,21 @@ mul, MulOp = make_op_and_type(operator.mul, AssociativeOp)
 matmul, MatmulOp = make_op_and_type(operator.matmul, Op)
 or_, OrOp = make_op_and_type(operator.or_, AssociativeOp)
 xor, XorOp = make_op_and_type(operator.xor, AssociativeOp)
-
-log1p, Log1pOp = make_op_and_type(math.log1p, Op)
-sqrt, SqrtOp = make_op_and_type(math.sqrt, Op)
-exp, ExpOp = make_op_and_type(math.exp, TransformOp)
-tanh, TanhOp = make_op_and_type(math.tanh, TransformOp)
-atanh, AtanhOp = make_op_and_type(math.atanh, TransformOp)
-log, LogOp = make_op_and_type(lambda x: math.log(x) if x > 0 else -math.inf,
-                              parent=TransformOp, name="log")
-
-sigmoid, SigmoidOp = make_op_and_type(sigmoid, TransformOp)
-softplus, SoftplusOp = make_op_and_type(softplus, Op)
 max, MaxOp = make_op_and_type(max, AssociativeOp)
 min, MinOp = make_op_and_type(min, AssociativeOp)
-reciprocal, ReciprocalOp = make_op_and_type(reciprocal, Op)
+
 lgamma, LgammaOp = make_op_and_type(math.lgamma, Op)
+log1p, Log1pOp = make_op_and_type(math.log1p, Op)
+reciprocal, ReciprocalOp = make_op_and_type(reciprocal, Op)
+softplus, SoftplusOp = make_op_and_type(softplus, Op)
+sqrt, SqrtOp = make_op_and_type(math.sqrt, Op)
+
+exp, ExpOp = make_op_and_type(math.exp, TransformOp)
+log, LogOp = make_op_and_type(lambda x: math.log(x) if x > 0 else -math.inf,
+                              parent=TransformOp, name="log")
+tanh, TanhOp = make_op_and_type(math.tanh, TransformOp)
+atanh, AtanhOp = make_op_and_type(math.atanh, TransformOp)
+sigmoid, SigmoidOp = make_op_and_type(sigmoid, TransformOp)
 
 
 @SubOp
@@ -194,12 +194,19 @@ __all__ = [
     'AtanhOp',
     'DivOp',
     'ExpOp',
+    'EqOp',
+    'GeOp',
+    'GtOp',
+    'LeOp',
+    'LtOp',
+    'NeOp',
     'GetitemOp',
     'LogOp',
     'MatmulOp',
     'MulOp',
     'NegOp',
     'NullOp',
+    'PowOp',
     'ReciprocalOp',
     'SigmoidOp',
     'SubOp',

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -5,7 +5,7 @@ import math
 import operator
 from numbers import Number
 
-from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, OpCacheMeta, TransformOp
+from .op import DISTRIBUTIVE_OPS, PRODUCT_INVERSES, UNITS, Op, CachedOpMeta, TransformOp
 
 _builtin_abs = abs
 _builtin_max = max
@@ -53,7 +53,7 @@ def nullop(x, y):
     raise ValueError("should never actually evaluate this!")
 
 
-class GetitemOp(Op, metaclass=OpCacheMeta):
+class GetitemOp(Op, metaclass=CachedOpMeta):
     """
     Op encoding an index into one dimension, e.g. ``x[:,:,y]`` for offset of 2.
     """

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -51,19 +51,39 @@ class Op(Dispatcher):
         return self.__name__
 
 
-def make_op_and_type(fn, parent=None, *, name=None, module_name="funsor.ops"):
+def make_op(fn=None, parent=None, *, name=None, module_name="funsor.ops"):
+    # Support use as decorator.
+    if fn is None:
+        return lambda fn: make_op(fn, parent, name=name, module_name=module_name)
+
     if parent is None:
         parent = Op
     assert issubclass(parent, Op)
 
     if name is None:
-        name = fn.__name__
+        name = fn if isinstance(fn, str) else fn.__name__
     assert isinstance(name, str)
 
     classname = name[0].upper() + name[1:].rstrip("_") + "Op"  # e.g. add -> AddOp
     new_type = CachedOpMeta(classname, (parent,), {})
     new_type.__module__ = module_name
-    return new_type(fn, name=name), new_type
+    return new_type(fn, name=name)
+
+
+def declare_op_types(locals_, all_, name_):
+    op_types = set(v for v in locals_.values()
+                   if isinstance(v, type) and issubclass(v, Op))
+    # Adds all op types to __all__, and fix their modules.
+    for typ in op_types:
+        if typ.__module__ == name_:
+            typ.__module__ = "funsor.ops"
+        all_.append(typ.__name__)
+    # Adds type(op) to locals, for each op in locals.
+    for name, op in list(locals_.items()):
+        if isinstance(op, Op) and type(op) not in op_types:
+            locals_[type(op).__name__] = type(op)
+            all_.append(type(op).__name__)
+    all_.sort()
 
 
 class TransformOp(Op):
@@ -100,11 +120,12 @@ UNITS = {}                # op -> value
 PRODUCT_INVERSES = {}     # op -> inverse op
 
 __all__ = [
+    'CachedOpMeta',
     'DISTRIBUTIVE_OPS',
     'Op',
-    'CachedOpMeta',
     'PRODUCT_INVERSES',
     'TransformOp',
     'UNITS',
-    'make_op_and_type',
+    'declare_op_types',
+    'make_op',
 ]

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -12,7 +12,7 @@ class CachedOpMeta(type):
         try:
             return cls._cache[args]
         except KeyError:
-            instance = super(CachedOpMeta, cls).__call__(*args)
+            instance = super(CachedOpMeta, cls).__call__(*args, **kwargs)
             cls._cache[args] = instance
             return instance
 
@@ -51,7 +51,7 @@ class Op(Dispatcher):
         return self.__name__
 
 
-def make_op_and_type(fn, parent=None, *, name=None):
+def make_op_and_type(fn, parent=None, *, name=None, module_name="funsor.ops"):
     if parent is None:
         parent = Op
     assert issubclass(parent, Op)
@@ -62,6 +62,7 @@ def make_op_and_type(fn, parent=None, *, name=None):
 
     classname = name[0].upper() + name[1:] + "Op"  # e.g. add -> AddOp
     new_type = CachedOpMeta(classname, (parent,), {})
+    new_type.__module__ = module_name
     return new_type(fn, name=name), new_type
 
 

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -60,7 +60,7 @@ def make_op_and_type(fn, parent=None, *, name=None, module_name="funsor.ops"):
         name = fn.__name__
     assert isinstance(name, str)
 
-    classname = name[0].upper() + name[1:] + "Op"  # e.g. add -> AddOp
+    classname = name[0].upper() + name[1:].rstrip("_") + "Op"  # e.g. add -> AddOp
     new_type = CachedOpMeta(classname, (parent,), {})
     new_type.__module__ = module_name
     return new_type(fn, name=name), new_type

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -17,26 +17,6 @@ class CachedOpMeta(type):
             return instance
 
 
-def make_op(fn=None, parent=None, *, name=None):
-    if parent is None:
-        parent = Op
-    assert issubclass(parent, Op)
-
-    if fn is None:
-        return functools.partial(make_op, parent=parent)
-
-    if name is None:
-        name = fn.__name__
-
-    classname = name[0].upper() + name[1:] + "Op"
-    return OpCacheMeta(classname, (parent,), {})(fn, name=name)
-
-
-def make_op_and_type(fn, parent=None, *, name=None):
-    new_op = make_op(fn, parent, name=name)
-    return new_op, type(new_op)
-
-
 class Op(Dispatcher):
 
     def __init_subclass__(cls, **kwargs):
@@ -69,6 +49,20 @@ class Op(Dispatcher):
 
     def __str__(self):
         return self.__name__
+
+
+def make_op_and_type(fn, parent=None, *, name=None):
+    if parent is None:
+        parent = Op
+    assert issubclass(parent, Op)
+
+    if name is None:
+        name = fn.__name__
+    assert isinstance(name, str)
+
+    classname = name[0].upper() + name[1:] + "Op"  # e.g. add -> AddOp
+    new_type = OpCacheMeta(classname, (parent,), {})
+    return new_type(fn, name=name), new_type
 
 
 class TransformOp(Op):
@@ -111,4 +105,5 @@ __all__ = [
     'PRODUCT_INVERSES',
     'TransformOp',
     'UNITS',
+    'make_op_and_type',
 ]

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -8,7 +8,7 @@ class CachedOpMeta(type):
     """
     Metaclass for caching op instance construction.
     """
-    def __call__(cls, *args):
+    def __call__(cls, *args, **kwargs):
         try:
             return cls._cache[args]
         except KeyError:
@@ -61,7 +61,7 @@ def make_op_and_type(fn, parent=None, *, name=None):
     assert isinstance(name, str)
 
     classname = name[0].upper() + name[1:] + "Op"  # e.g. add -> AddOp
-    new_type = OpCacheMeta(classname, (parent,), {})
+    new_type = CachedOpMeta(classname, (parent,), {})
     return new_type(fn, name=name), new_type
 
 

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -4,6 +4,19 @@
 from multipledispatch import Dispatcher
 
 
+class OpCacheMeta(type):
+    """
+    Metaclass for caching op instance construction.
+    """
+    _cache = {}
+
+    def __call__(cls, *args, **kwargs):
+        key = (cls,) + tuple(args) + tuple(kwargs.items())
+        if key not in OpCacheMeta._cache:
+            OpCacheMeta._cache[key] = super(OpCacheMeta, cls).__call__(*args, **kwargs)
+        return OpCacheMeta._cache[key]
+
+
 class Op(Dispatcher):
     def __init__(self, fn, *, name=None):
         if isinstance(fn, str):
@@ -69,6 +82,7 @@ PRODUCT_INVERSES = {}     # op -> inverse op
 __all__ = [
     'DISTRIBUTIVE_OPS',
     'Op',
+    'OpCacheMeta',
     'PRODUCT_INVERSES',
     'TransformOp',
     'UNITS',

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -26,9 +26,10 @@ def make_op(fn=None, parent=None, *, name=None):
         return functools.partial(make_op, parent=parent)
 
     if name is None:
-        name = fn.__name__ + "Op"
+        name = fn.__name__
 
-    return OpCacheMeta(name, (parent,))(fn, name=name)
+    classname = name[0].upper() + name[1:] + "Op"
+    return OpCacheMeta(classname, (parent,), {})(fn, name=name)
 
 
 def make_op_and_type(fn, parent=None, *, name=None):

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -17,6 +17,25 @@ class CachedOpMeta(type):
             return instance
 
 
+def make_op(fn=None, parent=None, *, name=None):
+    if parent is None:
+        parent = Op
+    assert issubclass(parent, Op)
+
+    if fn is None:
+        return functools.partial(make_op, parent=parent)
+
+    if name is None:
+        name = fn.__name__ + "Op"
+
+    return OpCacheMeta(name, (parent,))(fn, name=name)
+
+
+def make_op_and_type(fn, parent=None, *, name=None):
+    new_op = make_op(fn, parent, name=name)
+    return new_op, type(new_op)
+
+
 class Op(Dispatcher):
 
     def __init_subclass__(cls, **kwargs):

--- a/funsor/torch/distributions.py
+++ b/funsor/torch/distributions.py
@@ -326,7 +326,7 @@ def deltadist_to_funsor(pyro_dist, output=None, dim_to_name=None):
 
 
 JointDirichletMultinomial = Contraction[
-    Union[ops.LogAddExpOp, ops.NullOp],
+    Union[ops.LogaddexpOp, ops.NullOp],
     ops.AddOp,
     frozenset,
     Tuple[Dirichlet, Multinomial],  # noqa: F821
@@ -345,15 +345,15 @@ eager.register(Delta, Variable, Funsor, Funsor)(eager_delta_funsor_funsor)  # no
 eager.register(Delta, Variable, Variable, Variable)(eager_delta_variable_variable)  # noqa: F821
 eager.register(Normal, Funsor, Tensor, Funsor)(eager_normal)  # noqa: F821
 eager.register(MultivariateNormal, Funsor, Tensor, Funsor)(eager_mvn)  # noqa: F821
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, BernoulliProbs)(  # noqa: F821
     eager_beta_bernoulli)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Categorical)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, Categorical)(  # noqa: F821
     eager_dirichlet_categorical)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Dirichlet, Multinomial)(  # noqa: F821
     eager_dirichlet_multinomial)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Gamma)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Gamma, Gamma)(  # noqa: F821
     eager_gamma_gamma)
-eager.register(Contraction, ops.LogAddExpOp, ops.AddOp, frozenset, Gamma, Poisson)(  # noqa: F821
+eager.register(Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, Gamma, Poisson)(  # noqa: F821
     eager_gamma_poisson)
 eager.register(Binary, ops.SubOp, JointDirichletMultinomial, DirichletMultinomial)(  # noqa: F821
     eager_dirichlet_posterior)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -298,7 +298,7 @@ def test_reduce_all(op):
     x = Variable('x', Bint[2])
     y = Variable('y', Bint[3])
     z = Variable('z', Bint[4])
-    if isinstance(op, ops.LogAddExpOp):
+    if isinstance(op, ops.LogaddexpOp):
         pytest.skip()  # not defined for integers
 
     with interpretation(sequential):
@@ -332,7 +332,7 @@ def test_reduce_subset(op, reduced_vars):
     f = x * y + z
     dtype = f.dtype
     check_funsor(f, {'x': Bint[2], 'y': Bint[3], 'z': Bint[4]}, Array[dtype, ()])
-    if isinstance(op, ops.LogAddExpOp):
+    if isinstance(op, ops.LogaddexpOp):
         pytest.skip()  # not defined for integers
 
     with interpretation(sequential):


### PR DESCRIPTION
Addresses #351. ~~Blocked by #421.~~

This PR breaks up the monolithic `funsor.domains.find_domain` into a `singledispatch` registry of patterns for individual ops, adds a new helper function `funsor.ops.op.make_op_and_type` for generating new op classes programmatically, and applies this helper liberally throughout the base op definition files.

The motivation for this change to `find_domain` is that it is now possible to register additional rules in `find_domain` for ops created elsewhere and to represent lazy application of any op with a single `Finitary` funsor. In particular, this is necessary for the plan in #351 to have `funsor.function` represent functions as newly created ops whose `find_domain` implementation can be read off from their type signatures.  `make_op_and_type` will also be useful for pattern-matching more generally, since most basic ops will now have their own classes.

Tested:
- Exercised by existing tests