### PR TITLE
Add license check to make targets lint and format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ lint: FORCE
 	flake8
 	black --check .
 	isort --check .
+	python scripts/update_headers.py --check
 
 license: FORCE
 	python scripts/update_headers.py
 
-format: FORCE
+format: license FORCE
 	black .
 	isort .
 

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -1,8 +1,10 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import glob
 import os
+import sys
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 blacklist = ["/build/", "/dist/"]
@@ -10,6 +12,11 @@ file_types = [
     ("*.py", "# {}"),
     ("*.cpp", "// {}"),
 ]
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--check", action="store_true")
+args = parser.parse_args()
+dirty = []
 
 for basename, comment in file_types:
     copyright_line = comment.format("Copyright Contributors to the Pyro project.\n")
@@ -55,7 +62,16 @@ for basename, comment in file_types:
         if not changed:
             continue
 
+        if args.check:
+            dirty.append(filename)
+            continue
+
         with open(filename, "w") as f:
             f.write("".join(lines))
 
         print("updated {}".format(filename[len(root) + 1 :]))
+
+if dirty:
+    print("The following files need license headers:\n{}".format("\n".join(dirty)))
+    print("Please run 'make license'")
+    sys.exit(1)


### PR DESCRIPTION
Changes to `update_headers.py` are ported from [pyro/scripts/update_headers.py](https://github.com/pyro-ppl/pyro/blob/dev/scripts/update_headers.py).