### PR TITLE
Temporarily disable VAE example smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifeq (${FUNSOR_BACKEND}, torch)
 	python examples/minipyro.py --jit
 	python examples/slds.py -n 2 -t 50
 	python examples/pcfg.py --size 3
-	python examples/vae.py --smoke-test
+	# python examples/vae.py --smoke-test
 	python examples/eeg_slds.py --num-steps 2 --fon --test
 	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
 	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke


### PR DESCRIPTION
Open PRs are currently blocked by `examples/vae.py` failing to download MNIST with `torchvision`, described upstream here: https://github.com/pytorch/vision/issues/3497

This PR temporarily disables the VAE example until we move to a `torchvision` release that includes the fix in https://github.com/pytorch/vision/issues/3497