### PR TITLE
Support ops.sum(data, dim=None, keepdims=False)

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -250,20 +250,21 @@ def _find_domain_log_exp(op, domain):
 
 @find_domain.register(ops.SumOp)
 def _find_domain_sum(op, domain):
-    # Canonicalize axes.
-    ndim = len(domain.shape)
-    if op.axis is None:
-        axis = set(range(ndim))
-    elif isinstance(op.axis, int):
-        axis = {op.axis % ndim}
+    # Canonicalize dim.
+    dim = op.defaults.get("dim", None)
+    ndims = len(domain.shape)
+    if dim is None:
+        dims = set(range(ndims))
+    elif isinstance(dim, int):
+        dims = {dim % ndims}
     else:
-        axis = {i % ndim for i in op.axis}
+        dims = {i % ndims for i in dim}
 
     # Compute shape.
-    if op.keepdims:
-        shape = tuple(1 if i in axis else size for i, size in enumerate(domain.shape))
+    if op.defaults.get("keepdims", False):
+        shape = tuple(1 if i in dims else size for i, size in enumerate(domain.shape))
     else:
-        shape = tuple(size for i, size in enumerate(domain.shape) if i not in axis)
+        shape = tuple(size for i, size in enumerate(domain.shape) if i not in dims)
 
     # Compute domain.
     if domain.dtype == "real":

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -258,8 +258,8 @@ def _stack(parts, dim=0):
 
 
 @ops.sum.register(array)
-def _sum(x, dim):
-    return np.sum(x, axis=dim)
+def _sum(x, dim, keepdims):
+    return np.sum(x, dim, keepdims=keepdims)
 
 
 @ops.triangular_solve.register(array, array)

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -42,7 +42,7 @@ full_like = make_op(np.full_like)
 isnan = make_op(np.isnan)
 prod = make_op(np.prod)
 stack = make_op("stack")
-sum = make_op(np.sum, params=("axis", "keepdims"))
+sum = make_op(np.sum)
 transpose = make_op("transpose")
 
 sqrt.register(array)(np.sqrt)

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -70,8 +70,8 @@ def amin(x, dim=None, keepdims=False):
 
 
 @UnaryOp.make
-def sum(x, dim=None):
-    return np.sum(x, dim)
+def sum(x, dim=None, keepdims=False):
+    return np.sum(x, dim, keepdims=keepdims)
 
 
 @UnaryOp.make

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -42,7 +42,7 @@ full_like = make_op(np.full_like)
 isnan = make_op(np.isnan)
 prod = make_op(np.prod)
 stack = make_op("stack")
-sum = make_op(np.sum)
+sum = make_op(np.sum, params=("axis", "keepdims"))
 transpose = make_op("transpose")
 
 sqrt.register(array)(np.sqrt)

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -121,42 +121,25 @@ class Op(Dispatcher):
         return decorator
 
 
-class ParametrizedOp(Op, metaclass=CachedOpMeta):
-    def __call__(self, *args, **kwargs):
-        params = tuple(kwargs.get(k, v) for k, v in self._params.items())
-        op = type(self)()  # The canonical dispatcher.
-        return super(ParametrizedOp, op).__call__(*args, *params)
-
-
-def make_op(fn=None, parent=None, *, name=None, params=None, module_name="funsor.ops"):
+def make_op(fn=None, parent=None, *, name=None, module_name="funsor.ops"):
     """
     Factory to create a new :class:`Op` subclass and a new instance of that class.
     """
     # Support use as decorator.
     if fn is None:
-        return lambda fn: make_op(
-            fn,
-            parent,
-            name=name,
-            params=params,
-            module_name=module_name,
-        )
+        return lambda fn: make_op(fn, parent, name=name, module_name=module_name)
+
+    if parent is None:
+        parent = Op
+    assert issubclass(parent, Op)
 
     if name is None:
         name = fn if isinstance(fn, str) else fn.__name__
     assert isinstance(name, str)
 
-    if params is not None:
-        parent = ParametrizedOp
-    if parent is None:
-        parent = Op
-    assert issubclass(parent, Op)
-
     classname = name.capitalize().rstrip("_") + "Op"  # e.g. add -> AddOp
     cls = type(classname, (parent,), {})
     cls.__module__ = module_name
-    if params is not None:
-        cls._params = params
     op = cls(fn, name=name)
     return op
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -773,7 +773,7 @@ def eager_reshape_tensor(op, arg):
 
 
 @eager.register(Unary, ops.SumOp, Tensor)
-def eager_reshape_tensor(op, arg):
+def eager_sum_tensor(op, arg):
     if not arg.inputs:
         return Tensor(op(arg.data), arg.inputs, arg.dtype)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -772,6 +772,25 @@ def eager_reshape_tensor(op, arg):
     return Tensor(data, arg.inputs, arg.dtype)
 
 
+@eager.register(Unary, ops.SumOp, Tensor)
+def eager_reshape_tensor(op, arg):
+    if not arg.inputs:
+        return Tensor(op(arg.data), arg.inputs, arg.dtype)
+
+    # Work around batch inputs.
+    dim = op.defaults.get("dim", None)
+    keepdims = op.defaults.get("keepdims", False)
+    ndims = len(arg.output.shape)
+    if dim is None:
+        dim = tuple(range(-ndims, 0))
+    elif isinstance(dim, int):
+        dim = dim % ndims - ndims
+    else:
+        dim = tuple(d % ndims - ndims for d in dim)
+    data = op(arg.data, dim, keepdims)
+    return Tensor(data, arg.inputs, arg.dtype)
+
+
 @eager.register(Binary, GetitemOp, Tensor, Number)
 def eager_getitem_tensor_number(op, lhs, rhs):
     offset = op.defaults["offset"]

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -279,9 +279,22 @@ def _stack(dim, *x):
     return torch.stack(x, dim=dim)
 
 
+# OLD
 @ops.sum.register(torch.Tensor, (int, type(None)))
 def _sum(x, dim):
     return x.sum() if dim is None else x.sum(dim)
+
+
+# NEW
+@ops.sum.register(torch.Tensor)
+@ops.sum.register(torch.Tensor, type(None), bool)
+def _sum_int(x, axis=None, keepdims=False):
+    return x.sum(keepdim=keepdims)
+
+
+@ops.sum.register(torch.Tensor, int, bool)
+def _sum_int(x, axis, keepdims):
+    return x.sum(axis, keepdim=keepdims)
 
 
 @ops.triangular_solve.register(torch.Tensor, torch.Tensor)

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -279,22 +279,9 @@ def _stack(dim, *x):
     return torch.stack(x, dim=dim)
 
 
-# OLD
 @ops.sum.register(torch.Tensor, (int, type(None)))
 def _sum(x, dim):
     return x.sum() if dim is None else x.sum(dim)
-
-
-# NEW
-@ops.sum.register(torch.Tensor)
-@ops.sum.register(torch.Tensor, type(None), bool)
-def _sum_int(x, axis=None, keepdims=False):
-    return x.sum(keepdim=keepdims)
-
-
-@ops.sum.register(torch.Tensor, int, bool)
-def _sum_int(x, axis, keepdims):
-    return x.sum(axis, keepdim=keepdims)
 
 
 @ops.triangular_solve.register(torch.Tensor, torch.Tensor)

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -271,8 +271,13 @@ ops.stack.register(typing.Tuple[torch.Tensor, ...])(torch.stack)
 
 
 @ops.sum.register(torch.Tensor)
-def _sum(x, dim):
-    return x.sum() if dim is None else x.sum(dim)
+def _sum(x, dim, keepdims):
+    if dim is None:
+        if keepdims:
+            dim = tuple(range(x.dim()))
+            return x.sum(dim, True)
+        return x.sum()
+    return x.sum(dim, keepdims)
 
 
 @ops.triangular_solve.register(torch.Tensor, torch.Tensor)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1306,3 +1306,34 @@ def test_scatter_pure_renaming():
 
     assert actual.input_vars == expected.input_vars
     assert ((actual - expected).abs() < 1e-4).data.all()
+
+
+# TODO add a test with batch dimensions
+@pytest.mark.parametrize("shape", [(2, 3, 4)], ids=str)
+def test_sum_parameters(shape):
+    data = randn(*shape)
+    AXES = [None, 0, 1, 2, -1, -2, -3, [0, 2]]
+    KEEPDIMS = [False, True]
+
+    assert_close(Tensor(ops.sum(data)), ops.sum(Tensor(data)))
+    for axis in AXES:
+        assert_close(Tensor(ops.sum(data, axis)), ops.sum(Tensor(data), axis))
+        assert_close(Tensor(ops.sum(data, axis=axis)), ops.sum(Tensor(data), axis=axis))
+    for keepdim in KEEPDIMS:
+        assert_close(
+            Tensor(ops.sum(data, keepdim=keepdim)),
+            ops.sum(Tensor(data), keepdim=keepdim),
+        )
+        for axis in AXES:
+            assert_close(
+                Tensor(ops.sum(data, axis, keepdim)),
+                ops.sum(Tensor(data), axis, keepdim),
+            )
+            assert_close(
+                Tensor(ops.sum(data, axis, keepdim=keepdim)),
+                ops.sum(Tensor(data), axis, keepdim=keepdim),
+            )
+            assert_close(
+                Tensor(ops.sum(data, axis=axis, keepdim=keepdim)),
+                ops.sum(Tensor(data), axis=axis, keepdim=keepdim),
+            )

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1307,32 +1307,51 @@ def test_scatter_pure_renaming():
     assert ((actual - expected).abs() < 1e-4).data.all()
 
 
-# TODO add a test with batch dimensions
-@pytest.mark.parametrize("shape", [(2, 3, 4)], ids=str)
-def test_sum_parameters(shape):
-    data = randn(*shape)
-    AXES = [None, 0, 1, 2, -1, -2, -3, [0, 2]]
+@pytest.mark.parametrize("event_shape", [(2, 3, 4)], ids=str)
+def test_sum(event_shape):
+    data = randn(*event_shape)
+    DIMS = [None, 0, 1, 2, -1, -2, -3, (0, 2)]
     KEEPDIMS = [False, True]
 
     assert_close(Tensor(ops.sum(data)), ops.sum(Tensor(data)))
-    for axis in AXES:
-        assert_close(Tensor(ops.sum(data, axis)), ops.sum(Tensor(data), axis))
-        assert_close(Tensor(ops.sum(data, axis=axis)), ops.sum(Tensor(data), axis=axis))
-    for keepdim in KEEPDIMS:
+    for dim in DIMS:
+        assert_close(Tensor(ops.sum(data, dim)), ops.sum(Tensor(data), dim))
+        assert_close(Tensor(ops.sum(data, dim=dim)), ops.sum(Tensor(data), dim=dim))
+    for keepdims in KEEPDIMS:
         assert_close(
-            Tensor(ops.sum(data, keepdim=keepdim)),
-            ops.sum(Tensor(data), keepdim=keepdim),
+            Tensor(ops.sum(data, keepdims=keepdims)),
+            ops.sum(Tensor(data), keepdims=keepdims),
         )
-        for axis in AXES:
+        for dim in DIMS:
             assert_close(
-                Tensor(ops.sum(data, axis, keepdim)),
-                ops.sum(Tensor(data), axis, keepdim),
+                Tensor(ops.sum(data, dim, keepdims)),
+                ops.sum(Tensor(data), dim, keepdims),
             )
             assert_close(
-                Tensor(ops.sum(data, axis, keepdim=keepdim)),
-                ops.sum(Tensor(data), axis, keepdim=keepdim),
+                Tensor(ops.sum(data, dim, keepdims=keepdims)),
+                ops.sum(Tensor(data), dim, keepdims=keepdims),
             )
             assert_close(
-                Tensor(ops.sum(data, axis=axis, keepdim=keepdim)),
-                ops.sum(Tensor(data), axis=axis, keepdim=keepdim),
+                Tensor(ops.sum(data, dim=dim, keepdims=keepdims)),
+                ops.sum(Tensor(data), dim=dim, keepdims=keepdims),
             )
+
+
+@pytest.mark.parametrize("batch_shape", [(), (5,)], ids=str)
+@pytest.mark.parametrize("event_shape", [(2, 3, 4)], ids=str)
+def test_sum_batch(batch_shape, event_shape):
+    inputs = OrderedDict((k, Bint[s]) for k, s in zip("abc", batch_shape))
+    data = randn(*batch_shape, *event_shape)
+    DIMS = [None, 0, 1, 2, -1, -2, -3, (0, 2)]
+    KEEPDIMS = [False, True]
+
+    def raw_sum(x, dim=None, keepdims=False, batch_ndims=len(batch_shape)):
+        if batch_ndims == 0:
+            return ops.sum(x, dim, keepdims)
+        return ops.stack([raw_sum(part, dim, keepdims, batch_ndims - 1) for part in x])
+
+    for keepdims in KEEPDIMS:
+        for dim in DIMS:
+            actual = ops.sum(Tensor(data, inputs), dim, keepdims)
+            expected = Tensor(raw_sum(data, dim, keepdims), inputs)
+            assert_close(actual, expected)


### PR DESCRIPTION
Addresses #489 
pair coded with @eb8680 @ordabayevy @fehiepsi 

This demonstrates the new parametrized op syntax from #491 .  The recipe is:
1. add new `*args, *kwargs` to your op in `funsor.ops.array`
2. add backend support in `funsor.torch.ops` and `funsor.jax.ops`
3. implement `find_domain(op, ...)` in `funsor.domains`
4. work around batch dimensions in `funsor.tensor`
5. add some tests

## Tested
- [x] unit test for various op arg,kwarg syntax
- [x] unit test for batched tensors