### PR TITLE
Implement Scatter funsor

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -277,12 +277,13 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
-    "torch": ("http://pytorch.org/docs/master/", None),
-    "pyro": ("http://docs.pyro.ai/en/stable/", None),
-    "opt_einsum": ("https://optimized-einsum.readthedocs.io/en/stable/", None),
+    "jax": ("https://jax.readthedocs.io/en/latest/", None),
     "multipledispatch": ("https://multiple-dispatch.readthedocs.io/en/latest/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "opt_einsum": ("https://optimized-einsum.readthedocs.io/en/stable/", None),
+    "pyro": ("http://docs.pyro.ai/en/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "torch": ("http://pytorch.org/docs/master/", None),
 }
 
 # @jpchen's hack to get rtd builder to install latest pytorch

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -8,6 +8,7 @@ import numpy as onp
 from jax import lax
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
+from jax.ops import index_update
 from jax.scipy.linalg import cho_solve, solve_triangular
 from jax.scipy.special import expit, gammaln, logsumexp
 
@@ -225,6 +226,11 @@ def _safesub(x, y):
     except ValueError:
         finfo = np.iinfo(y.dtype)
     return x + np.clip(-y, a_min=None, a_max=finfo.max)
+
+
+@ops.scatter.register(array, tuple, array)
+def _scatter(dest, indices, src):
+    return index_update(dest, indices, src)
 
 
 @ops.stack.register(int, [array + (int, float)])

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -81,7 +81,7 @@ class Op(Dispatcher):
         super(Op, self).__init__(name)
         if fn is not None:
             # register as default operation
-            for nargs in (1, 2):
+            for nargs in (1, 2, 3):
                 default_signature = (object,) * nargs
                 self.add(default_signature, fn)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -26,6 +26,7 @@ from .terms import (
     FunsorMeta,
     Lambda,
     Number,
+    Scatter,
     Slice,
     Tuple,
     Unary,
@@ -621,6 +622,64 @@ def tensor_to_data(x, name_to_dim=None):
         for dim, size in zip(dims, data.shape):
             batch_shape[dim] = size
         return data.reshape(tuple(batch_shape) + x.output.shape)
+
+
+@eager.register(Scatter, Op, tuple, Number)
+def eager_scatter_number(op, subs, source):
+    # case: injective renaming
+    if all(isinstance(v, Variable) for k, v in subs):
+        if len({v.name for k, v in subs}) == len(subs):
+            return source
+
+    source = Tensor(numeric_array(source.data), dtype=source.dtype)
+    return eager_scatter_tensor(op, subs, source)
+
+
+@eager.register(Scatter, Op, tuple, Tensor, frozenset)
+def eager_scatter_tensor(op, subs, source, reduced_vars):
+    if not all(isinstance(v, (Variable, Number, Slice, Tensor)) for k, v in subs):
+        return None
+
+    # Compute shapes.
+    reduced_names = frozenset(v.name for v in reduced_vars)
+    destin_inputs = OrderedDict()
+    tensor_inputs = OrderedDict()
+    for key, value in subs:
+        for k, d in value.inputs.items():
+            # These are "batch" inputs and should be left of subs keys.
+            if k not in reduced_names:
+                destin_inputs[k] = d
+            tensor_inputs[k] = d
+    for k, d in source.inputs.items():
+        # These are "batch" inputs and should be left of subs keys.
+        if k not in reduced_names:
+            destin_inputs[k] = d
+        tensor_inputs[k] = d
+    for key, value in subs:
+        # These are "event" inputs and should be right of "batch" inputs.
+        destin_inputs[key] = value.output
+
+    # Construct aligned backend tensors.
+    tensors = []
+    for k, d in tensor_inputs.items():
+        if k not in reduced_names:
+            tensors.append(Variable(k, d))  # effectively a slice
+    for key, value in subs:
+        tensors.append(value)
+    tensors = [source.materialize(x) for x in tensors]
+    tensors.append(source)
+    tensors = [align_tensor(tensor_inputs, x, expand=True) for x in tensors]
+    indices = tuple(tensors[:-1])
+    source_data = tensors[-1]
+
+    # Construct a destination backend tensor.
+    output = source.output
+    shape = tuple(d.size for d in destin_inputs.values()) + output.shape
+    destin = ops.new_full(source.data, shape, ops.UNITS[op])
+
+    # TODO Add a check for injectivity and dispatch to scatter_add etc.
+    data = ops.scatter(destin, indices, source_data)
+    return Tensor(data, destin_inputs, output.dtype)
 
 
 @eager.register(Binary, Op, Tensor, Number)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1074,6 +1074,84 @@ def die_reduce(op, arg, reduced_vars):
     raise NotImplementedError(f"Missing pattern for {repr(expr)}")
 
 
+class Scatter(Funsor):
+    """
+    Transpose of structurally linear :class:`Subs`, followed by
+    :class:`Reduce`.
+
+    For injective scatter operations this should satisfy the equation::
+
+        if destin = Scatter(op, subs, source, frozenset())
+        then source = Subs(destin, subs)
+
+    .. warning:: This is currently implemented only for injective scatter
+        operations. In particular, this does not allow accumulation behavior
+        like scatter-add.
+
+    .. note:: ``Scatter(ops.add, ...)`` is the funsor analog of
+        ``numpy.add.at()`` or :func:`torch.index_put` or
+        :func:`jax.lax.scatter_add`. For injective substitutions,
+        ``Scatter(ops.add, ...)`` is roughly equivalent to the tensor
+        operation::
+
+            result = zeros(...)  # since zero is the additive unit
+            result[subs] = source
+
+    :param AssociativeOp op: An op. The unit of this op will be used as
+        default value.
+    :param tuple subs: A substitution.
+    :param Funsor source: A source for data to be scattered from.
+    :param frozenset reduced_vars: A set of variables over which to reduce.
+    """
+
+    def __init__(self, op, subs, source, reduced_vars):
+        assert isinstance(op, AssociativeOp)
+        assert isinstance(subs, tuple)
+        assert len(subs) == len(set(key for key, value in subs))
+        assert isinstance(source, Funsor)
+        assert isinstance(reduced_vars, frozenset)
+        assert all(isinstance(v, Variable) for v in reduced_vars)
+        reduced_names = frozenset(v.name for v in reduced_vars)
+
+        # First compute inputs of the pure-scatter op with no reduction.
+        inputs = OrderedDict()
+        for key, value in subs:
+            assert isinstance(key, str)
+            assert isinstance(value, Funsor)
+            assert key not in source.inputs
+            assert key not in reduced_names
+            for k, d in value.inputs.items():
+                # These are "batch" inputs and should be left of subs keys.
+                d2 = inputs.setdefault(k, d)
+                assert d2 == d
+        for k, d in source.inputs.items():
+            # These are "batch" inputs and should be left of subs keys.
+            d2 = inputs.setdefault(k, d)
+            assert d2 == d
+        for key, value in subs:
+            assert key not in inputs
+            # These are "event" inputs and should be right of "batch" inputs.
+            inputs[key] = value.output
+
+        # Then narrow these down to the fused scatter-reduce op.
+        inputs = OrderedDict(
+            (k, d) for k, d in inputs.items() if k not in reduced_names
+        )
+        fresh = frozenset(key for key, value in subs)
+        bound = {v.name: v.output for v in reduced_vars}
+        super().__init__(inputs, source.output, fresh, bound)
+        self.op = op
+        self.subs = subs
+        self.source = source
+        self.reduced_vars = reduced_vars
+
+    def _alpha_convert(self, alpha_subs):
+        alpha_subs = {k: to_funsor(v, self.bound[k]) for k, v in alpha_subs.items()}
+        op, subs, source, reduced_vars = super()._alpha_convert(alpha_subs)
+        reduced_vars = frozenset(alpha_subs.get(var.name, var) for var in reduced_vars)
+        return op, subs, source, reduced_vars
+
+
 class NumberMeta(FunsorMeta):
     """
     Wrapper to fill in default ``dtype``.
@@ -1779,6 +1857,7 @@ __all__ = [
     "Lambda",
     "Number",
     "Reduce",
+    "Scatter",
     "Stack",
     "Slice",
     "Subs",

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -454,3 +454,12 @@ def make_hmm_einsum(num_steps):
         inputs.append(str(opt_einsum.get_symbol(t + 1)))
     equation = ",".join(inputs) + "->"
     return equation
+
+
+def iter_subsets(iterable, *, min_size=None, max_size=None):
+    if min_size is None:
+        min_size = 0
+    if max_size is None:
+        max_size = len(iterable)
+    for size in range(min_size, max_size + 1):
+        yield from itertools.combinations(iterable, size)

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -183,6 +183,11 @@ def _new_zeros(x, shape):
     return x.new_zeros(shape)
 
 
+@ops.new_full.register(torch.Tensor, tuple, numbers.Number)
+def _new_full(x, shape, value):
+    return x.new_full(shape, value)
+
+
 @ops.permute.register(torch.Tensor, (tuple, list))
 def _permute(x, dims):
     return x.permute(dims)
@@ -228,6 +233,19 @@ def _safesub(x, y):
     except TypeError:
         finfo = torch.iinfo(y.dtype)
     return x + (-y).clamp(max=finfo.max)
+
+
+@ops.scatter.register(torch.Tensor, tuple, torch.Tensor)
+def _scatter(destin, indices, source):
+    result = destin.clone()
+    result[indices] = source
+    return result
+
+
+@ops.scatter_add.register(torch.Tensor, tuple, torch.Tensor)
+def _scatter_add(destin, indices, source):
+    result = destin.clone()
+    return result.index_put(indices, source, accumulate=True)
 
 
 @ops.stack.register(int, [torch.Tensor])

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ per-file-ignores =
     funsor/ops/__init__.py:F401,F403
     funsor/jax/distributions.py:F821
     funsor/torch/distributions.py:F821
+    test/conftest.py:E402
 
 [isort]
 profile = black

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,9 @@
 import os
 
 import numpy as np
+import pytest
+
+pytest.register_assert_rewrite("funsor.testing")  # noqa: E402
 
 import funsor.util
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -6,6 +6,7 @@ import io
 import itertools
 import pickle
 from collections import OrderedDict
+from functools import reduce
 from typing import get_type_hints
 
 import numpy as np
@@ -14,6 +15,7 @@ import pytest
 import funsor
 import funsor.ops as ops
 from funsor.domains import Array, Bint, Product, Real, Reals, find_domain
+from funsor.interpretations import eager, lazy
 from funsor.tensor import (
     REDUCE_OP_TO_NUMERIC,
     Einsum,
@@ -23,12 +25,13 @@ from funsor.tensor import (
     stack,
     tensordot,
 )
-from funsor.terms import Cat, Lambda, Number, Slice, Stack, Variable, lazy
+from funsor.terms import Cat, Lambda, Number, Scatter, Slice, Stack, Variable
 from funsor.testing import (
     assert_close,
     assert_equiv,
     check_funsor,
     empty,
+    iter_subsets,
     rand,
     randn,
     random_tensor,
@@ -1226,3 +1229,219 @@ def test_diagonal_rename():
 
 def test_empty_tensor_possible():
     funsor.to_funsor(randn(3, 0), dim_to_name=OrderedDict([(-1, "a"), (-2, "b")]))
+
+
+@pytest.mark.parametrize("op", [ops.add, ops.mul, ops.max, ops.min])
+def test_scatter_number(op):
+    source = random_tensor(OrderedDict(k=Bint[5]))
+    actual = Scatter(op, (("i", Number(0, 3)),), source, frozenset())
+
+    proto = source.data.reshape((-1,))[:1].reshape(())
+    zero = ops.full_like(ops.expand(proto, (5, 2)), ops.UNITS[op])
+    expected_data = ops.cat(1, source.data.reshape((5, 1)), zero)
+    expected = Tensor(expected_data, OrderedDict(k=Bint[5], i=Bint[3]))
+
+    assert_close(actual, expected)
+    assert_close(actual(i=0), source)  # Scatter is transpose to Subs
+
+
+def test_scatter_2d():
+    # Consider n=5 nonzero entries in a 3x4 image.
+    i = Tensor(numeric_array([0, 0, 1, 2, 2]), dtype=3)["n"]
+    j = Tensor(numeric_array([0, 1, 0, 2, 3]), dtype=4)["n"]
+    source = Tensor(numeric_array([1.0, 2.0, 3.0, 4.0, 5.0]))["n"]
+    reduced_vars = frozenset({Variable("n", Bint[5])})
+    actual = Scatter(ops.add, (("i", i), ("j", j)), source, reduced_vars)
+    expected = Tensor(
+        numeric_array(
+            [
+                [1.0, 2.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 4.0, 5.0],
+            ]
+        )
+    )["i", "j"]
+
+    assert_close(actual, expected)
+
+
+def test_scatter_3():
+    # b is a batch variable
+    # n,m are reduced variables, and
+    # i is a destin variable
+    source = Tensor(
+        numeric_array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [1.5, 2.5, 3.5], [4.5, 5.5, 6.5]]
+        )
+    )["b", "n"]
+    i = Tensor(numeric_array([[0, 1], [3, 4], [5, 6]]), dtype=7)["n", "m"]
+    reduced_vars = frozenset({Variable("n", Bint[3]), Variable("m", Bint[2])})
+    actual = Scatter(ops.add, (("i", i),), source, reduced_vars)
+    expected = Tensor(
+        numeric_array(
+            [
+                [1.0, 4.0, 1.5, 4.5],
+                [1.0, 4.0, 1.5, 4.5],
+                [0.0, 0.0, 0.0, 0.0],
+                [2.0, 5.0, 2.5, 5.5],
+                [2.0, 5.0, 2.5, 5.5],
+                [3.0, 6.0, 3.5, 6.5],
+                [3.0, 6.0, 3.5, 6.5],
+            ]
+        ).T
+    )["b", "i"]
+    assert_close(actual, expected)
+
+
+@pytest.mark.xfail(reason="non-injective")
+def test_scatter_4():
+    source = Number(1.0)
+    i = Tensor(numeric_array([0, 0]), dtype=1)["n"]
+    reduced_vars = frozenset({Variable("n", Bint[2])})
+    # By extensionality, i should be equivalent to:
+    #   i = Number(0, dtype=1)
+    # however that would lead to actual = Tensor([1.0])["i"].
+    actual = Scatter(ops.add, (("i", i),), source, reduced_vars)
+    expected = Tensor(numeric_array([2.0]))["i"]
+    assert_close(actual, expected)
+
+
+def test_scatter_diag_embed():
+    source = random_tensor(OrderedDict(k=Bint[3]))
+    k = Variable("k", Bint[3])
+    actual = Scatter(ops.add, (("i", k), ("j", k)), source, frozenset({k}))
+    assert set(actual.inputs) == {"i", "j"}
+
+    expected_data = numeric_array(
+        [
+            [float(source.data[0]), 0, 0],
+            [0, float(source.data[1]), 0],
+            [0, 0, float(source.data[2])],
+        ]
+    )
+    expected = Tensor(expected_data)["i", "j"]
+    assert_close(actual, expected)
+
+
+def _scatter_i_examples():
+    result = []
+    for source_inputs in ["", "a", "ab", "abc"]:
+        sets = ["".join(s) for s in iter_subsets(source_inputs)]
+        for i_inputs, reduced_vars in itertools.product(sets, sets):
+            result.append((source_inputs, i_inputs, reduced_vars))
+    return result
+
+
+@pytest.mark.parametrize("source_inputs, i_inputs, reduced_vars", _scatter_i_examples())
+@pytest.mark.parametrize("output_shape", [(), (5,)], ids=str)
+def test_scatter_i(source_inputs, i_inputs, output_shape, reduced_vars):
+    inputs = OrderedDict(a=Bint[2], b=Bint[3], c=Bint[4])
+    reduced_names = set(reduced_vars)
+    reduced_vars = frozenset(Variable(k, inputs[k]) for k in reduced_vars)
+
+    source_inputs = OrderedDict((k, v) for k, v in inputs.items() if k in source_inputs)
+    source = random_tensor(source_inputs, Reals[output_shape])
+
+    # Sample an injective set of indices.
+    i_inputs = OrderedDict((k, v) for k, v in inputs.items() if k in i_inputs)
+    i_shape = tuple(v.size for v in i_inputs.values())
+    i_numel = reduce(ops.mul, i_shape, 1)
+    i_size = i_numel * 2  # give a little headroom
+    i_data = np.random.permutation(i_size)[:i_numel]
+    i_data = numeric_array(i_data.reshape(i_shape))
+    i = Tensor(i_data, i_inputs, dtype=i_size)
+    subs = (("i", i),)
+
+    for interp in [lazy, eager]:
+        with interp:
+            destin = Scatter(ops.add, subs, source, reduced_vars)
+
+        # Check shape.
+        assert destin.inputs.get("i") == Bint[i_size]
+        for k, v in source_inputs.items():
+            if k in reduced_names:
+                assert k not in destin.inputs
+            else:
+                assert destin.inputs.get(k) == v
+        assert destin.output == source.output
+
+    if reduced_vars <= i.input_vars:
+        # Check that Scatter is a pseudoinverse of Subs.
+        source2 = destin(**dict(subs))
+        assert source2.input_vars == source.input_vars
+        assert ((source2 - source).abs() < 1e-6).data.all()
+
+        # Check total.
+        actual = destin.reduce(ops.add, destin.input_vars - source.input_vars)
+        expected = source.reduce(ops.add, source.input_vars - destin.input_vars)
+        assert expected.input_vars <= actual.input_vars
+        assert ((actual - expected).abs() < 1e-6).data.all()
+
+
+def _scatter_ji_examples():
+    result = []
+    for source_inputs in ["", "a", "ab", "abc"]:
+        sets = ["".join(s) for s in iter_subsets(source_inputs)]
+        for i_inputs, j_inputs, reduced_vars in itertools.product(sets, sets, sets):
+            result.append((source_inputs, i_inputs, j_inputs, reduced_vars))
+    return result
+
+
+@pytest.mark.parametrize(
+    "source_inputs, i_inputs, j_inputs, reduced_vars",
+    _scatter_ji_examples(),
+)
+@pytest.mark.parametrize("output_shape", [()], ids=str)
+def test_scatter_ji(source_inputs, i_inputs, j_inputs, output_shape, reduced_vars):
+    inputs = OrderedDict(a=Bint[2], b=Bint[3], c=Bint[4])
+    reduced_names = set(reduced_vars)
+    reduced_vars = frozenset(Variable(k, inputs[k]) for k in reduced_vars)
+
+    source_inputs = OrderedDict((k, v) for k, v in inputs.items() if k in source_inputs)
+    source = random_tensor(source_inputs, Reals[output_shape])
+
+    # Sample an injective set of indices.
+    i_inputs = OrderedDict((k, v) for k, v in inputs.items() if k in i_inputs)
+    i_shape = tuple(v.size for v in i_inputs.values())
+    i_numel = reduce(ops.mul, i_shape, 1)
+    i_size = i_numel * 2  # give a little headroom
+    i_data = np.random.permutation(i_size)[:i_numel]
+    i_data = numeric_array(i_data.reshape(i_shape))
+    i = Tensor(i_data, i_inputs, dtype=i_size)
+
+    # Sample another injective set of indices.
+    j_inputs = OrderedDict((k, v) for k, v in inputs.items() if k in j_inputs)
+    j_shape = tuple(v.size for v in j_inputs.values())
+    j_numel = reduce(ops.mul, j_shape, 1)
+    j_size = j_numel * 2  # give a little headroom
+    j_data = np.random.permutation(j_size)[:j_numel]
+    j_data = numeric_array(j_data.reshape(j_shape))
+    j = Tensor(j_data, j_inputs, dtype=j_size)
+
+    subs = (("i", i), ("j", j))
+
+    for interp in [lazy, eager]:
+        with interp:
+            destin = Scatter(ops.add, subs, source, reduced_vars)
+
+        # Check shape.
+        assert destin.inputs.get("i") == Bint[i_size]
+        assert destin.inputs.get("j") == Bint[j_size]
+        for k, v in source_inputs.items():
+            if k in reduced_names:
+                assert k not in destin.inputs
+            else:
+                assert destin.inputs.get(k) == v
+        assert destin.output == source.output
+
+    if reduced_vars <= i.input_vars | j.input_vars:
+        # Check that Scatter is a pseudoinverse of Subs.
+        source2 = destin(**dict(subs))
+        source2 = source2.align(tuple(source.inputs))
+        assert_close(source2, source)
+
+        # Check total.
+        actual = destin.reduce(ops.add, destin.input_vars - source.input_vars)
+        expected = source.reduce(ops.add, source.input_vars - destin.input_vars)
+        assert set(expected.inputs).issubset(actual.inputs)
+        assert (ops.abs(actual - expected) < 1e-6).data.all()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1375,7 +1375,7 @@ def test_scatter_i(source_inputs, i_inputs, output_shape, reduced_vars):
         actual = destin.reduce(ops.add, destin.input_vars - source.input_vars)
         expected = source.reduce(ops.add, source.input_vars - destin.input_vars)
         assert expected.input_vars <= actual.input_vars
-        assert ((actual - expected).abs() < 1e-6).data.all()
+        assert ((actual - expected).abs() < 1e-5).data.all()
 
 
 def _scatter_ji_examples():
@@ -1444,4 +1444,4 @@ def test_scatter_ji(source_inputs, i_inputs, j_inputs, output_shape, reduced_var
         actual = destin.reduce(ops.add, destin.input_vars - source.input_vars)
         expected = source.reduce(ops.add, source.input_vars - destin.input_vars)
         assert set(expected.inputs).issubset(actual.inputs)
-        assert (ops.abs(actual - expected) < 1e-6).data.all()
+        assert ((actual - expected).abs() < 1e-4).data.all()


### PR DESCRIPTION
Addresses #446 
Blocking #445
pair coded with @eb8680 

This implements a scatter-reduce funsor `Scatter` that fuses a transpose-`Subs` operation with a `Reduce` operation. This new `Scatter` is roughly a funsor analog of `torch.scatter_add`, but generalized to arbitrary associative ops and to more flexible (and named) indexing.

## Tested
- [x] unit tests of `Scatter(ops.add, ..., Tensor(...), ...)`