### PR TITLE
Move instrumentation into funsor.instrument module

### DIFF
--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -5,14 +5,13 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
-import funsor.interpreter as interpreter
-import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture, nullop
 from funsor.domains import Bint
 from funsor.gaussian import Gaussian, align_gaussian
 from funsor.interpreter import interpretation
 from funsor.ops import AssociativeOp
 from funsor.registry import KeyedRegistry
+from funsor.tensor import Tensor
 from funsor.terms import (
     Binary,
     Cat,
@@ -26,7 +25,8 @@ from funsor.terms import (
     substitute,
     to_funsor,
 )
-from funsor.tensor import Tensor
+
+from . import instrument, interpreter, ops
 
 
 def _alpha_unmangle(expr):
@@ -106,10 +106,10 @@ def _fail_default(*args):
 
 
 adjoint_ops = KeyedRegistry(default=_fail_default)
-if interpreter._DEBUG:
+if instrument.DEBUG:
     adjoint_ops_register = adjoint_ops.register
     adjoint_ops.register = lambda *args: lambda fn: adjoint_ops_register(*args)(
-        interpreter.debug_logged(fn)
+        instrument.debug_logged(fn)
     )
 
 

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -3,7 +3,6 @@
 
 from collections import OrderedDict
 
-import funsor.ops as ops
 from funsor.domains import Domain, Real
 from funsor.interpreter import debug_logged
 from funsor.ops import AddOp, SubOp, TransformOp
@@ -21,6 +20,8 @@ from funsor.terms import (
     eager,
     to_funsor,
 )
+
+from . import ops
 
 
 def solve(expr, value):

--- a/funsor/factory.py
+++ b/funsor/factory.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 import makefun
 
-from funsor.interpreter import debug_logged
+from funsor.instrument import debug_logged
 from funsor.terms import Funsor, FunsorMeta, Variable, eager, to_funsor
 
 

--- a/funsor/instrument.py
+++ b/funsor/instrument.py
@@ -84,6 +84,7 @@ else:
 
 
 # Allow line_profiler to override profile_timed by adding it to __builtins__.
+# For details see https://github.com/pyutils/line_profiler
 profile = __builtins__.get("profile", debug_logged)
 
 

--- a/funsor/instrument.py
+++ b/funsor/instrument.py
@@ -1,0 +1,117 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import atexit
+import functools
+import inspect
+import os
+from collections import Counter, defaultdict
+from timeit import default_timer
+
+DEBUG = int(os.environ.get("FUNSOR_DEBUG", 0))
+PROFILE = int(os.environ.get("FUNSOR_PROFILE", 0))
+
+STACK_SIZE = 0
+
+
+def get_indent():
+    result = "    \u2502" * (STACK_SIZE // 4 + 3)
+    return result[:STACK_SIZE]
+
+
+if DEBUG:
+
+    class DebugLogged(object):
+        def __init__(self, fn):
+            self.fn = fn
+            while isinstance(fn, functools.partial):
+                fn = fn.func
+            path = inspect.getabsfile(fn)
+            lineno = inspect.getsourcelines(fn)[1]
+            self._message = "{} file://{} {}".format(fn.__name__, path, lineno)
+
+        def __call__(self, *args, **kwargs):
+            global STACK_SIZE
+            print(get_indent() + self._message)
+            STACK_SIZE += 1
+            try:
+                return self.fn(*args, **kwargs)
+            finally:
+                STACK_SIZE -= 1
+
+        @property
+        def register(self):
+            return self.fn.register
+
+    def debug_logged(fn):
+        if isinstance(fn, DebugLogged):
+            return fn
+        return DebugLogged(fn)
+
+
+elif PROFILE:
+
+    class ProfileLogged(object):
+        def __init__(self, fn):
+            self.fn = fn
+            while isinstance(fn, functools.partial):
+                fn = fn.func
+            path = inspect.getabsfile(fn).split("/funsor/")[-1]
+            lineno = inspect.getsourcelines(fn)[1]
+            self._message = "{} {} {}".format(fn.__name__, path, lineno)
+
+        def __call__(self, *args, **kwargs):
+            start = default_timer()
+            result = self.fn(*args, **kwargs)
+            COUNTERS["time"][self._message] += default_timer() - start
+            COUNTERS["call"][self._message] += 1
+            return result
+
+        @property
+        def register(self):
+            return self.fn.register
+
+    def debug_logged(fn):
+        if isinstance(fn, ProfileLogged):
+            return fn
+        return ProfileLogged(fn)
+
+
+else:
+
+    def debug_logged(fn):
+        return fn
+
+
+# Allow line_profiler to override profile_timed by adding it to __builtins__.
+profile = __builtins__.get("profile", debug_logged)
+
+
+COUNTERS = defaultdict(Counter)
+if PROFILE:
+    COUNTERS["time"]["total"] -= default_timer()
+
+    @atexit.register
+    def print_counters():
+        COUNTERS["time"]["total"] += default_timer()
+        for name, counter in sorted(COUNTERS.items()):
+            if "total" not in counter and len(counter) > 1:
+                counter["total"] = sum(counter.values())
+            print("-" * 80)
+            print(f"     count {name}")
+            for key, value in counter.most_common(PROFILE):
+                if isinstance(value, float):
+                    print(f"{value: >10f} {key}")
+                else:
+                    print(f"{value: >10} {key}")
+        print("-" * 80)
+
+
+__all__ = [
+    "DEBUG",
+    "PROFILE",
+    "STACK_SIZE",
+    "debug_logged",
+    "get_indent",
+    "profile",
+]

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -1,13 +1,11 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import atexit
 import functools
-import inspect
 import os
 import re
 import types
-from collections import Counter, OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
 from functools import singledispatch
 from timeit import default_timer
@@ -15,108 +13,19 @@ from timeit import default_timer
 import numpy as np
 
 from funsor.domains import ArrayType
+from funsor.instrument import debug_logged
 from funsor.ops import Op, is_numeric_array
 from funsor.registry import KeyedRegistry
 from funsor.util import is_nn_module
 
+from . import instrument
+
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-_DEBUG = int(os.environ.get("FUNSOR_DEBUG", 0))
-_PROFILE = int(os.environ.get("FUNSOR_PROFILE", 0))
-_STACK_SIZE = 0
 
 _INTERPRETATION = None  # To be set later in funsor.terms
 _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
 
 _GENSYM_COUNTER = 0
-
-
-def _indent():
-    result = "    \u2502" * (_STACK_SIZE // 4 + 3)
-    return result[:_STACK_SIZE]
-
-
-if _DEBUG:
-
-    class DebugLogged(object):
-        def __init__(self, fn):
-            self.fn = fn
-            while isinstance(fn, functools.partial):
-                fn = fn.func
-            path = inspect.getabsfile(fn)
-            lineno = inspect.getsourcelines(fn)[1]
-            self._message = "{} file://{} {}".format(fn.__name__, path, lineno)
-
-        def __call__(self, *args, **kwargs):
-            global _STACK_SIZE
-            print(_indent() + self._message)
-            _STACK_SIZE += 1
-            try:
-                return self.fn(*args, **kwargs)
-            finally:
-                _STACK_SIZE -= 1
-
-        @property
-        def register(self):
-            return self.fn.register
-
-    def debug_logged(fn):
-        if isinstance(fn, DebugLogged):
-            return fn
-        return DebugLogged(fn)
-
-
-elif _PROFILE:
-
-    class ProfileLogged(object):
-        def __init__(self, fn):
-            self.fn = fn
-            while isinstance(fn, functools.partial):
-                fn = fn.func
-            path = inspect.getabsfile(fn).split("/funsor/")[-1]
-            lineno = inspect.getsourcelines(fn)[1]
-            self._message = "{} {} {}".format(fn.__name__, path, lineno)
-
-        def __call__(self, *args, **kwargs):
-            start = default_timer()
-            result = self.fn(*args, **kwargs)
-            COUNTERS["time"][self._message] += default_timer() - start
-            COUNTERS["call"][self._message] += 1
-            return result
-
-        @property
-        def register(self):
-            return self.fn.register
-
-    def debug_logged(fn):
-        if isinstance(fn, ProfileLogged):
-            return fn
-        return ProfileLogged(fn)
-
-
-else:
-
-    def debug_logged(fn):
-        return fn
-
-
-COUNTERS = defaultdict(Counter)
-if _PROFILE:
-    COUNTERS["time"]["total"] -= default_timer()
-
-    @atexit.register
-    def print_counters():
-        COUNTERS["time"]["total"] += default_timer()
-        for name, counter in sorted(COUNTERS.items()):
-            if "total" not in counter and len(counter) > 1:
-                counter["total"] = sum(counter.values())
-            print("-" * 80)
-            print(f"     count {name}")
-            for key, value in counter.most_common(_PROFILE):
-                if isinstance(value, float):
-                    print(f"{value: >10f} {key}")
-                else:
-                    print(f"{value: >10} {key}")
-        print("-" * 80)
 
 
 def _classname(cls):
@@ -130,21 +39,20 @@ class Interpreter:
 
 
 def debug_interpret(cls, *args):
-    global _STACK_SIZE
-    indent = _indent()
-    if _DEBUG > 1:
+    indent = instrument.get_indent()
+    if instrument.DEBUG > 1:
         typenames = [_classname(cls)] + [_classname(type(arg)) for arg in args]
     else:
         typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
     print(indent + " ".join(typenames))
 
-    _STACK_SIZE += 1
+    instrument.STACK_SIZE += 1
     try:
         result = _INTERPRETATION(cls, *args)
     finally:
-        _STACK_SIZE -= 1
+        instrument.STACK_SIZE -= 1
 
-    if _DEBUG > 1:
+    if instrument.DEBUG > 1:
         result_str = re.sub("\n", "\n          " + indent, str(result))
     else:
         result_str = type(result).__name__
@@ -152,7 +60,7 @@ def debug_interpret(cls, *args):
     return result
 
 
-interpret = debug_interpret if _DEBUG else Interpreter()
+interpret = debug_interpret if instrument.DEBUG else Interpreter()
 
 
 def set_interpretation(new):
@@ -383,14 +291,15 @@ def dispatched_interpretation(fn):
     """
     registry = KeyedRegistry(default=lambda *args: None)
 
-    if _DEBUG or _PROFILE:
+    if instrument.DEBUG or instrument.PROFILE:
         fn.register = lambda *args: lambda fn: registry.register(*args)(
             debug_logged(fn)
         )
     else:
         fn.register = registry.register
 
-    if _PROFILE:
+    if instrument.PROFILE:
+        COUNTERS = instrument.COUNTERS
 
         def profiled_dispatch(*args):
             name = fn.__name__ + ".dispatch"
@@ -438,7 +347,7 @@ class StatefulInterpretation(metaclass=StatefulInterpretationMeta):
     def __call__(self, cls, *args):
         return self.dispatch(cls, *args)(self, *args)
 
-    if _DEBUG:
+    if instrument.DEBUG:
 
         @classmethod
         def register(cls, *args):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -38,29 +38,32 @@ class Interpreter:
         return _INTERPRETATION
 
 
-def debug_interpret(cls, *args):
-    indent = instrument.get_indent()
-    if instrument.DEBUG > 1:
-        typenames = [_classname(cls)] + [_classname(type(arg)) for arg in args]
-    else:
-        typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
-    print(indent + " ".join(typenames))
+if instrument.DEBUG:
 
-    instrument.STACK_SIZE += 1
-    try:
-        result = _INTERPRETATION(cls, *args)
-    finally:
-        instrument.STACK_SIZE -= 1
+    def interpret(cls, *args):
+        indent = instrument.get_indent()
+        if instrument.DEBUG > 1:
+            typenames = [_classname(cls)] + [_classname(type(arg)) for arg in args]
+        else:
+            typenames = [cls.__name__] + [type(arg).__name__ for arg in args]
+        print(indent + " ".join(typenames))
 
-    if instrument.DEBUG > 1:
-        result_str = re.sub("\n", "\n          " + indent, str(result))
-    else:
-        result_str = type(result).__name__
-    print(indent + "-> " + result_str)
-    return result
+        instrument.STACK_SIZE += 1
+        try:
+            result = _INTERPRETATION(cls, *args)
+        finally:
+            instrument.STACK_SIZE -= 1
+
+        if instrument.DEBUG > 1:
+            result_str = re.sub("\n", "\n          " + indent, str(result))
+        else:
+            result_str = type(result).__name__
+        print(indent + "-> " + result_str)
+        return result
 
 
-interpret = debug_interpret if instrument.DEBUG else Interpreter()
+else:
+    interpret = Interpreter()
 
 
 def set_interpretation(new):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -15,12 +15,12 @@ from weakref import WeakValueDictionary
 from multipledispatch import dispatch
 from multipledispatch.variadic import Variadic, isvariadic
 
-import funsor.interpreter as interpreter
-import funsor.ops as ops
 from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
 from funsor.interpreter import PatternMissingError, dispatched_interpretation, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.util import get_backend, getargspec, lazy_property, pretty, quote
+
+from . import instrument, interpreter, ops
 
 
 def substitute(expr, subs):
@@ -34,9 +34,9 @@ def substitute(expr, subs):
         expr = cls(*args)
         fresh_subs = tuple((k, v) for k, v in subs if k in expr.fresh)
         if fresh_subs:
-            expr = interpreter.debug_logged(expr.eager_subs)(fresh_subs)
-        if interpreter._PROFILE:
-            interpreter.COUNTERS["interpretation"]["substitute"] += 1
+            expr = instrument.debug_logged(expr.eager_subs)(fresh_subs)
+        if instrument.PROFILE:
+            instrument.COUNTERS["interpretation"]["substitute"] += 1
         return expr
 
     with interpreter.interpretation(subs_interpreter):
@@ -57,7 +57,7 @@ def _alpha_mangle(expr):
     if not alpha_subs:
         return expr
 
-    ast_values = interpreter.debug_logged(expr._alpha_convert)(alpha_subs)
+    ast_values = instrument.debug_logged(expr._alpha_convert)(alpha_subs)
     return reflect(type(expr), *ast_values)
 
 
@@ -104,13 +104,13 @@ def reflect(cls, *args, **kwargs):
     result = super(FunsorMeta, cls_specific).__call__(*args)
     result._ast_values = args
 
-    if interpreter._PROFILE:
+    if instrument.PROFILE:
         size, depth, width = _get_ast_stats(result)
-        interpreter.COUNTERS["ast_size"][size] += 1
-        interpreter.COUNTERS["ast_depth"][depth] += 1
+        instrument.COUNTERS["ast_size"][size] += 1
+        instrument.COUNTERS["ast_depth"][depth] += 1
         classname = getattr(cls, "__origin__", cls).__name__
-        interpreter.COUNTERS["funsor"][classname] += 1
-        interpreter.COUNTERS[classname][width] += 1
+        instrument.COUNTERS["funsor"][classname] += 1
+        instrument.COUNTERS[classname][width] += 1
 
     # alpha-convert eagerly upon binding any variable
     result = _alpha_mangle(result)
@@ -570,7 +570,7 @@ class Funsor(object, metaclass=FunsorMeta):
         if sampled_vars.isdisjoint(self.inputs):
             return self
 
-        result = interpreter.debug_logged(self.unscaled_sample)(
+        result = instrument.debug_logged(self.unscaled_sample)(
             sampled_vars, sample_inputs, rng_key
         )
         if sample_inputs is not None:
@@ -1084,14 +1084,14 @@ class Unary(Funsor):
 
 @eager.register(Unary, Op, Funsor)
 def eager_unary(op, arg):
-    return interpreter.debug_logged(arg.eager_unary)(op)
+    return instrument.debug_logged(arg.eager_unary)(op)
 
 
 @eager.register(Unary, AssociativeOp, Funsor)
 def eager_unary(op, arg):
     if not arg.output.shape:
         return arg
-    return interpreter.debug_logged(arg.eager_unary)(op)
+    return instrument.debug_logged(arg.eager_unary)(op)
 
 
 _INFIX = {
@@ -1230,7 +1230,7 @@ def eager_reduce(op, arg, reduced_vars):
     arg, reduced_vars = _reduce_unrelated_vars(op, arg, reduced_vars)
     if reduced_vars is None:
         return arg
-    return interpreter.debug_logged(arg.eager_reduce)(op, reduced_vars)
+    return instrument.debug_logged(arg.eager_reduce)(op, reduced_vars)
 
 
 @sequential.register(Reduce, AssociativeOp, Funsor, frozenset)
@@ -1238,7 +1238,7 @@ def sequential_reduce(op, arg, reduced_vars):
     arg, reduced_vars = _reduce_unrelated_vars(op, arg, reduced_vars)
     if reduced_vars is None:
         return arg
-    return interpreter.debug_logged(arg.sequential_reduce)(op, reduced_vars)
+    return instrument.debug_logged(arg.sequential_reduce)(op, reduced_vars)
 
 
 @moment_matching.register(Reduce, AssociativeOp, Funsor, frozenset)
@@ -1246,7 +1246,7 @@ def moment_matching_reduce(op, arg, reduced_vars):
     arg, reduced_vars = _reduce_unrelated_vars(op, arg, reduced_vars)
     if reduced_vars is None:
         return arg
-    return interpreter.debug_logged(arg.moment_matching_reduce)(op, reduced_vars)
+    return instrument.debug_logged(arg.moment_matching_reduce)(op, reduced_vars)
 
 
 class NumberMeta(FunsorMeta):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ filterwarnings = error
     ignore:Mixed memory format:UserWarning
     ignore:Cannot memoize Op:UserWarning
     ignore::DeprecationWarning
+    ignore:CUDA initialization:UserWarning
     once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL


### PR DESCRIPTION
This moves a bunch of instrumentation from `funsor.interpretations` to `funsor.instrument`, separating concerns.