### PR TITLE
Add requirements to make rtd builds pass

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,8 @@
+makefun
 multipledispatch
+nbsphinx
 numpy>=1.7
 opt_einsum>=2.3.2
 pytest>=4.1
-makefun
+sphinx-gallery
 typing_extensions


### PR DESCRIPTION
Currently, [rtd is failing](https://readthedocs.org/projects/funsor/builds/) due to the missing of those requirements.