### PR TITLE
Add profiling counters via FUNSOR_PROFILE=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
 	pytest -v -n auto test/
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
-	FUNSOR_PROFILE=1 pytest -v test/test_einsum.py
+	FUNSOR_PROFILE=99 pytest -v test/test_einsum.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py
 	python examples/discrete_hmm.py -n 2

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
 	pytest -v -n auto test/
 	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
+	FUNSOR_PROFILE=1 pytest -v test/test_einsum.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
 	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py
 	python examples/discrete_hmm.py -n 2

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -1,12 +1,13 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import atexit
 import functools
 import inspect
 import os
 import re
 import types
-from collections import OrderedDict, namedtuple
+from collections import Counter, OrderedDict, namedtuple
 from contextlib import contextmanager
 from functools import singledispatch
 
@@ -19,6 +20,7 @@ from funsor.util import is_nn_module
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _DEBUG = int(os.environ.get("FUNSOR_DEBUG", 0))
+_PROFILE = int(os.environ.get("FUNSOR_PROFILE", 0))
 _STACK_SIZE = 0
 
 _INTERPRETATION = None  # To be set later in funsor.terms
@@ -59,9 +61,43 @@ if _DEBUG:
         if isinstance(fn, DebugLogged):
             return fn
         return DebugLogged(fn)
+elif _PROFILE:
+
+    class ProfileLogged(object):
+        def __init__(self, fn):
+            self.fn = fn
+            while isinstance(fn, functools.partial):
+                fn = fn.func
+            path = inspect.getabsfile(fn).split("/funsor/")[-1]
+            lineno = inspect.getsourcelines(fn)[1]
+            self._message = "{} {} {}".format(fn.__name__, path, lineno)
+
+        def __call__(self, *args, **kwargs):
+            COUNTERS[self._message] += 1
+            return self.fn(*args, **kwargs)
+
+        @property
+        def register(self):
+            return self.fn.register
+
+    def debug_logged(fn):
+        if isinstance(fn, ProfileLogged):
+            return fn
+        return ProfileLogged(fn)
 else:
     def debug_logged(fn):
         return fn
+
+
+COUNTERS = Counter()
+if _PROFILE:
+    @atexit.register
+    def print_counters():
+        print("-" * 80)
+        print("     COUNT NAME")
+        for name, value in COUNTERS.most_common():
+            print(f"{value: >10} {name}")
+        print("-" * 80)
 
 
 def _classname(cls):
@@ -325,7 +361,7 @@ def dispatched_interpretation(fn):
     Decorator to create a dispatched interpretation function.
     """
     registry = KeyedRegistry(default=lambda *args: None)
-    if _DEBUG:
+    if _DEBUG or _PROFILE:
         fn.register = lambda *args: lambda fn: registry.register(*args)(debug_logged(fn))
     else:
         fn.register = registry.register

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -380,10 +380,11 @@ def dispatched_interpretation(fn):
 
     if _PROFILE:
         def profiled_dispatch(*args):
+            name = fn.__name__ + ".dispatch"
             start = default_timer()
             result = registry.dispatch(*args)
-            COUNTERS["time"][fn.__name__ + ".dispatch"] += default_timer() - start
-
+            COUNTERS["time"][name] += default_timer() - start
+            COUNTERS["call"][name] += 1
             COUNTERS["interpretation"][fn.__name__] += 1
             return result
         fn.dispatch = profiled_dispatch

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -95,8 +95,11 @@ else:
 
 COUNTERS = defaultdict(Counter)
 if _PROFILE:
+    COUNTERS["time"]["total"] -= default_timer()
+
     @atexit.register
     def print_counters():
+        COUNTERS["time"]["total"] += default_timer()
         for name, counter in sorted(COUNTERS.items()):
             print("-" * 80)
             print(f"     count {name}")
@@ -377,8 +380,12 @@ def dispatched_interpretation(fn):
 
     if _PROFILE:
         def profiled_dispatch(*args):
+            start = default_timer()
+            result = registry.dispatch(*args)
+            COUNTERS["time"][fn.__name__ + ".dispatch"] += default_timer() - start
+
             COUNTERS["interpretation"][fn.__name__] += 1
-            return registry.dispatch(*args)
+            return result
         fn.dispatch = profiled_dispatch
     else:
         fn.dispatch = registry.dispatch

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -7,7 +7,7 @@ import inspect
 import os
 import re
 import types
-from collections import Counter, OrderedDict, namedtuple
+from collections import Counter, OrderedDict, defaultdict, namedtuple
 from contextlib import contextmanager
 from functools import singledispatch
 
@@ -73,7 +73,7 @@ elif _PROFILE:
             self._message = "{} {} {}".format(fn.__name__, path, lineno)
 
         def __call__(self, *args, **kwargs):
-            COUNTERS[self._message] += 1
+            COUNTERS["call"][self._message] += 1
             return self.fn(*args, **kwargs)
 
         @property
@@ -89,14 +89,15 @@ else:
         return fn
 
 
-COUNTERS = Counter()
+COUNTERS = defaultdict(Counter)
 if _PROFILE:
     @atexit.register
     def print_counters():
-        print("-" * 80)
-        print("     COUNT NAME")
-        for name, value in COUNTERS.most_common():
-            print(f"{value: >10} {name}")
+        for name, counter in sorted(COUNTERS.items()):
+            print("-" * 80)
+            print(f"     count {name}")
+            for key, value in counter.most_common():
+                print(f"{value: >10} {key}")
         print("-" * 80)
 
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -101,9 +101,11 @@ if _PROFILE:
     def print_counters():
         COUNTERS["time"]["total"] += default_timer()
         for name, counter in sorted(COUNTERS.items()):
+            if "total" not in counter and len(counter) > 1:
+                counter["total"] = sum(counter.values())
             print("-" * 80)
             print(f"     count {name}")
-            for key, value in counter.most_common():
+            for key, value in counter.most_common(_PROFILE):
                 if isinstance(value, float):
                     print(f"{value: >10f} {key}")
                 else:

--- a/funsor/optimizer.py
+++ b/funsor/optimizer.py
@@ -50,8 +50,9 @@ def unfold_contraction_generic_tuple(red_op, bin_op, reduced_vars, terms):
     return None
 
 
-unfold.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])(
-    lambda r, b, v, *ts: unfold(Contraction, r, b, v, tuple(ts)))
+@unfold.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])
+def unfold_contraction_variadic(r, b, v, *ts):
+    return unfold(Contraction, r, b, v, tuple(ts))
 
 
 @interpreter.dispatched_interpretation
@@ -66,8 +67,9 @@ def optimize(cls, *args):
 REAL_SIZE = 3  # the "size" of a real-valued dimension passed to the path optimizer
 
 
-optimize.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])(
-    lambda r, b, v, *ts: optimize(Contraction, r, b, v, tuple(ts)))
+@optimize.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])
+def optimize_contraction_variadic(r, b, v, *ts):
+    return optimize(Contraction, r, b, v, tuple(ts))
 
 
 @optimize.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Funsor, Funsor)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -7,7 +7,7 @@ import math
 import numbers
 import typing
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from collections.abc import Hashable
 from functools import reduce, singledispatch
 from weakref import WeakValueDictionary
@@ -35,6 +35,8 @@ def substitute(expr, subs):
         fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
         if fresh_subs:
             expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
+        if interpreter._PROFILE:
+            interpreter.COUNTERS["interpretation"]["substitute"] += 1
         return expr
 
     with interpreter.interpretation(subs_interpreter):
@@ -52,7 +54,7 @@ def _alpha_mangle(expr):
     if not alpha_subs:
         return expr
 
-    ast_values = expr._alpha_convert(alpha_subs)
+    ast_values = interpreter.debug_logged(expr._alpha_convert)(alpha_subs)
     return reflect(type(expr), *ast_values)
 
 
@@ -89,10 +91,12 @@ def reflect(cls, *args, **kwargs):
     result._ast_values = args
 
     if interpreter._PROFILE:
-        size, depth = _get_ast_stats(result)
+        size, depth, width = _get_ast_stats(result)
         interpreter.COUNTERS["ast_size"][size] += 1
         interpreter.COUNTERS["ast_depth"][depth] += 1
-        interpreter.COUNTERS["funsor"][getattr(cls, "__origin__", cls).__name__] += 1
+        classname = getattr(cls, "__origin__", cls).__name__
+        interpreter.COUNTERS["funsor"][classname] += 1
+        interpreter.COUNTERS[classname][width] += 1
 
     # alpha-convert eagerly upon binding any variable
     result = _alpha_mangle(result)
@@ -1675,27 +1679,46 @@ def of_shape(*shape):
     return symbolic(*shape)
 
 
+AstStats = namedtuple("AstStats", ("size", "depth", "width"))
+
+
 # Profiling helpers
 @singledispatch
+def _count_funsors(x):
+    return 0
+
+
+@_count_funsors.register(Funsor)
+def _(x):
+    return 1
+
+
+@_count_funsors.register(tuple)
+def _(x):
+    return sum(map(_count_funsors, x))
+
+
+@singledispatch
 def _get_ast_stats(x):
-    return 1, 1
+    return AstStats(1, 1, 0)
 
 
 @_get_ast_stats.register(Funsor)
 def _(x):
     result = getattr(x, "_ast_stats", None)
     if result is None:
-        size, depth = _get_ast_stats(x._ast_values)
-        result = x._ast_stats = size + 1, depth + 1
+        size, depth, _ = _get_ast_stats(x._ast_values)
+        width = _count_funsors(x._ast_values)
+        result = x._ast_stats = AstStats(size + 1, depth + 1, width)
     return result
 
 
 @_get_ast_stats.register(tuple)
 def _(x):
     parts = list(map(_get_ast_stats, x))
-    size = sum(size for size, _ in parts)
-    depth = max([0] + [depth for _, depth in parts])
-    return size, depth
+    size = sum(p.size for p in parts)
+    depth = max([0] + [p.depth for p in parts])
+    return AstStats(size, depth, 0)
 
 
 ################################################################################

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -523,7 +523,7 @@ def test_generic_log_prob(case, use_lazy):
         raw_value = raw_dist.sample()
     expected_logprob = to_funsor(raw_dist.log_prob(raw_value), output=funsor.Real, dim_to_name=dim_to_name)
     funsor_value = to_funsor(raw_value, output=expected_value_domain, dim_to_name=dim_to_name)
-    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-4 if use_lazy else 1e-3)
+    assert_close(funsor_dist(value=funsor_value), expected_logprob, rtol=1e-3)
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro/issues/2721
pair coded with @eb8680 

This adds a `interpreter.COUNTERS` which is a `defaultdict(Counter)`. When enabled, counters instrument a few sizes, call counts, and times of chosen parts of Funsor, and are printed on program exit.

## Tested
- [x] ran locally
- [x] added a smoke test