### PR TITLE
Support IndependentConstraint in Distribution._infer_param_domain

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -267,7 +267,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         elif support_name == "Real":
             if name == "logits" and (
                     "probs" in cls.dist_class.arg_constraints
-                    and type(cls.dist_class.arg_constraints["probs"]).__name__ == "Simplex"):
+                    and type(cls.dist_class.arg_constraints["probs"]).__name__.lstrip("_") == "Simplex"):
                 output = Reals[raw_shape[-1 - event_dim:]]
             else:
                 output = Reals[raw_shape[len(raw_shape) - event_dim:]]

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -256,22 +256,22 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             support = support.base_constraint
             support_name = type(support).__name__
 
-        if support_name == "_Simplex":
+        if support_name == "Simplex":
             output = Reals[raw_shape[-1 - event_dim:]]
-        elif support_name == "_RealVector":
+        elif support_name == "RealVector":
             output = Reals[raw_shape[-1 - event_dim:]]
-        elif support_name in ["_LowerCholesky", "_PositiveDefinite"]:
+        elif support_name in ["LowerCholesky", "PositiveDefinite"]:
             output = Reals[raw_shape[-2 - event_dim:]]
         # resolve the issue: logits's constraints are real (instead of real_vector)
         # for discrete multivariate distributions in Pyro
-        elif support_name == "_Real":
+        elif support_name == "Real":
             if name == "logits" and (
                     "probs" in cls.dist_class.arg_constraints
-                    and type(cls.dist_class.arg_constraints["probs"]).__name__ == "_Simplex"):
+                    and type(cls.dist_class.arg_constraints["probs"]).__name__ == "Simplex"):
                 output = Reals[raw_shape[-1 - event_dim:]]
             else:
                 output = Reals[raw_shape[len(raw_shape) - event_dim:]]
-        elif support_name in ("_Interval", "_GreaterThan", "_LessThan"):
+        elif support_name in ("Interval", "GreaterThan", "LessThan"):
             output = Reals[raw_shape[len(raw_shape) - event_dim:]]
         else:
             output = None

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -254,7 +254,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         while support_name == "IndependentConstraint":
             event_dim += support.reinterpreted_batch_ndims
             support = support.base_constraint
-            support_name = type(support).__name__
+            support_name = type(support).__name__.lstrip("_")
 
         if support_name == "Simplex":
             output = Reals[raw_shape[-1 - event_dim:]]

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -248,11 +248,11 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         # define backend-specific distributions and overide these `infer_value_domain`,
         # `infer_param_domain` methods.
         # Because NumPyro and Pyro have the same pattern, we use name check for simplicity.
-        support_name = type(support).__name__
+        support_name = type(support).__name__.lstrip("_")
 
         event_dim = 0
-        while support_name == "_IndependentConstraint":
-            event_dim += support.event_dim
+        while support_name == "IndependentConstraint":
+            event_dim += support.reinterpreted_batch_ndims
             support = support.base_constraint
             support_name = type(support).__name__
 


### PR DESCRIPTION
Addresses #386. Blocking all other PRs.

This PR updates the logic in `Distribution._infer_param_domain` to handle the new `_IndependentConstraint` in NumPyro added in https://github.com/pyro-ppl/numpyro/pull/876, which should fix the CI failures in #430 and other PRs.

Tested:
- Exercised by existing tests that are currently failing, including `test_distributions_generic::test_generic_sample` for `CategoricalLogits`