### PR TITLE
Reinstate black-compatible isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,14 @@ docs: FORCE
 lint: FORCE
 	flake8
 	black --check .
+	isort --check .
 
 license: FORCE
 	python scripts/update_headers.py
 
 format: FORCE
 	black .
+	isort .
 
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)

--- a/examples/discrete_hmm.py
+++ b/examples/discrete_hmm.py
@@ -7,8 +7,8 @@ from collections import OrderedDict
 import torch
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 from funsor.terms import lazy

--- a/examples/eeg_slds.py
+++ b/examples/eeg_slds.py
@@ -17,13 +17,13 @@ from os.path import exists
 from urllib.request import urlopen
 
 import numpy as np
+import pyro
 import torch
 import torch.nn as nn
-import pyro
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.pyro.convert import (
     funsor_to_cat_and_mvn,
     funsor_to_mvn,

--- a/examples/kalman_filter.py
+++ b/examples/kalman_filter.py
@@ -6,8 +6,8 @@ import argparse
 import torch
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.interpreter import interpretation, reinterpret
 from funsor.optimizer import apply_optimizer
 from funsor.terms import lazy

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -10,6 +10,8 @@ import uuid
 import pyro
 import pyro.poutine as poutine
 import torch
+from model import Guide, Model
+from seal_data import prepare_fake, prepare_seal
 
 import funsor
 import funsor.ops as ops
@@ -17,8 +19,6 @@ from funsor.interpreter import interpretation
 from funsor.optimizer import apply_optimizer
 from funsor.sum_product import MarkovProduct, naive_sequential_sum_product, sum_product
 from funsor.terms import lazy, to_funsor
-from model import Guide, Model
-from seal_data import prepare_fake, prepare_seal
 
 
 def aic_num_parameters(model, guide=None):

--- a/examples/mixed_hmm/model.py
+++ b/examples/mixed_hmm/model.py
@@ -7,8 +7,8 @@ import pyro
 import torch
 from torch.distributions import constraints
 
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.domains import Bint, Reals
 from funsor.tensor import Tensor
 from funsor.terms import Stack, Variable, to_funsor

--- a/examples/sensor.py
+++ b/examples/sensor.py
@@ -12,8 +12,8 @@ import torch.nn as nn
 from torch.optim import Adam
 
 import funsor
-import funsor.torch.distributions as f_dist
 import funsor.ops as ops
+import funsor.torch.distributions as f_dist
 from funsor.domains import Reals
 from funsor.pyro.convert import dist_to_funsor, funsor_to_mvn
 from funsor.tensor import Tensor, Variable
@@ -241,8 +241,8 @@ def main(args):
         import matplotlib
 
         matplotlib.use("Agg")
-        from matplotlib import pyplot
         import numpy as np
+        from matplotlib import pyplot
 
         seeds = set(seed for seed, _, _ in results)
         X = args.num_frames

--- a/examples/slds.py
+++ b/examples/slds.py
@@ -6,8 +6,8 @@ import argparse
 import torch
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 
 
 def main(args):

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -12,8 +12,8 @@ from torch.nn import functional as F
 from torchvision import datasets, transforms
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.domains import Bint, Reals
 
 REPO_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -3,7 +3,7 @@
 
 from funsor.domains import Array, Bint, Domain, Real, Reals, bint, find_domain, reals
 from funsor.integrate import Integrate
-from funsor.interpreter import reinterpret, interpretation
+from funsor.interpreter import interpretation, reinterpret
 from funsor.sum_product import MarkovProduct
 from funsor.tensor import Tensor, function
 from funsor.terms import (
@@ -41,7 +41,6 @@ from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     terms,
     testing,
 )
-
 
 __all__ = [
     "Array",

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -13,6 +13,7 @@ from funsor.gaussian import Gaussian, align_gaussian
 from funsor.interpreter import interpretation
 from funsor.ops import AssociativeOp
 from funsor.registry import KeyedRegistry
+from funsor.tensor import Tensor
 from funsor.terms import (
     Binary,
     Cat,
@@ -26,7 +27,6 @@ from funsor.terms import (
     substitute,
     to_funsor,
 )
-from funsor.tensor import Tensor
 
 
 def _alpha_unmangle(expr):

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -25,6 +25,7 @@ from funsor.terms import (
     substitute,
     to_funsor,
 )
+
 from . import instrument, interpreter, ops
 
 

--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -8,7 +8,7 @@ import opt_einsum
 
 from funsor.interpreter import gensym
 from funsor.tensor import Einsum, Tensor, get_default_prototype
-from funsor.terms import Binary, Funsor, Lambda, Reduce, Unary, Variable, Bint
+from funsor.terms import Binary, Bint, Funsor, Lambda, Reduce, Unary, Variable
 
 from . import ops
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -43,7 +43,6 @@ from funsor.terms import (
 )
 from funsor.util import broadcast_shape, get_backend, getargspec, lazy_property
 
-
 BACKEND_TO_DISTRIBUTIONS_BACKEND = {
     "torch": "funsor.torch.distributions",
     "jax": "funsor.jax.distributions",

--- a/funsor/einsum/numpy_map.py
+++ b/funsor/einsum/numpy_map.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
-
 from functools import reduce
 
 import funsor.ops as ops

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -7,7 +7,7 @@ from typing import Union
 import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.delta import Delta
-from funsor.gaussian import Gaussian, align_gaussian, _mv, _trace_mm, _vv
+from funsor.gaussian import Gaussian, _mv, _trace_mm, _vv, align_gaussian
 from funsor.tensor import Tensor
 from funsor.terms import (
     Funsor,

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -9,8 +9,8 @@ import funsor.jax.ops  # noqa: F401
 import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
-from funsor.terms import Funsor, to_funsor
 from funsor.tensor import Tensor, tensor_to_funsor
+from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
 
 

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -4,6 +4,8 @@
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 
+import funsor.jax.distributions as _
+import funsor.jax.ops as _
 import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
@@ -11,8 +13,7 @@ from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
 
-from . import distributions as _  # noqa: F401
-from . import ops as _  # noqa: F401
+del _  # flake8
 
 
 @adjoint_ops.register(

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -4,22 +4,23 @@
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 
-import funsor.jax.distributions as _
-import funsor.jax.ops as _
-import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
+from funsor.ops import AssociativeOp
 from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
+
+from . import distributions as _
+from . import ops as _
 
 del _  # flake8
 
 
 @adjoint_ops.register(
     Tensor,
-    ops.AssociativeOp,
-    ops.AssociativeOp,
+    AssociativeOp,
+    AssociativeOp,
     Funsor,
     (DeviceArray, Tracer),
     tuple,

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -4,14 +4,15 @@
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 
-import funsor.jax.distributions  # noqa: F401
-import funsor.jax.ops  # noqa: F401
 import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
 from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
+
+from . import distributions as _  # noqa: F401
+from . import ops as _  # noqa: F401
 
 
 @adjoint_ops.register(

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -6,10 +6,11 @@ from typing import Tuple, Union
 
 import numpyro.distributions as dist
 
+import funsor.ops as ops
 from funsor.cnf import Contraction
 from funsor.distribution import (
-    Bernoulli,
     FUNSOR_DIST_NAMES,
+    Bernoulli,
     LogNormal,
     backenddist_to_funsor,
     eager_beta,
@@ -37,7 +38,6 @@ from funsor.distribution import (
     transformeddist_to_funsor,
 )
 from funsor.domains import Real, Reals
-import funsor.ops as ops
 from funsor.tensor import Tensor
 from funsor.terms import Binary, Funsor, Reduce, Variable, eager, to_data, to_funsor
 from funsor.util import methodof

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -11,7 +11,7 @@ from jax.interpreters.xla import DeviceArray
 from jax.scipy.linalg import cho_solve, solve_triangular
 from jax.scipy.special import expit, gammaln, logsumexp
 
-import funsor.ops as ops
+from .. import ops
 
 ################################################################################
 # Register Ops

--- a/funsor/ops/__init__.py
+++ b/funsor/ops/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from . import array, builtin, op
 from .array import *
 from .builtin import *
 from .op import *

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -181,6 +181,9 @@ PRODUCT_INVERSES[mul] = truediv
 PRODUCT_INVERSES[add] = sub
 
 __all__ = [
+    "AssociativeOp",
+    "GetitemOp",
+    "NullOp",
     "abs",
     "add",
     "and_",

--- a/funsor/pyro/distribution.py
+++ b/funsor/pyro/distribution.py
@@ -4,8 +4,8 @@
 from collections import OrderedDict
 
 import torch
-from torch.distributions import constraints
 from pyro.distributions import TorchDistribution
+from torch.distributions import constraints
 
 from funsor.cnf import Contraction
 from funsor.delta import Delta

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -15,11 +15,12 @@ from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic
 
 import funsor
-import funsor.ops as ops
-from funsor.delta import Delta
-from funsor.domains import Array, ArrayType, Bint, Product, Real, Reals, find_domain
-from funsor.ops import GetitemOp, MatmulOp, Op, ReshapeOp
-from funsor.terms import (
+
+from . import ops
+from .delta import Delta
+from .domains import Array, ArrayType, Bint, Product, Real, Reals, find_domain
+from .ops import GetitemOp, MatmulOp, Op, ReshapeOp
+from .terms import (
     Binary,
     Funsor,
     FunsorMeta,
@@ -34,7 +35,7 @@ from funsor.terms import (
     to_data,
     to_funsor,
 )
-from funsor.util import get_backend, get_tracing_state, getargspec, is_nn_module, quote
+from .util import get_backend, get_tracing_state, getargspec, is_nn_module, quote
 
 
 def get_default_prototype():

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -15,12 +15,12 @@ from weakref import WeakValueDictionary
 from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic, isvariadic
 
-import funsor.interpreter as interpreter
-import funsor.ops as ops
 from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
 from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.util import get_backend, getargspec, lazy_property, pretty, quote
+
+from . import interpreter, ops
 
 
 def substitute(expr, subs):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -17,10 +17,10 @@ from multipledispatch.variadic import Variadic
 import funsor.ops as ops
 from funsor.cnf import Contraction
 from funsor.delta import Delta
-from funsor.domains import Domain, Bint, Real
+from funsor.domains import Bint, Domain, Real
 from funsor.gaussian import Gaussian
-from funsor.terms import Funsor, Number
 from funsor.tensor import Tensor
+from funsor.terms import Funsor, Number
 from funsor.util import get_backend
 
 

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -4,18 +4,19 @@
 import torch
 from multipledispatch import dispatch
 
-import funsor.ops as ops
-import funsor.torch.distributions  # noqa: F401
-import funsor.torch.ops  # noqa: F401
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
+from funsor.ops import AssociativeOp
 from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
 
+from . import distributions as _  # noqa: F401
+from . import ops as _  # noqa: F401
+
 
 @adjoint_ops.register(
-    Tensor, ops.AssociativeOp, ops.AssociativeOp, Funsor, torch.Tensor, tuple, object
+    Tensor, AssociativeOp, AssociativeOp, Funsor, torch.Tensor, tuple, object
 )
 def adjoint_tensor(adj_redop, adj_binop, out_adj, data, inputs, dtype):
     return {}

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -4,6 +4,8 @@
 import torch
 from multipledispatch import dispatch
 
+import funsor.torch.distributions as _
+import funsor.torch.ops as _
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
 from funsor.ops import AssociativeOp
@@ -11,8 +13,7 @@ from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
 
-from . import distributions as _  # noqa: F401
-from . import ops as _  # noqa: F401
+del _  # flake8
 
 
 @adjoint_ops.register(

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -4,13 +4,13 @@
 import torch
 from multipledispatch import dispatch
 
+import funsor.ops as ops
 import funsor.torch.distributions  # noqa: F401
 import funsor.torch.ops  # noqa: F401
-import funsor.ops as ops
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
-from funsor.terms import Funsor, to_funsor
 from funsor.tensor import Tensor, tensor_to_funsor
+from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
 
 

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -4,14 +4,15 @@
 import torch
 from multipledispatch import dispatch
 
-import funsor.torch.distributions as _
-import funsor.torch.ops as _
 from funsor.adjoint import adjoint_ops
 from funsor.interpreter import children, recursion_reinterpret
 from funsor.ops import AssociativeOp
 from funsor.tensor import Tensor, tensor_to_funsor
 from funsor.terms import Funsor, to_funsor
 from funsor.util import quote
+
+from . import distributions as _
+from . import ops as _
 
 del _  # flake8
 

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -178,12 +178,14 @@ def set_backend(backend):
         _FUNSOR_BACKEND = "torch"
 
         import torch  # noqa: F401
+
         import funsor.torch  # noqa: F401
     elif backend == "jax":
         _FUNSOR_BACKEND = "jax"
         _JAX_LOADED = True
 
         import jax  # noqa: F401
+
         import funsor.jax  # noqa: F401
     else:
         raise ValueError(

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import glob
+import os
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 blacklist = ["/build/", "/dist/"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,11 @@ per-file-ignores =
     funsor/jax/distributions.py:F821
     funsor/torch/distributions.py:F821
 
+[isort]
+profile = black
+known_first_party = funsor, test
+known_third_party = opt_einsum, pyro, pyroapi, torch, torchvision
+
 [tool:pytest]
 filterwarnings = error
     ignore:numpy.ufunc size changed:RuntimeWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ filterwarnings = error
     ignore:Mixed memory format:UserWarning
     ignore:Cannot memoize Op:UserWarning
     ignore::DeprecationWarning
+    ignore:CUDA initialization:UserWarning
     once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "test": [
             "black",
             "flake8",
+            "isort>=5.0",
             "pandas",
             "pyro-api>=0.1.2",
             "pytest==4.3.1",
@@ -61,6 +62,7 @@ setup(
         "dev": [
             "black",
             "flake8",
+            "isort>=5.0",
             "pandas",
             "pytest==4.3.1",
             "pytest-xdist==1.27.0",

--- a/test/examples/test_bart.py
+++ b/test/examples/test_bart.py
@@ -7,8 +7,8 @@ import pytest
 import torch
 
 import funsor
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.cnf import Contraction
 from funsor.domains import Bint, Real, Reals
 from funsor.gaussian import Gaussian

--- a/test/examples/test_sensor_fusion.py
+++ b/test/examples/test_sensor_fusion.py
@@ -6,8 +6,8 @@ from collections import OrderedDict
 import pytest
 import torch
 
-import funsor.torch.distributions as dist
 import funsor.ops as ops
+import funsor.torch.distributions as dist
 from funsor.cnf import Contraction
 from funsor.domains import Bint, Reals
 from funsor.gaussian import Gaussian

--- a/test/test_affine.py
+++ b/test/test_affine.py
@@ -8,6 +8,7 @@ import pytest
 from funsor.affine import extract_affine, is_affine
 from funsor.cnf import Contraction
 from funsor.domains import Bint, Real, Reals  # noqa: F401
+from funsor.tensor import Einsum, Tensor
 from funsor.terms import Number, Unary, Variable
 from funsor.testing import (
     assert_close,
@@ -17,7 +18,6 @@ from funsor.testing import (
     random_gaussian,
     random_tensor,
 )
-from funsor.tensor import Einsum, Tensor
 
 assert ones  # flake8
 assert random_gaussian  # flake8

--- a/test/test_cnf.py
+++ b/test/test_cnf.py
@@ -9,12 +9,11 @@ import pytest
 
 from funsor import ops
 from funsor.cnf import (
-    Contraction,
     BACKEND_TO_EINSUM_BACKEND,
     BACKEND_TO_LOGSUMEXP_BACKEND,
+    Contraction,
 )
-from funsor.domains import Bint, Bint  # noqa F403
-from funsor.domains import Reals
+from funsor.domains import Bint, Reals  # noqa F403
 from funsor.einsum import einsum, naive_plated_einsum
 from funsor.interpreter import interpretation, reinterpret
 from funsor.tensor import Tensor

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -6,7 +6,7 @@ import pickle
 
 import pytest
 
-from funsor.domains import Bint, Real, Reals, Bint, Reals  # noqa F401
+from funsor.domains import Bint, Real, Reals  # noqa F401
 
 
 @pytest.mark.parametrize(

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -22,8 +22,8 @@ from funsor.testing import (
     randn,
     random_gaussian,
     random_tensor,
-    zeros,
     xfail_if_not_implemented,
+    zeros,
 )
 from funsor.util import get_backend
 

--- a/test/test_memoize.py
+++ b/test/test_memoize.py
@@ -14,7 +14,6 @@ from funsor.terms import reflect
 from funsor.testing import make_einsum_example, xfail_param
 from funsor.util import get_backend
 
-
 EINSUM_EXAMPLES = [
     ("a,b->", ""),
     ("ab,a->", ""),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,8 +6,8 @@ import weakref
 import pytest
 
 from funsor.distribution import BACKEND_TO_DISTRIBUTIONS_BACKEND
-from funsor.util import get_backend
 from funsor.ops import WrappedTransformOp
+from funsor.util import get_backend
 
 
 @pytest.fixture

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -33,9 +33,9 @@ pytestmark = pytest.mark.skipif(
 )
 if get_backend() == "torch":
     import torch
-    from funsor.torch.distributions import Categorical
-
     from pyro.ops.contract import einsum as pyro_einsum
+
+    from funsor.torch.distributions import Categorical
 
 OPTIMIZED_EINSUM_EXAMPLES = [make_chain_einsum(t) for t in range(2, 50, 10)] + [
     make_hmm_einsum(t) for t in range(2, 50, 10)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import re
 import os
+import re
 from collections import OrderedDict
 from functools import partial, reduce
 
@@ -15,12 +15,12 @@ from funsor.optimizer import apply_optimizer
 from funsor.sum_product import (
     MarkovProduct,
     _partition,
-    partial_unroll,
     mixed_sequential_sum_product,
+    modified_partial_sum_product,
     naive_sarkka_bilmes_product,
     naive_sequential_sum_product,
     partial_sum_product,
-    modified_partial_sum_product,
+    partial_unroll,
     sarkka_bilmes_product,
     sequential_sum_product,
     sum_product,

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -13,7 +13,7 @@ import pytest
 
 import funsor
 import funsor.ops as ops
-from funsor.domains import Array, Bint, Real, Product, Reals, find_domain
+from funsor.domains import Array, Bint, Product, Real, Reals, find_domain
 from funsor.interpreter import interpretation
 from funsor.tensor import (
     REDUCE_OP_TO_NUMERIC,


### PR DESCRIPTION
- Adds `isort .` to `make format`
- Adds `isort --check .` to `make lint`
- Adds isort section to setup.cfg
- Adds `isort>=5.0` to requirements
- Works around https://github.com/pytorch/pytorch/issues/47038