### PR TITLE
Use typing and pytypes for type checking and multiple dispatch

### DIFF
--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -7,6 +7,8 @@ import weakref
 
 from multipledispatch import Dispatcher
 
+from funsor.util import _type_to_typing
+
 
 class CachedOpMeta(type):
     """
@@ -39,7 +41,10 @@ class Op(Dispatcher):
             # register as default operation
             for nargs in (1, 2):
                 default_signature = (object,) * nargs
-                self.add(default_signature, fn)
+                self.register(*default_signature)(fn)
+
+    def register(self, *types):
+        return super().register(*tuple(map(_type_to_typing, types)))
 
         # Register all existing patterns.
         for supercls in reversed(inspect.getmro(type(self))):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -13,14 +13,14 @@ from functools import reduce, singledispatch
 from weakref import WeakValueDictionary
 
 from multipledispatch import dispatch
-from multipledispatch.variadic import Variadic, isvariadic
+from multipledispatch.variadic import Variadic
 
 import funsor.interpreter as interpreter
 import funsor.ops as ops
 from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
 from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec, get_backend, lazy_property, pretty, quote
+from funsor.util import GenericTypeMeta, getargspec, get_backend, lazy_property, pretty, quote
 
 
 def substitute(expr, subs):
@@ -182,7 +182,7 @@ def moment_matching(cls, *args):
 interpreter.set_interpretation(eager)  # Use eager interpretation by default.
 
 
-class FunsorMeta(type):
+class FunsorMeta(GenericTypeMeta):
     """
     Metaclass for Funsors to perform four independent tasks:
 
@@ -206,15 +206,9 @@ class FunsorMeta(type):
     """
     def __init__(cls, name, bases, dct):
         super(FunsorMeta, cls).__init__(name, bases, dct)
-        if not hasattr(cls, "__args__"):
-            cls.__args__ = ()
-        if cls.__args__:
-            base, = bases
-            cls.__origin__ = base
-        else:
+        if not cls.__args__:
             cls._ast_fields = getargspec(cls.__init__)[0][1:]
             cls._cons_cache = WeakValueDictionary()
-            cls._type_cache = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs):
         if cls.__args__:
@@ -229,77 +223,6 @@ class FunsorMeta(type):
             args = tuple(args)
 
         return interpret(cls, *args)
-
-    def __getitem__(cls, arg_types):
-        if not isinstance(arg_types, tuple):
-            arg_types = (arg_types,)
-        assert not any(isvariadic(arg_type) for arg_type in arg_types), "nested variadic types not supported"
-        # switch tuple to typing.Tuple
-        arg_types = tuple(typing.Tuple if arg_type is tuple else arg_type for arg_type in arg_types)
-        if arg_types not in cls._type_cache:
-            assert not cls.__args__, "cannot subscript a subscripted type {}".format(cls)
-            assert len(arg_types) == len(cls._ast_fields), "must provide types for all params"
-            new_dct = cls.__dict__.copy()
-            new_dct.update({"__args__": arg_types})
-            # type(cls) to handle FunsorMeta subclasses
-            cls._type_cache[arg_types] = type(cls)(cls.__name__, (cls,), new_dct)
-        return cls._type_cache[arg_types]
-
-    def __subclasscheck__(cls, subcls):  # issubclass(subcls, cls)
-        if cls is subcls:
-            return True
-        if not isinstance(subcls, FunsorMeta):
-            return super(FunsorMeta, getattr(cls, "__origin__", cls)).__subclasscheck__(subcls)
-
-        cls_origin = getattr(cls, "__origin__", cls)
-        subcls_origin = getattr(subcls, "__origin__", subcls)
-        if not super(FunsorMeta, cls_origin).__subclasscheck__(subcls_origin):
-            return False
-
-        if cls.__args__:
-            if not subcls.__args__:
-                return False
-            if len(cls.__args__) != len(subcls.__args__):
-                return False
-            for subcls_param, param in zip(subcls.__args__, cls.__args__):
-                if not _issubclass_tuple(subcls_param, param):
-                    return False
-        return True
-
-    @lazy_property
-    def classname(cls):
-        return cls.__name__ + "[{}]".format(", ".join(
-            str(getattr(t, "classname", t))  # Tuple doesn't have __name__
-            for t in cls.__args__))
-
-
-def _issubclass_tuple(subcls, cls):
-    """
-    utility for pattern matching with tuple subexpressions
-    """
-    # so much boilerplate...
-    cls_is_union = hasattr(cls, "__origin__") and (cls.__origin__ or cls) is typing.Union
-    if isinstance(cls, tuple) or cls_is_union:
-        return any(_issubclass_tuple(subcls, option)
-                   for option in (getattr(cls, "__args__", []) if cls_is_union else cls))
-
-    subcls_is_union = hasattr(subcls, "__origin__") and (subcls.__origin__ or subcls) is typing.Union
-    if isinstance(subcls, tuple) or subcls_is_union:
-        return any(_issubclass_tuple(option, cls)
-                   for option in (getattr(subcls, "__args__", []) if subcls_is_union else subcls))
-
-    subcls_is_tuple = hasattr(subcls, "__origin__") and (subcls.__origin__ or subcls) in (tuple, typing.Tuple)
-    cls_is_tuple = hasattr(cls, "__origin__") and (cls.__origin__ or cls) in (tuple, typing.Tuple)
-    if subcls_is_tuple != cls_is_tuple:
-        return False
-    if not cls_is_tuple:
-        return issubclass(subcls, cls)
-    if not cls.__args__:
-        return True
-    if not subcls.__args__ or len(subcls.__args__) != len(cls.__args__):
-        return False
-
-    return all(_issubclass_tuple(a, b) for a, b in zip(subcls.__args__, cls.__args__))
 
 
 def _convert_reduced_vars(reduced_vars, inputs):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -20,7 +20,7 @@ import funsor.ops as ops
 from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
 from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import GenericTypeMeta, getargspec, get_backend, lazy_property, pretty, quote
+from funsor.util import GenericTypeMeta, getargspec, get_backend, lazy_property, pretty, quote, _type_to_typing
 
 
 def substitute(expr, subs):
@@ -215,6 +215,7 @@ class FunsorMeta(GenericTypeMeta):
             arg_types = (arg_types,)
         assert len(arg_types) == len(cls._ast_fields), \
             "Must provide exactly one type per subexpression"
+        arg_types = tuple(map(_type_to_typing, arg_types))
         return super().__getitem__(arg_types)
 
     def __call__(cls, *args, **kwargs):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -210,6 +210,13 @@ class FunsorMeta(GenericTypeMeta):
             cls._ast_fields = getargspec(cls.__init__)[0][1:]
             cls._cons_cache = WeakValueDictionary()
 
+    def __getitem__(cls, arg_types):
+        if not isinstance(arg_types, tuple):
+            arg_types = (arg_types,)
+        assert len(arg_types) == len(cls._ast_fields), \
+            "Must provide exactly one type per subexpression"
+        return super().__getitem__(arg_types)
+
     def __call__(cls, *args, **kwargs):
         if cls.__args__:
             cls = cls.__origin__

--- a/setup.py
+++ b/setup.py
@@ -33,18 +33,14 @@ setup(
     author='Uber AI Labs',
     author_email='fritzo@uber.com',
     python_requires=">=3.6",
-    dependency_links=[
-        # pin pytypes to master
-        'git+https://github.com/Stewori/pytypes.git@master#egg=pytypes-0a0',
-        # use a fork of multipledispatch that depends on pytypes
-        'git+https://github.com/eb8680/multipledispatch.git@pytypes-master#egg=multipledispatch.git-0.6.0a0',
-    ],
     install_requires=[
         'makefun',
-        'multipledispatch',
+        # use a fork of multipledispatch that depends on pytypes
+        'git+https://github.com/eb8680/multipledispatch.git@pytypes-master#egg=multipledispatch',
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
-        'pytypes',
+        # pin pytypes to master
+        'git+https://github.com/Stewori/pytypes.git@master#egg=pytypes',
     ],
     extras_require={
         'torch': [

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,18 @@ setup(
     author='Uber AI Labs',
     author_email='fritzo@uber.com',
     python_requires=">=3.6",
+    dependency_links=[
+        # pin pytypes to master
+        'git+https://github.com/Stewori/pytypes.git@master#egg=pytypes-0a0',
+        # use a fork of multipledispatch that depends on pytypes
+        'git+https://github.com/eb8680/multipledispatch.git@pytypes-master#egg=multipledispatch.git-0.6.0a0',
+    ],
     install_requires=[
         'makefun',
         'multipledispatch',
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
+        'pytypes',
     ],
     extras_require={
         'torch': [

--- a/test/test_cnf.py
+++ b/test/test_cnf.py
@@ -9,7 +9,7 @@ import pytest
 
 from funsor import ops
 from funsor.cnf import Contraction, BACKEND_TO_EINSUM_BACKEND, BACKEND_TO_LOGSUMEXP_BACKEND
-from funsor.domains import Bint, Bint  # noqa F403
+from funsor.domains import Array, Bint  # noqa F403
 from funsor.domains import Reals
 from funsor.einsum import einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret


### PR DESCRIPTION
Addresses #351, #355.

This is a more ambitious version of the changes in #433 that uses the `typing`-compatible runtime type checking library [pytypes](https://github.com/Stewori/pytypes) for type checking and inference (via `pytypes.is_subtype`, a `typing`-compatible version of `issubclass`) and for pattern matching (via a [pytypes-based fork](https://github.com/mrocklin/multipledispatch/compare/master...eb8680:pytypes-master?expand=1) of multipledispatch that uses `pytypes.is_subtype` in place of `issubclass`).

After these changes, it should be possible to use all of `typing` directly when describing funsor input and output types or when writing patterns, e.g. we could simply replace `Product` from #430 with `typing.Tuple`:
```py
class Tuple(Funsor):
    def __init__(self, args):
        ...
        output = typing.Tuple[tuple(arg.output for arg in args)]
        ...
```
...or use `typing.Tuple`, including variadic cases, in patterns like the ones needed for `Finitary` in #423:
```py
@eager.register(Finitary)
def eager_finitary_generic(
        op: EinsumOp, 
        args: typing.Tuple[typing.Union[Tensor, Number], ...]  # variadic
    ) -> typing.Union[Tensor, Number]:
    ...
```
As suggested in #355, we could even replace many of the assertions in our `Funsor.__init__` methods with runtime type checking in interpreters, eliminating lots of boilerplate code and potentially boosting performance (by making many assertions optional):
```py
class FunsorMeta(type):
    def __call__(cls, *args, **kwargs):
        ...
        if interpreter.TYPECHECK:
            assert all(pytypes.is_of_type(arg, static_arg_type)  # is_of_type == isinstance
                        for arg, static_arg_type in zip(args, get_type_hints(cls.__init__)))
        return interpret(cls, *args)
```
```diff
# example
class Reduce(Funsor):
-     def __init__(self, op, arg, reduced_vars):
+     def __init__(self, op: ops.AssociativeOp, arg: Funsor, reduced_vars: typing.FrozenSet[Variable]):
-         assert callable(op)
-         assert isinstance(arg, Funsor)
-         assert isinstance(reduced_vars, frozenset)
-         assert all(isinstance(v, Variable) for v in reduced_vars)
          reduced_names = frozenset(v.name for v in reduced_vars)
          ...
```
I have also taken the opportunity to remove some of the uglier code in `FunsorMeta` and domains made obsolete by the use of `pytypes` and `typing`, including the custom introspection and subtype checking logic in `FunsorMeta`.

In #355 I had originally suggested going even further toward integrating `typing` with Funsor interpretations than the changes here by making parametric `Funsor` subtypes use `typing.Generic`.  I am somewhat skeptical about taking that additional step because of how difficult it is to interact with `typing.Generic` at runtime, and have chosen in this PR to retain a simplified version of the `GenericTypeMeta` class as a substrate for `Funsor` and `FunsorMeta`.

One critical question for this approach is how well the `multipledispatch` fork holds up in terms of correctness and performance and how much additional maintenance effort it would entail.  In an ideal world, someone else would implement a performant, fully `typing`-compatible `multipledispatch` completely independent of Funsor and we could just use their solution, since that's clearly a useful and interesting direction in its own right and there are a number of new runtime type checkers ([1](https://github.com/erezsh/runtype), [2](https://github.com/beartype/beartype)) that could be repurposed to support it.

However, since that is unlikely (AFAIK) in the near term and the developers of `multipledispatch` are not interested in merging the `pytypes`-based version (which I took and lightly modified from [an old pull request there](https://github.com/mrocklin/multipledispatch/pull/69)), we'd have to maintain the fork ourselves.  The core functionality seems to be largely complete - almost all of the multipledispatch and Funsor tests pass locally, and pytypes itself is extensively tested.  We might need to add a dedicated `typing`-compatible `Dispatcher` upon which to base `funsor.ops.Op` and `funsor.registry.KeyedRegistry` that makes sure signatures use `typing` syntax, e.g. converting tuples to `typing.Union`s or `object` to `typing.Any`.  As for performance, running tests locally shows there is definitely a slowdown relative to the current `multipledispatch`, although it's much less severe than the discussion in that `multipledispatch` PR would suggest.

Another practical issue is the compatibility of `pytypes` with various Python versions, especially 3.7-3.9.  It seems like that's been addressed to a large extent in their `master` branch, at least for the subset of `typing` we would use in Funsor, but I'm not entirely sure what its status is or when any outstanding issues might be resolved.

I am cautiously optimistic about these questions, but it's too early to say right now whether they'd end up being show-stoppers relative to the status quo or the simpler approach in #433.