### PR TITLE
Switch to testing with Pyro master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ jobs:
           python: 3.6
           script:
               - pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-              # Keep track of Pyro dev branch
-              - pip install https://github.com/pyro-ppl/pyro/archive/dev.zip
+              # Keep track of Pyro master branch
+              - pip install https://github.com/pyro-ppl/pyro/archive/master.zip
               - pip install -e .[torch]
               - FUNSOR_BACKEND=torch make test
         - name: jax


### PR DESCRIPTION
This will be required while Pyro dev branch tracks PyTorch 1.8 nightly https://github.com/pyro-ppl/pyro/pull/2753