### PR TITLE
Prettify generic distribution tests

### DIFF
--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import re
 from collections import OrderedDict
 from importlib import import_module
 
@@ -14,11 +15,17 @@ from funsor.distribution import BACKEND_TO_DISTRIBUTIONS_BACKEND
 from funsor.interpreter import interpretation
 from funsor.terms import eager, lazy, normalize, reflect, to_data, to_funsor
 from funsor.testing import (  # noqa: F401
-    assert_close, check_funsor, rand, randint, randn, random_scale_tril,
-    xfail_if_not_found, xfail_if_not_implemented, xfail_param
+    assert_close,
+    check_funsor,
+    rand,
+    randint,
+    randn,
+    random_scale_tril,
+    xfail_if_not_found,
+    xfail_if_not_implemented,
+    xfail_param
 )
 from funsor.util import get_backend
-
 
 _ENABLE_MC_DIST_TESTS = int(os.environ.get("FUNSOR_ENABLE_MC_DIST_TESTS", 0))
 
@@ -40,20 +47,19 @@ if get_backend() != "numpy":
     FAKES = _fakes()
 
 
-if get_backend() == "jax":
-    _expanded_dist_path = "backend_dist.ExpandedDistribution"
-elif get_backend() == "torch":
-    _expanded_dist_path = "backend_dist.torch_distribution.ExpandedDistribution"
-else:
-    _expanded_dist_path = ""
+if get_backend() == "torch":
+    # Patch backporting https://github.com/pyro-ppl/pyro/pull/2748
+    backend_dist.ExpandedDistribution = backend_dist.torch_distribution.ExpandedDistribution
 
 
 def normalize_with_subs(cls, *args):
     """
     This interpretation is like normalize, except it also evaluates Subs eagerly.
-    This is necessary because we want to convert distribution expressions to normal form in some tests,
-    but do not want to trigger eager patterns that rewrite some distributions (e.g. Normal to Gaussian)
-    since these tests are specifically intended to exercise funsor.distribution.Distribution.
+
+    This is necessary because we want to convert distribution expressions to
+    normal form in some tests, but do not want to trigger eager patterns that
+    rewrite some distributions (e.g. Normal to Gaussian) since these tests are
+    specifically intended to exercise funsor.distribution.Distribution.
     """
     result = normalize.dispatch(cls, *args)(*args)
     if result is None:
@@ -73,7 +79,8 @@ TEST_CASES = []
 class DistTestCase:
 
     def __init__(self, raw_dist, raw_params, expected_value_domain, xfail_reason=""):
-        self.raw_dist = raw_dist
+        assert isinstance(raw_dist, str)
+        self.raw_dist = re.sub(r"\s+", " ", raw_dist.strip())
         self.raw_params = raw_params
         self.expected_value_domain = expected_value_domain
         for name, raw_param in self.raw_params:
@@ -81,6 +88,12 @@ class DistTestCase:
                 # we need direct access to these tensors for gradient tests
                 setattr(self, name, eval(raw_param))
         TEST_CASES.append(self if not xfail_reason else xfail_param(self, reason=xfail_reason))
+
+    def get_dist(self):
+        dist = backend_dist  # noqa: F841
+        case = self  # noqa: F841
+        with xfail_if_not_found():
+            return eval(self.raw_dist)
 
     def __str__(self):
         return self.raw_dist + " " + str(self.raw_params)
@@ -93,42 +106,45 @@ for batch_shape in [(), (5,), (2, 3)]:
 
     # BernoulliLogits
     DistTestCase(
-        "backend_dist.Bernoulli(logits=case.logits)",
+        "dist.Bernoulli(logits=case.logits)",
         (("logits", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # BernoulliProbs
     DistTestCase(
-        "backend_dist.Bernoulli(probs=case.probs)",
+        "dist.Bernoulli(probs=case.probs)",
         (("probs", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # Beta
     DistTestCase(
-        "backend_dist.Beta(case.concentration1, case.concentration0)",
-        (("concentration1", f"ops.exp(randn({batch_shape}))"), ("concentration0", f"ops.exp(randn({batch_shape}))")),
+        "dist.Beta(case.concentration1, case.concentration0)",
+        (("concentration1", f"ops.exp(randn({batch_shape}))"),
+         ("concentration0", f"ops.exp(randn({batch_shape}))")),
         funsor.Real,
     )
     # NonreparameterizedBeta
     DistTestCase(
         "FAKES.NonreparameterizedBeta(case.concentration1, case.concentration0)",
-        (("concentration1", f"ops.exp(randn({batch_shape}))"), ("concentration0", f"ops.exp(randn({batch_shape}))")),
+        (("concentration1", f"ops.exp(randn({batch_shape}))"),
+         ("concentration0", f"ops.exp(randn({batch_shape}))")),
         funsor.Real,
     )
 
     # Binomial
     DistTestCase(
-        "backend_dist.Binomial(total_count=case.total_count, probs=case.probs)",
-        (("total_count", "randint(10, 12, ())" if get_backend() == "jax" else "5"), ("probs", f"rand({batch_shape})")),
+        "dist.Binomial(total_count=case.total_count, probs=case.probs)",
+        (("total_count", "randint(10, 12, ())" if get_backend() == "jax" else "5"),
+         ("probs", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # CategoricalLogits
     for size in [2, 4]:
         DistTestCase(
-            "backend_dist.Categorical(logits=case.logits)",
+            "dist.Categorical(logits=case.logits)",
             (("logits", f"rand({batch_shape + (size,)})"),),
             funsor.Bint[size],
         )
@@ -136,28 +152,29 @@ for batch_shape in [(), (5,), (2, 3)]:
     # CategoricalProbs
     for size in [2, 4]:
         DistTestCase(
-            "backend_dist.Categorical(probs=case.probs)",
+            "dist.Categorical(probs=case.probs)",
             (("probs", f"rand({batch_shape + (size,)})"),),
             funsor.Bint[size],
         )
 
     # Cauchy
     DistTestCase(
-        "backend_dist.Cauchy(loc=case.loc, scale=case.scale)",
-        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        "dist.Cauchy(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Chi2
     DistTestCase(
-        "backend_dist.Chi2(df=case.df)",
+        "dist.Chi2(df=case.df)",
         (("df", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # ContinuousBernoulli
     DistTestCase(
-        "backend_dist.ContinuousBernoulli(logits=case.logits)",
+        "dist.ContinuousBernoulli(logits=case.logits)",
         (("logits", f"rand({batch_shape})"),),
         funsor.Real,
     )
@@ -165,15 +182,16 @@ for batch_shape in [(), (5,), (2, 3)]:
     # Delta
     for event_shape in [(), (4,), (3, 2)]:
         DistTestCase(
-            f"backend_dist.Delta(v=case.v, log_density=case.log_density, event_dim={len(event_shape)})",
-            (("v", f"rand({batch_shape + event_shape})"), ("log_density", f"rand({batch_shape})")),
+            f"dist.Delta(v=case.v, log_density=case.log_density, event_dim={len(event_shape)})",
+            (("v", f"rand({batch_shape + event_shape})"),
+             ("log_density", f"rand({batch_shape})")),
             funsor.Reals[event_shape],
         )
 
     # Dirichlet
     for event_shape in [(1,), (4,)]:
         DistTestCase(
-            "backend_dist.Dirichlet(case.concentration)",
+            "dist.Dirichlet(case.concentration)",
             (("concentration", f"rand({batch_shape + event_shape})"),),
             funsor.Reals[event_shape],
         )
@@ -187,77 +205,83 @@ for batch_shape in [(), (5,), (2, 3)]:
     # DirichletMultinomial
     for event_shape in [(1,), (4,)]:
         DistTestCase(
-            "backend_dist.DirichletMultinomial(case.concentration, case.total_count)",
-            (("concentration", f"rand({batch_shape + event_shape})"), ("total_count", "randint(10, 12, ())")),
+            "dist.DirichletMultinomial(case.concentration, case.total_count)",
+            (("concentration", f"rand({batch_shape + event_shape})"),
+             ("total_count", "randint(10, 12, ())")),
             funsor.Reals[event_shape],
         )
 
     # Exponential
     DistTestCase(
-        "backend_dist.Exponential(rate=case.rate)",
+        "dist.Exponential(rate=case.rate)",
         (("rate", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # FisherSnedecor
     DistTestCase(
-        "backend_dist.FisherSnedecor(df1=case.df1, df2=case.df2)",
-        (("df1", f"rand({batch_shape})"), ("df2", f"rand({batch_shape})")),
+        "dist.FisherSnedecor(df1=case.df1, df2=case.df2)",
+        (("df1", f"rand({batch_shape})"),
+         ("df2", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Gamma
     DistTestCase(
-        "backend_dist.Gamma(case.concentration, case.rate)",
-        (("concentration", f"rand({batch_shape})"), ("rate", f"rand({batch_shape})")),
+        "dist.Gamma(case.concentration, case.rate)",
+        (("concentration", f"rand({batch_shape})"),
+         ("rate", f"rand({batch_shape})")),
         funsor.Real,
     )
     # NonreparametrizedGamma
     DistTestCase(
         "FAKES.NonreparameterizedGamma(case.concentration, case.rate)",
-        (("concentration", f"rand({batch_shape})"), ("rate", f"rand({batch_shape})")),
+        (("concentration", f"rand({batch_shape})"),
+         ("rate", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Geometric
     DistTestCase(
-        "backend_dist.Geometric(probs=case.probs)",
+        "dist.Geometric(probs=case.probs)",
         (("probs", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # Gumbel
     DistTestCase(
-        "backend_dist.Gumbel(loc=case.loc, scale=case.scale)",
-        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        "dist.Gumbel(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # HalfCauchy
     DistTestCase(
-        "backend_dist.HalfCauchy(scale=case.scale)",
+        "dist.HalfCauchy(scale=case.scale)",
         (("scale", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # HalfNormal
     DistTestCase(
-        "backend_dist.HalfNormal(scale=case.scale)",
+        "dist.HalfNormal(scale=case.scale)",
         (("scale", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # Laplace
     DistTestCase(
-        "backend_dist.Laplace(loc=case.loc, scale=case.scale)",
-        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        "dist.Laplace(loc=case.loc, scale=case.scale)",
+        (("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # LowRankMultivariateNormal
     for event_shape in [(3,), (4,)]:
         DistTestCase(
-            "backend_dist.LowRankMultivariateNormal(loc=case.loc, cov_factor=case.cov_factor, cov_diag=case.cov_diag)",
+            "dist.LowRankMultivariateNormal(loc=case.loc, cov_factor=case.cov_factor, cov_diag=case.cov_diag)",
             (("loc", f"randn({batch_shape + event_shape})"),
              ("cov_factor", f"randn({batch_shape + event_shape + (2,)})"),
              ("cov_diag", f"rand({batch_shape + event_shape})")),
@@ -267,7 +291,7 @@ for batch_shape in [(), (5,), (2, 3)]:
     # Multinomial
     for event_shape in [(1,), (4,)]:
         DistTestCase(
-            "backend_dist.Multinomial(case.total_count, probs=case.probs)",
+            "dist.Multinomial(case.total_count, probs=case.probs)",
             (("total_count", "randint(5, 7, ())" if get_backend() == "jax" else "5"),
              ("probs", f"rand({batch_shape + event_shape})")),
             funsor.Reals[event_shape],
@@ -276,85 +300,95 @@ for batch_shape in [(), (5,), (2, 3)]:
     # MultivariateNormal
     for event_shape in [(1,), (3,)]:
         DistTestCase(
-            "backend_dist.MultivariateNormal(loc=case.loc, scale_tril=case.scale_tril)",
-            (("loc", f"randn({batch_shape + event_shape})"), ("scale_tril", f"random_scale_tril({batch_shape + event_shape * 2})")),  # noqa: E501
+            "dist.MultivariateNormal(loc=case.loc, scale_tril=case.scale_tril)",
+            (("loc", f"randn({batch_shape + event_shape})"),
+             ("scale_tril", f"random_scale_tril({batch_shape + event_shape * 2})")),
             funsor.Reals[event_shape],
         )
 
     # NegativeBinomial
     DistTestCase(
-        "backend_dist.NegativeBinomial(total_count=case.total_count, probs=case.probs)",
-        (("total_count", "randint(10, 12, ())" if get_backend() == "jax" else "5"), ("probs", f"rand({batch_shape})")),
+        "dist.NegativeBinomial(total_count=case.total_count, probs=case.probs)",
+        (("total_count", "randint(10, 12, ())" if get_backend() == "jax" else "5"),
+         ("probs", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Normal
     DistTestCase(
-        "backend_dist.Normal(case.loc, case.scale)",
-        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        "dist.Normal(case.loc, case.scale)",
+        (("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real,
     )
     # NonreparameterizedNormal
     DistTestCase(
         "FAKES.NonreparameterizedNormal(case.loc, case.scale)",
-        (("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        (("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # OneHotCategorical
     for size in [2, 4]:
         DistTestCase(
-            "backend_dist.OneHotCategorical(probs=case.probs)",
+            "dist.OneHotCategorical(probs=case.probs)",
             (("probs", f"rand({batch_shape + (size,)})"),),
             funsor.Reals[size],  # funsor.Bint[size],
         )
 
     # Pareto
     DistTestCase(
-        "backend_dist.Pareto(scale=case.scale, alpha=case.alpha)",
-        (("scale", f"rand({batch_shape})"), ("alpha", f"rand({batch_shape})")),
+        "dist.Pareto(scale=case.scale, alpha=case.alpha)",
+        (("scale", f"rand({batch_shape})"),
+         ("alpha", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Poisson
     DistTestCase(
-        "backend_dist.Poisson(rate=case.rate)",
+        "dist.Poisson(rate=case.rate)",
         (("rate", f"rand({batch_shape})"),),
         funsor.Real,
     )
 
     # RelaxedBernoulli
     DistTestCase(
-        "backend_dist.RelaxedBernoulli(temperature=case.temperature, logits=case.logits)",
-        (("temperature", f"rand({batch_shape})"), ("logits", f"rand({batch_shape})")),
+        "dist.RelaxedBernoulli(temperature=case.temperature, logits=case.logits)",
+        (("temperature", f"rand({batch_shape})"),
+         ("logits", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # StudentT
     DistTestCase(
-        "backend_dist.StudentT(df=case.df, loc=case.loc, scale=case.scale)",
-        (("df", f"rand({batch_shape})"), ("loc", f"randn({batch_shape})"), ("scale", f"rand({batch_shape})")),
+        "dist.StudentT(df=case.df, loc=case.loc, scale=case.scale)",
+        (("df", f"rand({batch_shape})"),
+         ("loc", f"randn({batch_shape})"),
+         ("scale", f"rand({batch_shape})")),
         funsor.Real
     )
 
     # Uniform
     DistTestCase(
-        "backend_dist.Uniform(low=case.low, high=case.high)",
+        "dist.Uniform(low=case.low, high=case.high)",
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
         funsor.Real
     )
 
     # VonMises
     DistTestCase(
-        "backend_dist.VonMises(case.loc, case.concentration)",
-        (("loc", f"rand({batch_shape})"), ("concentration", f"rand({batch_shape})")),
+        "dist.VonMises(case.loc, case.concentration)",
+        (("loc", f"rand({batch_shape})"),
+         ("concentration", f"rand({batch_shape})")),
         funsor.Real,
     )
 
     # Weibull
     DistTestCase(
-        "backend_dist.Weibull(scale=case.scale, concentration=case.concentration)",
-        (("scale", f"ops.exp(randn({batch_shape}))"), ("concentration", f"ops.exp(rand({batch_shape}))")),
+        "dist.Weibull(scale=case.scale, concentration=case.concentration)",
+        (("scale", f"ops.exp(randn({batch_shape}))"),
+         ("concentration", f"ops.exp(rand({batch_shape}))")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
@@ -362,51 +396,88 @@ for batch_shape in [(), (5,), (2, 3)]:
     # TransformedDistributions
     # ExpTransform
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.ExpTransform(),])",  # noqa: E501
-        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.ExpTransform()])
+        """,
+        (("low", f"rand({batch_shape})"),
+         ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
     # InverseTransform (log)
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.ExpTransform().inv,])",  # noqa: E501
-        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.ExpTransform().inv])
+        """,
+        (("low", f"rand({batch_shape})"),
+         ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
     # TanhTransform
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.TanhTransform(),])",  # noqa: E501
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.TanhTransform(),])
+        """,
         (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
     # AtanhTransform
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.TanhTransform().inv,])",  # noqa: E501
-        (("low", f"0.5*rand({batch_shape})"), ("high", f"0.5 + 0.5*rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.TanhTransform().inv])
+        """,
+        (("low", f"0.5*rand({batch_shape})"),
+         ("high", f"0.5 + 0.5*rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
     # multiple transforms
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.TanhTransform(), backend_dist.transforms.ExpTransform()])",  # noqa: E501
-        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.TanhTransform(),
+             dist.transforms.ExpTransform()])
+        """,
+        (("low", f"rand({batch_shape})"),
+         ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
     # ComposeTransform
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), backend_dist.transforms.ComposeTransform([backend_dist.transforms.TanhTransform(), backend_dist.transforms.ExpTransform()]))",  # noqa: E501
-        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            dist.transforms.ComposeTransform([
+                dist.transforms.TanhTransform(),
+                dist.transforms.ExpTransform()]))
+        """,
+        (("low", f"rand({batch_shape})"),
+         ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="backend not supported" if get_backend() != "torch" else "",
     )
 
     # SigmoidTransform (inversion not working)
     DistTestCase(
-        "backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), [backend_dist.transforms.SigmoidTransform(),])",  # noqa: E501
-        (("low", f"rand({batch_shape})"), ("high", f"2. + rand({batch_shape})")),
+        """
+        dist.TransformedDistribution(
+            dist.Uniform(low=case.low, high=case.high),
+            [dist.transforms.SigmoidTransform(),])
+        """,
+        (("low", f"rand({batch_shape})"),
+         ("high", f"2. + rand({batch_shape})")),
         funsor.Real,
         xfail_reason="failure to re-invert ops.sigmoid.inv, which is not atomic",
     )
@@ -415,7 +486,7 @@ for batch_shape in [(), (5,), (2, 3)]:
     for indep_shape in [(3,), (2, 3)]:
         # Beta.to_event
         DistTestCase(
-            f"backend_dist.Beta(case.concentration1, case.concentration0).to_event({len(indep_shape)})",
+            f"dist.Beta(case.concentration1, case.concentration0).to_event({len(indep_shape)})",
             (("concentration1", f"ops.exp(randn({batch_shape + indep_shape}))"),
              ("concentration0", f"ops.exp(randn({batch_shape + indep_shape}))")),
             funsor.Reals[indep_shape],
@@ -423,14 +494,23 @@ for batch_shape in [(), (5,), (2, 3)]:
         # Dirichlet.to_event
         for event_shape in [(2,), (4,)]:
             DistTestCase(
-                f"backend_dist.Dirichlet(case.concentration).to_event({len(indep_shape)})",
+                f"dist.Dirichlet(case.concentration).to_event({len(indep_shape)})",
                 (("concentration", f"rand({batch_shape + indep_shape + event_shape})"),),
                 funsor.Reals[indep_shape + event_shape],
             )
         # TransformedDistribution.to_event
         DistTestCase(
-            f"backend_dist.Independent(backend_dist.TransformedDistribution(backend_dist.Uniform(low=case.low, high=case.high), backend_dist.transforms.ComposeTransform([backend_dist.transforms.TanhTransform(), backend_dist.transforms.ExpTransform()])), {len(indep_shape)})",  # noqa: E501
-            (("low", f"rand({batch_shape + indep_shape})"), ("high", f"2. + rand({batch_shape + indep_shape})")),
+            f"""
+            dist.Independent(
+                dist.TransformedDistribution(
+                    dist.Uniform(low=case.low, high=case.high),
+                    dist.transforms.ComposeTransform([
+                        dist.transforms.TanhTransform(),
+                        dist.transforms.ExpTransform()])),
+                {len(indep_shape)})
+            """,
+            (("low", f"rand({batch_shape + indep_shape})"),
+             ("high", f"2. + rand({batch_shape + indep_shape})")),
             funsor.Reals[indep_shape],
             xfail_reason="to_funsor/to_data conversion is not yet reversible",
         )
@@ -439,7 +519,11 @@ for batch_shape in [(), (5,), (2, 3)]:
     for extra_shape in [(), (3,), (2, 3)]:
         # Poisson
         DistTestCase(
-            _expanded_dist_path + f"(backend_dist.Poisson(rate=case.rate), {extra_shape + batch_shape})",  # noqa: E501
+            f"""
+            dist.ExpandedDistribution(
+                dist.Poisson(rate=case.rate),
+                {extra_shape + batch_shape})
+            """,
             (("rate", f"rand({batch_shape})"),),
             funsor.Real,
         )
@@ -470,8 +554,8 @@ def test_generic_distribution_to_funsor(case):
     ] + ([backend_dist.torch_distribution.ExpandedDistribution] if get_backend() == "torch"
          else [backend_dist.ExpandedDistribution])
 
-    with xfail_if_not_found():
-        raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
+    raw_dist = case.get_dist()
+    expected_value_domain = case.expected_value_domain
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(normalize_with_subs):
@@ -504,9 +588,8 @@ def test_generic_distribution_to_funsor(case):
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
 @pytest.mark.parametrize("use_lazy", [True, False])
 def test_generic_log_prob(case, use_lazy):
-
-    with xfail_if_not_found():
-        raw_dist, expected_value_domain = eval(case.raw_dist), case.expected_value_domain
+    raw_dist = case.get_dist()
+    expected_value_domain = case.expected_value_domain
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(normalize_with_subs if use_lazy else eager):
@@ -529,9 +612,7 @@ def test_generic_log_prob(case, use_lazy):
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
 @pytest.mark.parametrize("expand", [False, True])
 def test_generic_enumerate_support(case, expand):
-
-    with xfail_if_not_found():
-        raw_dist = eval(case.raw_dist)
+    raw_dist = case.get_dist()
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(normalize_with_subs):
@@ -549,9 +630,7 @@ def test_generic_enumerate_support(case, expand):
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
 @pytest.mark.parametrize("sample_shape", [(), (2,), (4, 3)], ids=str)
 def test_generic_sample(case, sample_shape):
-
-    with xfail_if_not_found():
-        raw_dist = eval(case.raw_dist)
+    raw_dist = case.get_dist()
 
     dim_to_name, name_to_dim = _default_dim_to_name(sample_shape + raw_dist.batch_shape)
     with interpretation(normalize_with_subs):
@@ -573,9 +652,7 @@ def test_generic_sample(case, sample_shape):
     pytest.param("entropy", marks=[pytest.mark.skipif(get_backend() == "jax", reason="entropy not implemented")])
 ])
 def test_generic_stats(case, statistic):
-
-    with xfail_if_not_found():
-        raw_dist = eval(case.raw_dist)
+    raw_dist = case.get_dist()
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
     with interpretation(normalize_with_subs):


### PR DESCRIPTION
These are entirely aesthetic changes that make the tests more readable, auditable, and editable:
- wrap long lines
- replace `backend_dist` -> `dist` in test strings
- move `eval()` into a single helper
- avoid unnecessary destructured assignment
- patch to backport https://github.com/pyro-ppl/pyro/pull/2748