### PR TITLE
Clean up examples and tests after black

### DIFF
--- a/examples/eeg_slds.py
+++ b/examples/eeg_slds.py
@@ -193,12 +193,10 @@ class SLDS(nn.Module):
             if t > self.moment_matching_lag - 1:
                 log_prob = log_prob.reduce(
                     ops.logaddexp,
-                    frozenset(
-                        [
-                            s_vars[t - self.moment_matching_lag].name,
-                            x_vars[t - self.moment_matching_lag].name,
-                        ]
-                    ),
+                    {
+                        s_vars[t - self.moment_matching_lag],
+                        x_vars[t - self.moment_matching_lag],
+                    },
                 )
 
             # incorporate the observation p(y_t | x_t, s_t)
@@ -209,12 +207,10 @@ class SLDS(nn.Module):
         for t in range(self.moment_matching_lag):
             log_prob = log_prob.reduce(
                 ops.logaddexp,
-                frozenset(
-                    [
-                        s_vars[T - self.moment_matching_lag + t].name,
-                        x_vars[T - self.moment_matching_lag + t].name,
-                    ]
-                ),
+                {
+                    s_vars[T - self.moment_matching_lag + t],
+                    x_vars[T - self.moment_matching_lag + t],
+                },
             )
 
         # assert that we've reduced all the free variables in log_prob
@@ -259,7 +255,7 @@ class SLDS(nn.Module):
 
             if t > 0:
                 log_prob = log_prob.reduce(
-                    ops.logaddexp, frozenset([s_vars[t - 1].name, x_vars[t - 1].name])
+                    ops.logaddexp, {s_vars[t - 1], x_vars[t - 1]}
                 )
 
             # do 1-step prediction and compute test LL
@@ -311,7 +307,7 @@ class SLDS(nn.Module):
                 )
                 integral += x_trans_dist(s=s_vars[t], x=x_vars[t], y=x_vars[t + 1])
                 integral = integral.reduce(
-                    ops.logaddexp, frozenset([s_vars[t + 1].name, x_vars[t + 1].name])
+                    ops.logaddexp, {s_vars[t + 1], x_vars[t + 1]}
                 )
                 smoothing_dists.append(filtering_dists[t] + integral)
 

--- a/examples/forward_backward.py
+++ b/examples/forward_backward.py
@@ -93,7 +93,7 @@ def forward_backward_algorithm(
         # alpha[t-1] * trans[t] = p(y[0:t], x[t-1], x[t])
         alpha_trans = alpha(**{"x_curr": "x_prev"}) + trans
         # alpha[t] = p(y[0:t], x[t])
-        alpha = alpha_trans.reduce(ops.logaddexp, frozenset({"x_prev"}))
+        alpha = alpha_trans.reduce(ops.logaddexp, "x_prev")
         # alpha[t-1] * trans[t] * beta[t] / Z = p(x[t-1], x[t] | Y)
         marginal = alpha_trans + beta(**{"x_prev": "x_curr"}) - Z
         marginals.append(marginal)
@@ -137,12 +137,7 @@ def main(args):
     for t in range(args.time_steps - 1):
         factors.append(
             random_tensor(
-                OrderedDict(
-                    [
-                        ("x_prev", Bint[args.hidden_dim]),
-                        ("x_curr", Bint[args.hidden_dim]),
-                    ]
-                )
+                OrderedDict(x_prev=Bint[args.hidden_dim], x_curr=Bint[args.hidden_dim])
             )
         )
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -129,15 +129,7 @@ def test_indexing():
 
 def test_advanced_indexing_shape():
     I, J, M, N = 4, 4, 2, 3
-    x = Tensor(
-        randn((I, J)),
-        OrderedDict(
-            [
-                ("i", Bint[I]),
-                ("j", Bint[J]),
-            ]
-        ),
-    )
+    x = Tensor(randn((I, J)), OrderedDict(i=Bint[I], j=Bint[J]))
     m = Tensor(numeric_array([2, 3]), OrderedDict([("m", Bint[M])]), I)
     n = Tensor(numeric_array([0, 1, 1]), OrderedDict([("n", Bint[N])]), J)
     assert x.data.shape == (I, J)
@@ -233,55 +225,16 @@ def test_advanced_indexing_tensor(output_shape):
     #      \ | /
     #        x
     output = Reals[output_shape]
-    x = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-                ("j", Bint[3]),
-                ("k", Bint[4]),
-            ]
-        ),
-        output,
-    )
-    i = random_tensor(
-        OrderedDict(
-            [
-                ("u", Bint[5]),
-            ]
-        ),
-        Bint[2],
-    )
-    j = random_tensor(
-        OrderedDict(
-            [
-                ("v", Bint[6]),
-                ("u", Bint[5]),
-            ]
-        ),
-        Bint[3],
-    )
-    k = random_tensor(
-        OrderedDict(
-            [
-                ("v", Bint[6]),
-            ]
-        ),
-        Bint[4],
-    )
+    x = random_tensor(OrderedDict(i=Bint[2], j=Bint[3], k=Bint[4]), output)
+    i = random_tensor(OrderedDict(u=Bint[5]), Bint[2])
+    j = random_tensor(OrderedDict(v=Bint[6], u=Bint[5]), Bint[3])
+    k = random_tensor(OrderedDict(v=Bint[6]), Bint[4])
 
     expected_data = empty((5, 6) + output_shape)
     for u in range(5):
         for v in range(6):
             expected_data[u, v] = x.data[i.data[u], j.data[v, u], k.data[v]]
-    expected = Tensor(
-        expected_data,
-        OrderedDict(
-            [
-                ("u", Bint[5]),
-                ("v", Bint[6]),
-            ]
-        ),
-    )
+    expected = Tensor(expected_data, OrderedDict(u=Bint[5], v=Bint[6]))
 
     assert_equiv(expected, x(i, j, k))
     assert_equiv(expected, x(i=i, j=j, k=k))
@@ -306,13 +259,7 @@ def test_advanced_indexing_tensor(output_shape):
 def test_advanced_indexing_lazy(output_shape):
     x = Tensor(
         randn((2, 3, 4) + output_shape),
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-                ("j", Bint[3]),
-                ("k", Bint[4]),
-            ]
-        ),
+        OrderedDict(i=Bint[2], j=Bint[3], k=Bint[4]),
     )
     u = Variable("u", Bint[2])
     v = Variable("v", Bint[3])
@@ -328,15 +275,7 @@ def test_advanced_indexing_lazy(output_shape):
     for u in range(2):
         for v in range(3):
             expected_data[u, v] = x.data[i_data[u], j_data[v], k_data[u, v]]
-    expected = Tensor(
-        expected_data,
-        OrderedDict(
-            [
-                ("u", Bint[2]),
-                ("v", Bint[3]),
-            ]
-        ),
-    )
+    expected = Tensor(expected_data, OrderedDict(u=Bint[2], v=Bint[3]))
 
     assert_equiv(expected, x(i, j, k))
     assert_equiv(expected, x(i=i, j=j, k=k))
@@ -909,16 +848,7 @@ def test_function_of_numeric_array():
 
 
 def test_align():
-    x = Tensor(
-        randn((2, 3, 4)),
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-                ("j", Bint[3]),
-                ("k", Bint[4]),
-            ]
-        ),
-    )
+    x = Tensor(randn((2, 3, 4)), OrderedDict(i=Bint[2], j=Bint[3], k=Bint[4]))
     y = x.align(("j", "k", "i"))
     assert isinstance(y, Tensor)
     assert tuple(y.inputs) == ("j", "k", "i")
@@ -1030,41 +960,13 @@ def test_tensor_stack(n, shape, dim):
 
 @pytest.mark.parametrize("output", [Bint[2], Real, Reals[4], Reals[2, 3]], ids=str)
 def test_funsor_stack(output):
-    x = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-            ]
-        ),
-        output,
-    )
-    y = random_tensor(
-        OrderedDict(
-            [
-                ("j", Bint[3]),
-            ]
-        ),
-        output,
-    )
-    z = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-                ("k", Bint[4]),
-            ]
-        ),
-        output,
-    )
+    x = random_tensor(OrderedDict(i=Bint[2]), output)
+    y = random_tensor(OrderedDict(j=Bint[3]), output)
+    z = random_tensor(OrderedDict(i=Bint[2], k=Bint[4]), output)
 
     xy = Stack("t", (x, y))
     assert isinstance(xy, Tensor)
-    assert xy.inputs == OrderedDict(
-        [
-            ("t", Bint[2]),
-            ("i", Bint[2]),
-            ("j", Bint[3]),
-        ]
-    )
+    assert xy.inputs == OrderedDict(t=Bint[2], i=Bint[2], j=Bint[3])
     assert xy.output == output
     for j in range(3):
         assert_close(xy(t=0, j=j), x)
@@ -1073,14 +975,7 @@ def test_funsor_stack(output):
 
     xyz = Stack("t", (x, y, z))
     assert isinstance(xyz, Tensor)
-    assert xyz.inputs == OrderedDict(
-        [
-            ("t", Bint[3]),
-            ("i", Bint[2]),
-            ("j", Bint[3]),
-            ("k", Bint[4]),
-        ]
-    )
+    assert xyz.inputs == OrderedDict(t=Bint[3], i=Bint[2], j=Bint[3], k=Bint[4])
     assert xy.output == output
     for j in range(3):
         for k in range(4):
@@ -1094,32 +989,9 @@ def test_funsor_stack(output):
 
 @pytest.mark.parametrize("output", [Bint[2], Real, Reals[4], Reals[2, 3]], ids=str)
 def test_cat_simple(output):
-    x = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[2]),
-            ]
-        ),
-        output,
-    )
-    y = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[3]),
-                ("j", Bint[4]),
-            ]
-        ),
-        output,
-    )
-    z = random_tensor(
-        OrderedDict(
-            [
-                ("i", Bint[5]),
-                ("k", Bint[6]),
-            ]
-        ),
-        output,
-    )
+    x = random_tensor(OrderedDict(i=Bint[2]), output)
+    y = random_tensor(OrderedDict(i=Bint[3], j=Bint[4]), output)
+    z = random_tensor(OrderedDict(i=Bint[5], k=Bint[6]), output)
 
     assert Cat("i", (x,)) is x
     assert Cat("i", (y,)) is y
@@ -1127,23 +999,12 @@ def test_cat_simple(output):
 
     xy = Cat("i", (x, y))
     assert isinstance(xy, Tensor)
-    assert xy.inputs == OrderedDict(
-        [
-            ("i", Bint[2 + 3]),
-            ("j", Bint[4]),
-        ]
-    )
+    assert xy.inputs == OrderedDict(i=Bint[2 + 3], j=Bint[4])
     assert xy.output == output
 
     xyz = Cat("i", (x, y, z))
     assert isinstance(xyz, Tensor)
-    assert xyz.inputs == OrderedDict(
-        [
-            ("i", Bint[2 + 3 + 5]),
-            ("j", Bint[4]),
-            ("k", Bint[6]),
-        ]
-    )
+    assert xyz.inputs == OrderedDict(i=Bint[2 + 3 + 5], j=Bint[4], k=Bint[6])
     assert xy.output == output
 
 


### PR DESCRIPTION
This cleans up after `black` expanded some code in examples in tests:
- Replaces `OrderedDict([("i", Real)])` -> `OrderedDict(i=Real)` as allowed in Python 3.6
- Leverages `Funsor.reduce()` convenience handling to simplify example `reduced_vars`