### PR TITLE
Extract A-normal form computation from stack_reinterpret

### DIFF
--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -16,7 +16,7 @@ from funsor.delta import Delta
 from funsor.domains import find_domain
 from funsor.gaussian import Gaussian
 from funsor.interpretations import eager, normalize, reflect
-from funsor.interpreter import recursion_reinterpret
+from funsor.interpreter import children, recursion_reinterpret
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
 from funsor.tensor import Tensor
 from funsor.terms import (
@@ -248,6 +248,11 @@ def recursion_reinterpret_contraction(x):
     return type(x)(
         *map(recursion_reinterpret, (x.red_op, x.bin_op, x.reduced_vars) + x.terms)
     )
+
+
+@children.register(Contraction)
+def children_contraction(x):
+    return (x.red_op, x.bin_op, x.reduced_vars) + x.terms
 
 
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -6,7 +6,7 @@ import os
 import re
 import types
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from functools import singledispatch
 
 import numpy as np
@@ -216,11 +216,11 @@ def gensym(x=None):
 
 
 def anf(x):
-    stack = [x]
+    stack = deque([x])
     child_to_parents, children_counts = {}, {}
-    leaves = []
+    leaves = deque()
     while stack:
-        h = stack.pop(0)
+        h = stack.popleft()
         children_counts[h] = 0
         child_to_parents.setdefault(h, [])
         for c in children(h):
@@ -235,7 +235,7 @@ def anf(x):
 
     env = OrderedDict(((x, x),))
     while leaves:
-        h = leaves.pop(0)
+        h = leaves.popleft()
         for parent in child_to_parents[h]:
             children_counts[parent] -= 1
             if children_counts[parent] == 0:

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -221,6 +221,7 @@ class ANFDict(OrderedDict):
     OrderedDict with slightly more liberal hashing semantics.
     Used with cons-hashing for representing Funsor expression DAGs.
     """
+
     @staticmethod
     def _key(x):
         return id(x) if is_numeric_array(x) or not isinstance(x, Hashable) else x

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -252,9 +252,11 @@ def stack_reinterpret(x):
         if is_atom(value):
             continue
         if isinstance(value, (tuple, frozenset)):  # TODO absorb this into interpret
-            env[key] = type(value)(env.get(c, c) for c in children(value))
+            env[key] = type(value)(c if is_atom(c) else env[c] for c in children(value))
         else:
-            env[key] = interpret(type(value), *(env.get(c, c) for c in children(value)))
+            env[key] = interpret(
+                type(value), *(c if is_atom(c) else env[c] for c in children(value))
+            )
     return env[x]
 
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -7,7 +7,6 @@ import re
 import types
 import warnings
 from collections import OrderedDict
-from collections.abc import Hashable
 from functools import singledispatch
 
 import numpy as np

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -217,6 +217,10 @@ def gensym(x=None):
 
 
 class ANFDict(OrderedDict):
+    """
+    OrderedDict with slightly more liberal hashing semantics.
+    Used with cons-hashing for representing Funsor expression DAGs.
+    """
     @staticmethod
     def _key(x):
         return id(x) if is_numeric_array(x) or not isinstance(x, Hashable) else x


### PR DESCRIPTION
This PR refactors `funsor.interpreter.stack_reinterpret` into two functions `anf` and `stack_reinterpret`, where `anf` transforms a Funsor expression into a topologically ordered `OrderedDict` of subexpressions and `stack_reinterpret` `interpret()`s the subexpressions in order, using the `OrderedDict` to avoid evaluating expressions twice.

Exposing this representation of Funsor expressions should eventually make it easier to implement transformations like `adjoint` or `solve` that traverse expressions in reverse without resorting to a tape, or that do not need to traverse the entire expression (like alpha-renaming).

I would also like to refactor `recursion_reinterpret` to use `anf` to ensure that traversal order is always correct.

Tested: pure refactoring exercised by existing tests with `FUNSOR_USE_TCO=1`.