### PR TITLE
Slightly refactor logic in joint in prep for Approximate

### DIFF
--- a/funsor/joint.py
+++ b/funsor/joint.py
@@ -98,76 +98,65 @@ def moment_matching_contract_default(*args):
     Contraction, ops.LogaddexpOp, ops.AddOp, frozenset, (Number, Tensor), Gaussian
 )
 def moment_matching_contract_joint(red_op, bin_op, reduced_vars, discrete, gaussian):
-
     approx_vars = frozenset(
-        v for v in reduced_vars if v.name in gaussian.inputs if v.dtype != "real"
+        v for v in reduced_vars & gaussian.input_vars if v.dtype != "real"
     )
+    if not approx_vars:
+        return None
+
     exact_vars = reduced_vars - approx_vars
+    if exact_vars:
+        exact = Contraction(red_op, bin_op, exact_vars, discrete, gaussian)
+        return exact.reduce(red_op, approx_vars)
 
-    if exact_vars and approx_vars:
-        return Contraction(red_op, bin_op, exact_vars, discrete, gaussian).reduce(
-            red_op, approx_vars
-        )
+    discrete += gaussian.log_normalizer
+    new_discrete = discrete.reduce(ops.logaddexp, approx_vars & discrete.input_vars)
+    num_elements = reduce(
+        ops.mul,
+        [v.output.num_elements for v in approx_vars - discrete.input_vars],
+        1,
+    )
+    if num_elements != 1:
+        new_discrete -= math.log(num_elements)
 
-    if approx_vars and not exact_vars:
-        discrete += gaussian.log_normalizer
-        new_discrete = discrete.reduce(ops.logaddexp, approx_vars & discrete.input_vars)
-        new_discrete = discrete.reduce(ops.logaddexp, approx_vars & discrete.input_vars)
-        num_elements = reduce(
-            ops.mul,
-            [
-                gaussian.inputs[v.name].num_elements
-                for v in approx_vars - discrete.input_vars
-            ],
-            1,
-        )
-        if num_elements != 1:
-            new_discrete -= math.log(num_elements)
+    int_inputs = OrderedDict(
+        (k, d) for k, d in gaussian.inputs.items() if d.dtype != "real"
+    )
+    probs = (discrete - new_discrete.clamp_finite()).exp()
 
-        int_inputs = OrderedDict(
-            (k, d) for k, d in gaussian.inputs.items() if d.dtype != "real"
-        )
-        probs = (discrete - new_discrete.clamp_finite()).exp()
+    old_loc = Tensor(
+        ops.cholesky_solve(
+            ops.unsqueeze(gaussian.info_vec, -1), gaussian._precision_chol
+        ).squeeze(-1),
+        int_inputs,
+    )
+    new_loc = (probs * old_loc).reduce(ops.add, approx_vars)
+    old_cov = Tensor(ops.cholesky_inverse(gaussian._precision_chol), int_inputs)
+    diff = old_loc - new_loc
+    outers = Tensor(
+        ops.unsqueeze(diff.data, -1) * ops.unsqueeze(diff.data, -2), diff.inputs
+    )
+    new_cov = (probs * old_cov).reduce(ops.add, approx_vars) + (probs * outers).reduce(
+        ops.add, approx_vars
+    )
 
-        old_loc = Tensor(
-            ops.cholesky_solve(
-                ops.unsqueeze(gaussian.info_vec, -1), gaussian._precision_chol
-            ).squeeze(-1),
-            int_inputs,
-        )
-        new_loc = (probs * old_loc).reduce(ops.add, approx_vars)
-        old_cov = Tensor(ops.cholesky_inverse(gaussian._precision_chol), int_inputs)
-        diff = old_loc - new_loc
-        outers = Tensor(
-            ops.unsqueeze(diff.data, -1) * ops.unsqueeze(diff.data, -2), diff.inputs
-        )
-        new_cov = (probs * old_cov).reduce(ops.add, approx_vars) + (
-            probs * outers
-        ).reduce(ops.add, approx_vars)
+    # Numerically stabilize by adding bogus precision to empty components.
+    total = probs.reduce(ops.add, approx_vars)
+    mask = ops.unsqueeze(ops.unsqueeze((total.data == 0), -1), -1)
+    new_cov.data = new_cov.data + mask * ops.new_eye(
+        new_cov.data, new_cov.data.shape[-1:]
+    )
 
-        # Numerically stabilize by adding bogus precision to empty components.
-        total = probs.reduce(ops.add, approx_vars)
-        mask = ops.unsqueeze(ops.unsqueeze((total.data == 0), -1), -1)
-        new_cov.data = new_cov.data + mask * ops.new_eye(
-            new_cov.data, new_cov.data.shape[-1:]
-        )
+    new_precision = Tensor(
+        ops.cholesky_inverse(ops.cholesky(new_cov.data)), new_cov.inputs
+    )
+    new_info_vec = (new_precision.data @ ops.unsqueeze(new_loc.data, -1)).squeeze(-1)
+    new_inputs = new_loc.inputs.copy()
+    new_inputs.update((k, d) for k, d in gaussian.inputs.items() if d.dtype == "real")
+    new_gaussian = Gaussian(new_info_vec, new_precision.data, new_inputs)
+    new_discrete -= new_gaussian.log_normalizer
 
-        new_precision = Tensor(
-            ops.cholesky_inverse(ops.cholesky(new_cov.data)), new_cov.inputs
-        )
-        new_info_vec = (new_precision.data @ ops.unsqueeze(new_loc.data, -1)).squeeze(
-            -1
-        )
-        new_inputs = new_loc.inputs.copy()
-        new_inputs.update(
-            (k, d) for k, d in gaussian.inputs.items() if d.dtype == "real"
-        )
-        new_gaussian = Gaussian(new_info_vec, new_precision.data, new_inputs)
-        new_discrete -= new_gaussian.log_normalizer
-
-        return new_discrete + new_gaussian
-
-    return None
+    return new_discrete + new_gaussian
 
 
 ####################################################


### PR DESCRIPTION
This slightly simplifies the logic in a moment-matching pattern, in preparation for behavior changes in #457:

- exit early to simplify dispatch
- replace `.inputs` logic with `.input_vars` logic
- delete a blatantly duplicated line introduced in the sprawling #157

## Tested
- [x] refactoring is covered by existing tests