### PR TITLE
Improve __str__; add ops //, %, <<, >>

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -82,17 +82,21 @@ class Contraction(Funsor):
         self.reduced_vars = reduced_vars
 
     def __repr__(self):
-        if self.op in _INFIX:
+        if self.bin_op in _INFIX:
+            bin_op = " " + _INFIX[self.bin_op] + " "
             return "{}.reduce({}, {})".format(
-                f" {self.bin_op.name} ".join(map(repr, self.terms)),
-                _INFIX[self.op], str(set(self.reduced_vars)))
+                bin_op.join(map(repr, self.terms)),
+                self.red_op,
+                str(set(self.reduced_vars)))
         return super().__repr__()
 
     def __str__(self):
-        if self.op in _INFIX:
+        if self.bin_op in _INFIX:
+            bin_op = " " + _INFIX[self.bin_op] + " "
             return "{}.reduce({}, {})".format(
-                f" {self.bin_op.name} ".join(map(str, self.terms)),
-                _INFIX[self.op], str(set(map(str, self.reduced_vars))))
+                bin_op.join(map(str, self.terms)),
+                self.red_op,
+                str(set(map(str, self.reduced_vars))))
         return super().__str__()
 
     def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -20,6 +20,7 @@ from funsor.interpreter import interpretation, recursion_reinterpret
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
 from funsor.tensor import Tensor
 from funsor.terms import (
+    _INFIX,
     Align,
     Binary,
     Funsor,
@@ -79,6 +80,20 @@ class Contraction(Funsor):
         self.bin_op = bin_op
         self.terms = terms
         self.reduced_vars = reduced_vars
+
+    def __repr__(self):
+        if self.op in _INFIX:
+            return "{}.reduce({}, {})".format(
+                f" {self.bin_op.name} ".join(map(repr, self.terms)),
+                _INFIX[self.op], str(set(self.reduced_vars)))
+        return super().__repr__()
+
+    def __str__(self):
+        if self.op in _INFIX:
+            return "{}.reduce({}, {})".format(
+                f" {self.bin_op.name} ".join(map(str, self.terms)),
+                _INFIX[self.op], str(set(map(str, self.reduced_vars))))
+        return super().__str__()
 
     def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
         sampled_vars = sampled_vars.intersection(self.inputs)

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -222,12 +222,8 @@ def find_domain(op, *domains):
     raise NotImplementedError
 
 
-@find_domain.register(ops.Op)  # TODO this is too general, register all ops
-@find_domain.register(ops.ReciprocalOp)
-@find_domain.register(ops.SigmoidOp)
-@find_domain.register(ops.TanhOp)
-@find_domain.register(ops.AtanhOp)
-def _find_domain_pointwise_unary_transform(op, domain):
+@find_domain.register(ops.UnaryOp)
+def _find_domain_pointwise_unary_generic(op, domain):
     if isinstance(domain, ArrayType):
         return Array[domain.dtype, domain.shape]
     raise NotImplementedError
@@ -256,19 +252,35 @@ def _find_domain_getitem(op, lhs_domain, rhs_domain):
                                   f"{lhs_domain}[{rhs_domain}]")
 
 
-@find_domain.register(ops.EqOp)
-@find_domain.register(ops.GeOp)
-@find_domain.register(ops.GtOp)
-@find_domain.register(ops.LeOp)
-@find_domain.register(ops.LtOp)
-@find_domain.register(ops.NeOp)
-@find_domain.register(ops.PowOp)
-@find_domain.register(ops.SubOp)
-@find_domain.register(ops.TruedivOp)
+@find_domain.register(ops.BinaryOp)
 def _find_domain_pointwise_binary_generic(op, lhs, rhs):
     if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType) and \
             lhs.dtype == rhs.dtype:
         return Array[lhs.dtype, broadcast_shape(lhs.shape, rhs.shape)]
+    raise NotImplementedError("TODO")
+
+
+@find_domain.register(ops.FloordivOp)
+def _find_domain_floordiv(op, lhs, rhs):
+    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):
+        shape = broadcast_shape(lhs.shape, rhs.shape)
+        if isinstance(lhs.dtype, int) and isinstance(rhs.dtype, int):
+            size = (lhs.size - 1) // (rhs.size - 1) + 1
+            return Array[size, shape]
+        if lhs.dtype == "real" and rhs.dtype == "real":
+            return Reals[shape]
+    raise NotImplementedError("TODO")
+
+
+@find_domain.register(ops.ModOp)
+def _find_domain_mod(op, lhs, rhs):
+    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):
+        shape = broadcast_shape(lhs.shape, rhs.shape)
+        if isinstance(lhs.dtype, int) and isinstance(rhs.dtype, int):
+            dtype = max(0, rhs.dtype - 1)
+            return Array[dtype, shape]
+        if lhs.dtype == "real" and rhs.dtype == "real":
+            return Reals[shape]
     raise NotImplementedError("TODO")
 
 
@@ -311,7 +323,7 @@ def _find_domain_associative_generic(op, *domains):
     return Array[dtype, shape]
 
 
-@find_domain.register(ops.TransformOp)
+@find_domain.register(ops.WrappedTransformOp)
 def _transform_find_domain(op, domain):
     fn = op.dispatch(object)
     shape = fn.forward_shape(domain.shape)

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -90,6 +90,8 @@ and_ = make_op(operator.and_, AssociativeOp)
 mul = make_op(operator.mul, AssociativeOp)
 matmul = make_op(operator.matmul, BinaryOp)
 mod = make_op(operator.mod, BinaryOp)
+lshift = make_op(operator.lshift, BinaryOp)
+rshift = make_op(operator.rshift, BinaryOp)
 or_ = make_op(operator.or_, AssociativeOp)
 xor = make_op(operator.xor, AssociativeOp)
 max = make_op(max, AssociativeOp)
@@ -191,6 +193,7 @@ __all__ = [
     'lgamma',
     'log',
     'log1p',
+    'lshift',
     'lt',
     'matmul',
     'max',
@@ -203,6 +206,7 @@ __all__ = [
     'or_',
     'pow',
     'reciprocal',
+    'rshift',
     'safediv',
     'safesub',
     'sigmoid',

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -9,6 +9,7 @@ from .op import (
     DISTRIBUTIVE_OPS,
     PRODUCT_INVERSES,
     UNITS,
+    BinaryOp,
     CachedOpMeta,
     Op,
     TransformOp,
@@ -72,22 +73,23 @@ class GetitemOp(Op, metaclass=CachedOpMeta):
 
 getitem = GetitemOp(0)
 abs = make_op(_builtin_abs, UnaryOp)
-eq = make_op(operator.eq, Op)
-ge = make_op(operator.ge, Op)
-gt = make_op(operator.gt, Op)
+eq = make_op(operator.eq, BinaryOp)
+ge = make_op(operator.ge, BinaryOp)
+gt = make_op(operator.gt, BinaryOp)
 invert = make_op(operator.invert, UnaryOp)
-le = make_op(operator.le, Op)
-lt = make_op(operator.lt, Op)
-ne = make_op(operator.ne, Op)
-neg = make_op(operator.neg, Op)
-pow = make_op(operator.pow, Op)
-sub = make_op(operator.sub, Op)
-truediv = make_op(operator.truediv, Op)
-
+le = make_op(operator.le, BinaryOp)
+lt = make_op(operator.lt, BinaryOp)
+ne = make_op(operator.ne, BinaryOp)
+neg = make_op(operator.neg, UnaryOp)
+pow = make_op(operator.pow, BinaryOp)
+sub = make_op(operator.sub, BinaryOp)
+truediv = make_op(operator.truediv, BinaryOp)
+floordiv = make_op(operator.floordiv, BinaryOp)
 add = make_op(operator.add, AssociativeOp)
 and_ = make_op(operator.and_, AssociativeOp)
 mul = make_op(operator.mul, AssociativeOp)
-matmul = make_op(operator.matmul, Op)
+matmul = make_op(operator.matmul, BinaryOp)
+mod = make_op(operator.mod, BinaryOp)
 or_ = make_op(operator.or_, AssociativeOp)
 xor = make_op(operator.xor, AssociativeOp)
 max = make_op(max, AssociativeOp)
@@ -180,6 +182,7 @@ __all__ = [
     'atanh',
     'eq',
     'exp',
+    'floordiv',
     'ge',
     'getitem',
     'gt',
@@ -192,6 +195,7 @@ __all__ = [
     'matmul',
     'max',
     'min',
+    'mod',
     'mul',
     'ne',
     'neg',

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -555,14 +555,16 @@ def tensor_to_data(x, name_to_dim=None):
 
 @eager.register(Binary, Op, Tensor, Number)
 def eager_binary_tensor_number(op, lhs, rhs):
+    dtype = find_domain(op, lhs.output, rhs.output).dtype
     data = op(lhs.data, rhs.data)
-    return Tensor(data, lhs.inputs, lhs.dtype)
+    return Tensor(data, lhs.inputs, dtype)
 
 
 @eager.register(Binary, Op, Number, Tensor)
 def eager_binary_number_tensor(op, lhs, rhs):
+    dtype = find_domain(op, lhs.output, rhs.output).dtype
     data = op(lhs.data, rhs.data)
-    return Tensor(data, rhs.inputs, rhs.dtype)
+    return Tensor(data, rhs.inputs, dtype)
 
 
 @eager.register(Binary, Op, Tensor, Tensor)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -705,6 +705,18 @@ class Funsor(object, metaclass=FunsorMeta):
     def __rmod__(self, other):
         return Binary(ops.mod, to_funsor(other), self)
 
+    def __lshift__(self, other):
+        return Binary(ops.lshift, self, to_funsor(other))
+
+    def __rlshift__(self, other):
+        return Binary(ops.lshift, to_funsor(other), self)
+
+    def __rshift__(self, other):
+        return Binary(ops.rshift, self, to_funsor(other))
+
+    def __rrshift__(self, other):
+        return Binary(ops.rshift, to_funsor(other), self)
+
     def __pow__(self, other):
         return Binary(ops.pow, self, to_funsor(other))
 
@@ -1022,6 +1034,8 @@ _INFIX = {
     ops.gt: ">=",
     ops.le: "<=",
     ops.lt: "<",
+    ops.lshift: "<<",
+    ops.rshift: ">>",
 }
 
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -20,7 +20,7 @@ import funsor.ops as ops
 from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
 from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.util import getargspec, get_backend, lazy_property, pretty, quote
+from funsor.util import get_backend, getargspec, lazy_property, pretty, quote
 
 
 def substitute(expr, subs):
@@ -687,11 +687,23 @@ class Funsor(object, metaclass=FunsorMeta):
     def __rtruediv__(self, other):
         return Binary(ops.truediv, to_funsor(other), self)
 
+    def __floordiv__(self, other):
+        return Binary(ops.floordiv, self, to_funsor(other))
+
+    def __rfloordiv__(self, other):
+        return Binary(ops.floordiv, to_funsor(other), self)
+
     def __matmul__(self, other):
         return Binary(ops.matmul, self, to_funsor(other))
 
     def __rmatmul__(self, other):
         return Binary(ops.matmul, to_funsor(other), self)
+
+    def __mod__(self, other):
+        return Binary(ops.mod, self, to_funsor(other))
+
+    def __rmod__(self, other):
+        return Binary(ops.mod, to_funsor(other), self)
 
     def __pow__(self, other):
         return Binary(ops.pow, self, to_funsor(other))
@@ -908,7 +920,12 @@ class Subs(Funsor, metaclass=SubsMeta):
         self.subs = OrderedDict(subs)
 
     def __repr__(self):
-        return 'Subs({}, {})'.format(self.arg, self.subs)
+        return "{}({})".format(
+            repr(self.arg), ", ".join(f"{k}={repr(v)}" for k, v in self.subs))
+
+    def __str__(self):
+        return "{}({})".format(
+            str(self.arg), ", ".join(f"{k}={str(v)}" for k, v in self.subs))
 
     def _alpha_convert(self, alpha_subs):
         assert set(alpha_subs).issubset(self.bound)
@@ -969,8 +986,13 @@ class Unary(Funsor):
 
     def __repr__(self):
         if self.op in _PREFIX:
-            return '{}{}'.format(_PREFIX[self.op], self.arg)
-        return 'Unary({}, {})'.format(self.op.__name__, self.arg)
+            return "({}{})".format(_PREFIX[self.op], repr(self.arg))
+        return super().__repr__()
+
+    def __str__(self):
+        if self.op in _PREFIX:
+            return "({}{})".format(_PREFIX[self.op], str(self.arg))
+        return super().__str__()
 
 
 @eager.register(Unary, Op, Funsor)
@@ -986,11 +1008,20 @@ def eager_unary(op, arg):
 
 
 _INFIX = {
-    ops.add: '+',
-    ops.sub: '-',
-    ops.mul: '*',
-    ops.truediv: '/',
-    ops.pow: '**',
+    ops.add: "+",
+    ops.sub: "-",
+    ops.mul: "*",
+    ops.matmul: "@",
+    ops.truediv: "/",
+    ops.floordiv: "//",
+    ops.mod: "%",
+    ops.pow: "**",
+    ops.eq: "==",
+    ops.ne: "!=",
+    ops.ge: ">=",
+    ops.gt: ">=",
+    ops.le: "<=",
+    ops.lt: "<",
 }
 
 
@@ -1016,8 +1047,13 @@ class Binary(Funsor):
 
     def __repr__(self):
         if self.op in _INFIX:
-            return '({} {} {})'.format(self.lhs, _INFIX[self.op], self.rhs)
-        return 'Binary({}, {}, {})'.format(self.op.__name__, self.lhs, self.rhs)
+            return "({} {} {})".format(repr(self.lhs), _INFIX[self.op], repr(self.rhs))
+        return super().__repr__()
+
+    def __str__(self):
+        if self.op in _INFIX:
+            return "({} {} {})".format(str(self.lhs), _INFIX[self.op], str(self.rhs))
+        return super().__str__()
 
 
 class Reduce(Funsor):
@@ -1045,8 +1081,22 @@ class Reduce(Funsor):
         self.reduced_vars = reduced_vars
 
     def __repr__(self):
-        return 'Reduce({}, {}, {})'.format(
-            self.op.__name__, self.arg, self.reduced_vars)
+        assert self.reduced_vars
+        if self.reduced_vars == self.arg.input_vars:
+            return f"{repr(self.arg)}.reduce({self.op.__name__})"
+        rvars = [f'"{v.name}"' if v in self.arg.input_vars else repr(v)
+                 for v in self.reduced_vars]
+        return "{}.reduce({}, {{{}}})".format(
+            repr(self.arg), self.op.__name__, ", ".join(rvars))
+
+    def __str__(self):
+        assert self.reduced_vars
+        if self.reduced_vars == self.arg.input_vars:
+            return f"{str(self.arg)}.reduce({self.op.__name__})"
+        rvars = [f'"{v.name}"' if v in self.arg.input_vars else repr(v)
+                 for v in self.reduced_vars]
+        return "{}.reduce({}, {{{}}})".format(
+            str(self.arg), self.op.__name__, ", ".join(rvars))
 
     def _alpha_convert(self, alpha_subs):
         alpha_subs = {k: to_funsor(v, self.arg.inputs[k])
@@ -1131,9 +1181,9 @@ class Number(Funsor, metaclass=NumberMeta):
 
     def __repr__(self):
         if self.dtype == "real":
-            return 'Number({}, "real")'.format(repr(self.data))
+            return f"Number({str(self.data)})"
         else:
-            return 'Number({}, {})'.format(repr(self.data), self.dtype)
+            return f"Number({str(self.data)}, {self.dtype})"
 
     def __str__(self):
         return str(self.data)
@@ -1228,9 +1278,6 @@ class Slice(Funsor, metaclass=SliceMeta):
         super().__init__(inputs, output, fresh)
         self.name = name
         self.slice = slice(start, stop, step)
-
-    def __repr__(self):
-        return "Slice({})".format(", ".join(map(repr, self._ast_values)))
 
     def eager_subs(self, subs):
         assert len(subs) == 1 and subs[0][0] == self.name

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -921,11 +921,11 @@ class Subs(Funsor, metaclass=SubsMeta):
 
     def __repr__(self):
         return "{}({})".format(
-            repr(self.arg), ", ".join(f"{k}={repr(v)}" for k, v in self.subs))
+            repr(self.arg), ", ".join(f"{k}={repr(v)}" for k, v in self.subs.items()))
 
     def __str__(self):
         return "{}({})".format(
-            str(self.arg), ", ".join(f"{k}={str(v)}" for k, v in self.subs))
+            str(self.arg), ", ".join(f"{k}={str(v)}" for k, v in self.subs.items()))
 
     def _alpha_convert(self, alpha_subs):
         assert set(alpha_subs).issubset(self.bound)

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -46,7 +46,6 @@ def test_getitem_getitem(num_inputs):
     check_funsor(actual, expected.inputs, expected.output, expected.data)
 
 
-@pytest.mark.xfail(reason="missing pattern Variable //,% Number")
 def test_flatten():
     @make_funsor
     def Flatten21(
@@ -59,8 +58,8 @@ def test_flatten():
         n = to_funsor(j, x.inputs.get(j, None)).output.size
         ij = to_funsor(ij, Bint[m * n])
         ij = x.materialize(ij)
-        return x(**{i.name: ij // Number(n, m * n),
-                    j.name: ij % Number(n, m * n)})
+        return x(**{i.name: ij // Number(n, n + 1),
+                    j.name: ij % Number(n, n + 1)})
 
     inputs = OrderedDict()
     inputs["a"] = Bint[3]

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -329,7 +329,8 @@ def test_unary(symbol, dims):
 
 
 BINARY_OPS = [
-    '+', '-', '*', '/', '//', '%', '**', '==', '!=', '<', '<=', '>', '>=',
+    '+', '-', '*', '/', '//', '%', '**', "<<", ">>",
+    '==', '!=', '<', '<=', '>', '>=',
     'min', 'max',
 ]
 BOOLEAN_OPS = ['&', '|', '^']
@@ -431,8 +432,8 @@ def test_binary_scalar_funsor(symbol, dims, scalar):
     shape = tuple(sizes[d] for d in dims)
     inputs = OrderedDict((d, Bint[sizes[d]]) for d in dims)
     data1 = rand(shape) + 0.5
-    if symbol == "%":
-        pytest.xfail(reason="__rmod__ is not triggered")
+    if symbol in ("%", "<<", ">>"):
+        pytest.xfail(reason=f"right application of {symbol} is not triggered")
     expected_data = binary_eval(symbol, scalar, data1)
 
     x1 = Tensor(data1, inputs)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -329,7 +329,7 @@ def test_unary(symbol, dims):
 
 
 BINARY_OPS = [
-    '+', '-', '*', '/', '**', '==', '!=', '<', '<=', '>', '>=',
+    '+', '-', '*', '/', '//', '%', '**', '==', '!=', '<', '<=', '>', '>=',
     'min', 'max',
 ]
 BOOLEAN_OPS = ['&', '|', '^']
@@ -431,6 +431,8 @@ def test_binary_scalar_funsor(symbol, dims, scalar):
     shape = tuple(sizes[d] for d in dims)
     inputs = OrderedDict((d, Bint[sizes[d]]) for d in dims)
     data1 = rand(shape) + 0.5
+    if symbol == "%":
+        pytest.xfail(reason="__rmod__ is not triggered")
     expected_data = binary_eval(symbol, scalar, data1)
 
     x1 = Tensor(data1, inputs)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -334,6 +334,7 @@ BINARY_OPS = [
     'min', 'max',
 ]
 BOOLEAN_OPS = ['&', '|', '^']
+INTEGER_OPS = ["<<", ">>"]
 
 
 def binary_eval(symbol, x, y):
@@ -360,6 +361,9 @@ def test_binary_funsor_funsor(symbol, dims1, dims2):
         dtype = 2
         data1 = ops.astype(data1, 'uint8')
         data2 = ops.astype(data2, 'uint8')
+    elif symbol in INTEGER_OPS:
+        data1 = ops.astype(data1, 'int64')
+        data2 = ops.astype(data2, 'int64')
     x1 = Tensor(data1, inputs1, dtype)
     x2 = Tensor(data2, inputs2, dtype)
     inputs, aligned = align_tensors(x1, x2)
@@ -417,11 +421,16 @@ def test_binary_funsor_scalar(symbol, dims, scalar):
     shape = tuple(sizes[d] for d in dims)
     inputs = OrderedDict((d, Bint[sizes[d]]) for d in dims)
     data1 = rand(shape) + 0.5
+    dtype = "real"
+    if symbol in INTEGER_OPS:
+        data1 = ops.astype(data1, 'int64')
+        scalar = int(scalar)
+        dtype = 1 + scalar
     expected_data = binary_eval(symbol, data1, scalar)
 
-    x1 = Tensor(data1, inputs)
-    actual = binary_eval(symbol, x1, scalar)
-    check_funsor(actual, inputs, Real, expected_data)
+    x1 = Tensor(data1, inputs, dtype)
+    actual = binary_eval(symbol, x1, Number(scalar, dtype))
+    check_funsor(actual, inputs, Array[dtype, ()], expected_data)
 
 
 @pytest.mark.parametrize('scalar', [0.5])


### PR DESCRIPTION
## Summary
- Improves `Funsor.__repr__()`, `.__str__()` for quick debugging (for detailed structure, see `.pretty()`)
- Adds `ops.mod`, `ops.floordiv`, fixing the `Flatten21` example in test_factory.py
- Adds `ops.lshift`, `ops.rshift` (which Martin and I actually used just yesterday)
- Fixes a missing `find_domain()` computation in `Binary(Op, Number, Tensor)` and `Binary(Op, Tensor, Number)`

## Tested
- [x] un-xfailed the `Flatten21` test
- [x] added new ops to tensor tests