### PR TITLE
Fix make_funsor factory and add a FUNSOR_TYPECHECK interpreter

### DIFF
--- a/funsor/factory.py
+++ b/funsor/factory.py
@@ -218,7 +218,6 @@ def make_funsor(fn):
         dependent_args = _get_dependent_args(self._ast_fields, hints, args)
         output = output_type(**dependent_args)
         inputs = OrderedDict()
-        fresh = set()
         bound = {}
         for hint, arg, arg_name in zip(hints, args, self._ast_fields):
             if hint is Funsor:
@@ -239,9 +238,10 @@ def make_funsor(fn):
                 bound[arg.name] = inputs.pop(arg.name)
         for hint, arg in zip(hints, args):
             if isinstance(hint, Fresh):
-                fresh.add(arg.name)
-                inputs[arg.name] = arg.output
-        fresh = frozenset(fresh)
+                for k, d in arg.inputs.items():
+                    if k not in bound:
+                        inputs[k] = d
+        fresh = frozenset()
         Funsor.__init__(self, inputs, output, fresh, bound)
         for name, arg in zip(self._ast_fields, args):
             setattr(self, name, arg)

--- a/funsor/interpretations.py
+++ b/funsor/interpretations.py
@@ -351,6 +351,7 @@ A moment matching interpretation of :class:`Reduce` expressions. This falls
 back to :class:`eager` in other cases.
 """
 
+push_interpretation(reflect)  # Set for optional type checking.
 push_interpretation(eager)  # Use eager interpretation by default.
 
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -20,6 +20,7 @@ from . import instrument
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _USE_TCO = int(os.environ.get("FUNSOR_USE_TCO", 0))
+_TYPECHECK = int(os.environ.get("FUNSOR_TYPECHECK", 0))
 _STACK = []  # To be populated later in funsor.terms
 _GENSYM_COUNTER = 0
 
@@ -73,6 +74,16 @@ if instrument.DEBUG:
             result_str = type(result).__name__
         print(indent + "-> " + result_str)
         return result
+
+
+elif _TYPECHECK:
+
+    def interpret(cls, *args):
+        reflect = _STACK[0]
+        interpretation = _STACK[-1]
+        if interpretation is not reflect:
+            reflect.interpret(cls, *args)  # for checking only
+        return interpretation.interpret(cls, *args)
 
 
 else:

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -55,7 +55,7 @@ def test_flatten():
         i: Bound,
         j: Bound,
         ij: Fresh[lambda i, j: Bint[i.size * j.size]],
-    ) -> Fresh[lambda x: x.dtype]:
+    ) -> Fresh[lambda x: x]:
         m = to_funsor(i, x.inputs.get(i, None)).output.size
         n = to_funsor(j, x.inputs.get(j, None)).output.size
         ij = to_funsor(ij, Bint[m * n])
@@ -138,9 +138,10 @@ def test_cat2():
     inputs["b"] = Bint[4]
     x = random_tensor(inputs, Real)
     y = random_tensor(inputs, Real)
-    xy = Cat2(x, y, "a", "a", "aa")
+    y = y(a="c")  # to avoid bound variable clash
+    xy = Cat2(x, y, "a", "c", "ac")
 
-    check_funsor(xy, {"aa": Bint[6], "b": Bint[4]}, Real)
+    check_funsor(xy, {"ac": Bint[6], "b": Bint[4]}, Real)
 
 
 def test_normal():


### PR DESCRIPTION
pair coded with @eb8680 @ordabayevy @fehiepsi 

Note currently `FUNSOR_TYPECHECK` is enabled as an environment variable. To use in a jupyter notebook, try:
```py
%env FUNSOR_TYPECHECK=1
import funsor  # only after setting environment variable
```