### PR TITLE
Update uses of obsolete interpretation()

### DIFF
--- a/examples/eeg_slds.py
+++ b/examples/eeg_slds.py
@@ -7,7 +7,7 @@ Example: Switching Linear Dynamical System EEG
 
 We use a switching linear dynamical system [1] to model a EEG time series dataset.
 For inference we use a moment-matching approximation enabled by
-`funsor.interpretation(funsor.terms.moment_matching)`.
+`funsor.interpretations.moment_matching`.
 
 References
 
@@ -158,7 +158,7 @@ class SLDS(nn.Module):
         return trans_logits, trans_probs, trans_mvn, obs_mvn, x_trans_dist, y_dist
 
     # compute the marginal log probability of the observed data using a moment-matching approximation
-    @funsor.interpretation(funsor.terms.moment_matching)
+    @funsor.interpretations.moment_matching
     def log_prob(self, data):
         (
             trans_logits,
@@ -176,10 +176,8 @@ class SLDS(nn.Module):
 
         for t, y in enumerate(data):
             # construct free variables for s_t and x_t
-            s_vars[t] = funsor.Variable(
-                "s_{}".format(t), funsor.Bint[self.num_components]
-            )
-            x_vars[t] = funsor.Variable("x_{}".format(t), funsor.Reals[self.hidden_dim])
+            s_vars[t] = funsor.Variable(f"s_{t}", funsor.Bint[self.num_components])
+            x_vars[t] = funsor.Variable(f"x_{t}", funsor.Reals[self.hidden_dim])
 
             # incorporate the discrete switching dynamics
             log_prob += dist.Categorical(trans_probs(s=s_vars[t - 1]), value=s_vars[t])
@@ -229,7 +227,7 @@ class SLDS(nn.Module):
     # here we implicitly use a moment matching lag of L = 1. the general logic follows
     # the logic in the log_prob method.
     @torch.no_grad()
-    @funsor.interpretation(funsor.terms.moment_matching)
+    @funsor.interpretations.moment_matching
     def filter_and_predict(self, data, smoothing=False):
         (
             trans_logits,
@@ -249,10 +247,8 @@ class SLDS(nn.Module):
         test_LLs = []
 
         for t, y in enumerate(data):
-            s_vars[t] = funsor.Variable(
-                "s_{}".format(t), funsor.Bint[self.num_components]
-            )
-            x_vars[t] = funsor.Variable("x_{}".format(t), funsor.Reals[self.hidden_dim])
+            s_vars[t] = funsor.Variable(f"s_{t}", funsor.Bint[self.num_components])
+            x_vars[t] = funsor.Variable(f"x_{t}", funsor.Reals[self.hidden_dim])
 
             log_prob += dist.Categorical(trans_probs(s=s_vars[t - 1]), value=s_vars[t])
 
@@ -275,7 +271,7 @@ class SLDS(nn.Module):
                     predictive_y_dist(y=y).reduce(ops.logaddexp).data.item()
                 )
                 predictive_y_dist = predictive_y_dist.reduce(
-                    ops.logaddexp, frozenset(["x_{}".format(t), "s_{}".format(t)])
+                    ops.logaddexp, {f"x_{t}", f"s_{t}"}
                 )
                 predictive_y_dists.append(funsor_to_mvn(predictive_y_dist, 0, ()))
 
@@ -292,11 +288,11 @@ class SLDS(nn.Module):
             T = data.size(0)
 
             s_vars = {
-                t: funsor.Variable("s_{}".format(t), funsor.Bint[self.num_components])
+                t: funsor.Variable(f"s_{t}", funsor.Bint[self.num_components])
                 for t in range(T)
             }
             x_vars = {
-                t: funsor.Variable("x_{}".format(t), funsor.Reals[self.hidden_dim])
+                t: funsor.Variable(f"x_{t}", funsor.Reals[self.hidden_dim])
                 for t in range(T)
             }
 
@@ -329,7 +325,7 @@ class SLDS(nn.Module):
         if smoothing:
             # compute smoothed mean function
             smoothing_dists = [
-                funsor_to_cat_and_mvn(d, 0, ("s_{}".format(t),))
+                funsor_to_cat_and_mvn(d, 0, (f"s_{t}",))
                 for t, d in enumerate(reversed(smoothing_dists))
             ]
             means = torch.stack([d[1].mean for d in smoothing_dists])  # T 2 xdim
@@ -363,9 +359,9 @@ def main(args):
         download_data()
         N_val, N_test = 149, 200
         data = np.loadtxt("eeg.dat", delimiter=",", skiprows=19)
-        print("[raw data shape] {}".format(data.shape))
+        print(f"[raw data shape] {data.shape}")
         data = data[::20, :]
-        print("[data shape after thinning] {}".format(data.shape))
+        print(f"[data shape after thinning] {data.shape}")
         eye_state = [int(d) for d in data[:, -1].tolist()]
         data = torch.tensor(data[:, :-1]).float()
     # in test mode (for continuous integration on github) so create fake data
@@ -386,8 +382,8 @@ def main(args):
     data_std = data[0:N_train, :].std(0)
     data /= data_std
 
-    print("Length of time series T: {}   Observation dimension: {}".format(T, obs_dim))
-    print("N_train: {}  N_val: {}  N_test: {}".format(N_train, N_val, N_test))
+    print(f"Length of time series T: {T}   Observation dimension: {obs_dim}")
+    print(f"N_train: {N_train}  N_val: {N_val}  N_test: {N_test}")
 
     torch.manual_seed(args.seed)
 
@@ -493,7 +489,7 @@ def main(args):
                 pred_means[-N_valtest:, which] + 1.645 * pred_stds[-N_valtest:, which],
                 color="lightblue",
             )
-            ax.set_ylabel("$y_{%d}$" % (which + 1), fontsize=20)
+            ax.set_ylabel(f"$y_{which + 1}$", fontsize=20)
             ax.tick_params(axis="both", which="major", labelsize=14)
 
         axes[-1].plot(to_seconds * np.arange(T), eye_state, "k", ls="solid")

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -15,7 +15,6 @@ from pyroapi import infer, optim, pyro, pyro_backend
 from torch.distributions import constraints
 
 import funsor
-from funsor.interpreter import interpretation
 from funsor.montecarlo import MonteCarlo
 
 
@@ -44,7 +43,7 @@ def main(args):
 
     # Because the API in minipyro matches that of Pyro proper,
     # training code works with generic Pyro implementations.
-    with pyro_backend(args.backend), interpretation(MonteCarlo()):
+    with pyro_backend(args.backend), MonteCarlo():
         # Construct an SVI object so we can do variational inference on our
         # model/guide pair.
         Elbo = infer.JitTrace_ELBO if args.jit else infer.Trace_ELBO
@@ -57,14 +56,14 @@ def main(args):
         for step in range(args.num_steps):
             loss = svi.step(data)
             if args.verbose and step % 100 == 0:
-                print("step {} loss = {}".format(step, loss))
+                print(f"step {step} loss = {loss}")
 
         # Report the final values of the variational parameters
         # in the guide after training.
         if args.verbose:
             for name in pyro.get_param_store():
                 value = pyro.param(name).data
-                print("{} = {}".format(name, value.detach().cpu().numpy()))
+                print(f"{name} = {value.detach().cpu().numpy()}")
 
         # For this simple (conjugate) model we know the exact posterior. In
         # particular we know that the variational distribution should be

--- a/examples/slds.py
+++ b/examples/slds.py
@@ -33,7 +33,7 @@ def main(args):
     params = [trans_probs.data, trans_noise.data, emit_noise.data]
 
     # A Gaussian HMM model.
-    @funsor.interpretation(funsor.terms.moment_matching)
+    @funsor.interpretations.moment_matching
     def model(data):
         log_prob = funsor.Number(0.0)
 
@@ -47,11 +47,11 @@ def main(args):
             x_prev = x_curr
 
             # A delayed sample statement.
-            s_curr = funsor.Variable("s_{}".format(t), funsor.Bint[2])
+            s_curr = funsor.Variable(f"s_{t}", funsor.Bint[2])
             log_prob += dist.Categorical(trans_probs[s_prev], value=s_curr)
 
             # A delayed sample statement.
-            x_curr = funsor.Variable("x_{}".format(t), funsor.Real)
+            x_curr = funsor.Variable(f"x_{t}", funsor.Real)
             log_prob += dist.Normal(x_prev, trans_noise[s_curr], value=x_curr)
 
             # Marginalize out previous delayed sample statements.
@@ -76,7 +76,7 @@ def main(args):
         loss.backward()
         optim.step()
         if args.verbose and step % 10 == 0:
-            print("step {} loss = {}".format(step, loss.item()))
+            print(f"step {step} loss = {loss.item()}")
 
 
 if __name__ == "__main__":

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -70,7 +70,7 @@ def main(args):
     encode = funsor.function(Reals[28, 28], (Reals[20], Reals[20]))(encoder)
     decode = funsor.function(Reals[20], Reals[28, 28])(decoder)
 
-    @funsor.interpretation(funsor.montecarlo.MonteCarlo())
+    @funsor.montecarlo.MonteCarlo()
     def loss_function(data, subsample_scale):
         # Lazily sample from the guide.
         loc, scale = encode(data)
@@ -114,10 +114,10 @@ def main(args):
             train_loss += loss.item()
             optimizer.step()
             if batch_idx % 50 == 0:
-                print("  loss = {}".format(loss.item()))
+                print(f"  loss = {loss.item()}")
                 if batch_idx and args.smoke_test:
                     return
-        print("epoch {} train_loss = {}".format(epoch, train_loss))
+        print(f"epoch {epoch} train_loss = {train_loss}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Replaces `@interpretation(foo)` with `@foo` in a few examples
- Converts a few examples to use f-strings (now that we're using Python 3.6+ again)