### PR TITLE
Share more code between reinterpret implementations

### DIFF
--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -6,7 +6,7 @@ from collections.abc import Hashable
 
 from funsor.cnf import Contraction
 from funsor.interpretations import Interpretation, reflect
-from funsor.interpreter import reinterpret
+from funsor.interpreter import stack_reinterpret
 from funsor.ops import AssociativeOp
 from funsor.registry import KeyedRegistry
 from funsor.terms import (
@@ -130,7 +130,8 @@ class AdjointTape(Interpretation):
 
 def adjoint(sum_op, bin_op, expr):
     with AdjointTape() as tape:
-        root = reinterpret(expr)
+        # TODO fix traversal order in AdjointTape instead of using stack_reinterpret
+        root = stack_reinterpret(expr)
     return tape.adjoint(sum_op, bin_op, root)
 
 

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -6,7 +6,7 @@ from collections.abc import Hashable
 
 from funsor.cnf import Contraction, nullop
 from funsor.interpretations import Interpretation, reflect
-from funsor.interpreter import stack_reinterpret
+from funsor.interpreter import reinterpret
 from funsor.ops import AssociativeOp
 from funsor.registry import KeyedRegistry
 from funsor.terms import (
@@ -130,8 +130,7 @@ class AdjointTape(Interpretation):
 
 def adjoint(sum_op, bin_op, expr):
     with AdjointTape() as tape:
-        # TODO fix traversal order in AdjointTape instead of using stack_reinterpret
-        root = stack_reinterpret(expr)
+        root = reinterpret(expr)
     return tape.adjoint(sum_op, bin_op, root)
 
 

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -16,7 +16,7 @@ from funsor.delta import Delta
 from funsor.domains import find_domain
 from funsor.gaussian import Gaussian
 from funsor.interpretations import eager, normalize, reflect
-from funsor.interpreter import recursion_reinterpret
+from funsor.interpreter import children, recursion_reinterpret
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
 from funsor.tensor import Tensor
 from funsor.terms import (
@@ -248,6 +248,11 @@ def recursion_reinterpret_contraction(x):
     return type(x)(
         *map(recursion_reinterpret, (x.red_op, x.bin_op, x.reduced_vars) + x.terms)
     )
+
+
+@children.register(Contraction)
+def children_contraction(x):
+    return (x.red_op, x.bin_op, x.reduced_vars) + x.terms
 
 
 @eager.register(Contraction, AssociativeOp, AssociativeOp, frozenset, Variadic[Funsor])

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -16,7 +16,7 @@ from funsor.delta import Delta
 from funsor.domains import find_domain
 from funsor.gaussian import Gaussian
 from funsor.interpretations import eager, normalize, reflect
-from funsor.interpreter import children, recursion_reinterpret
+from funsor.interpreter import children
 from funsor.ops import DISTRIBUTIVE_OPS, AssociativeOp, NullOp, nullop
 from funsor.tensor import Tensor
 from funsor.terms import (
@@ -241,13 +241,6 @@ def _(arg, indent, out):
     quote.inplace(arg.terms, indent + 1, out)
     i, line = out[-1]
     out[-1] = i, line + ")"
-
-
-@recursion_reinterpret.register(Contraction)
-def recursion_reinterpret_contraction(x):
-    return type(x)(
-        *map(recursion_reinterpret, (x.red_op, x.bin_op, x.reduced_vars) + x.terms)
-    )
 
 
 @children.register(Contraction)

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -6,7 +6,7 @@ import os
 import re
 import types
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from functools import singledispatch
 
 import numpy as np
@@ -216,11 +216,11 @@ def gensym(x=None):
 
 
 def anf(x):
-    stack = [x]
+    stack = deque([x])
     child_to_parents, children_counts = {}, {}
-    leaves = []
+    leaves = deque()
     while stack:
-        h = stack.pop(0)
+        h = stack.popleft()
         children_counts[h] = 0
         child_to_parents.setdefault(h, [])
         for c in children(h):
@@ -235,7 +235,7 @@ def anf(x):
 
     env = OrderedDict(((x, x),))
     while leaves:
-        h = leaves.pop(0)
+        h = leaves.popleft()
         for parent in child_to_parents[h]:
             children_counts[parent] -= 1
             if children_counts[parent] == 0:

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -221,6 +221,7 @@ class ANFDict(OrderedDict):
     OrderedDict with slightly more liberal hashing semantics.
     Used with cons-hashing for representing Funsor expression DAGs.
     """
+
     @staticmethod
     def _key(x):
         return id(x) if is_numeric_array(x) or not isinstance(x, Hashable) else x

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -252,9 +252,11 @@ def stack_reinterpret(x):
         if is_atom(value):
             continue
         if isinstance(value, (tuple, frozenset)):  # TODO absorb this into interpret
-            env[key] = type(value)(env.get(c, c) for c in children(value))
+            env[key] = type(value)(c if is_atom(c) else env[c] for c in children(value))
         else:
-            env[key] = interpret(type(value), *(env.get(c, c) for c in children(value)))
+            env[key] = interpret(
+                type(value), *(c if is_atom(c) else env[c] for c in children(value))
+            )
     return env[x]
 
 

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -7,7 +7,6 @@ import re
 import types
 import warnings
 from collections import OrderedDict
-from collections.abc import Hashable
 from functools import singledispatch
 
 import numpy as np

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -96,32 +96,6 @@ def interpretation(new):
     return new
 
 
-@singledispatch
-def recursion_reinterpret(x):
-    r"""
-    Overloaded reinterpretation of a deferred expression.
-    This interpreter uses the Python stack and is subject to the recursion limit.
-
-    This handles a limited class of expressions, raising
-    ``ValueError`` in unhandled cases.
-
-    :param x: An input, typically involving deferred
-        :class:`~funsor.terms.Funsor` s.
-    :type x: A funsor or data structure holding funsors.
-    :return: A reinterpreted version of the input.
-    :raises: ValueError
-    """
-    raise ValueError(type(x))
-
-
-# We need to register this later in terms.py after declaring Funsor.
-# reinterpret.register(Funsor)
-@instrument.debug_logged
-def reinterpret_funsor(x):
-    interpret = _STACK[-1].interpret
-    return interpret(type(x), *map(recursion_reinterpret, x._ast_values))
-
-
 _ground_types = (
     str,
     int,
@@ -138,39 +112,10 @@ _ground_types = (
 )
 
 
-for t in _ground_types:
-
-    @recursion_reinterpret.register(t)
-    def recursion_reinterpret_ground(x):
-        return x
-
-
-@recursion_reinterpret.register(tuple)
-@instrument.debug_logged
-def recursion_reinterpret_tuple(x):
-    return tuple(map(recursion_reinterpret, x))
-
-
-@recursion_reinterpret.register(frozenset)
-@instrument.debug_logged
-def recursion_reinterpret_frozenset(x):
-    return frozenset(map(recursion_reinterpret, x))
-
-
-@recursion_reinterpret.register(dict)
-@instrument.debug_logged
-def recursion_reinterpret_dict(x):
-    return {key: recursion_reinterpret(value) for key, value in x.items()}
-
-
-@recursion_reinterpret.register(OrderedDict)
-@instrument.debug_logged
-def recursion_reinterpret_ordereddict(x):
-    return OrderedDict((key, recursion_reinterpret(value)) for key, value in x.items())
-
-
 @singledispatch
 def children(x):
+    if is_atom(x):
+        return ()
     raise ValueError(type(x))
 
 
@@ -189,13 +134,6 @@ def _children_tuple(x):
 @children.register(OrderedDict)
 def _children_tuple(x):
     return x.values()
-
-
-for t in _ground_types:
-
-    @children.register(t)
-    def _children_ground(x):
-        return ()
 
 
 def is_atom(x):
@@ -247,6 +185,21 @@ def anf(x):
 
 
 def stack_reinterpret(x):
+    r"""
+    Overloaded reinterpretation of a deferred expression.
+    This interpreter does not use the Python stack and
+    therefore works with arbitrarily large expressions.
+
+    This handles a limited class of expressions, raising
+    ``ValueError`` in unhandled cases.
+
+    :param x: An input, typically involving deferred
+        :class:`~funsor.terms.Funsor` s.
+    :type x: A funsor or data structure holding funsors.
+    :return: A reinterpreted version of the input.
+    :raises: ValueError
+    """
+    interpret = _STACK[-1].interpret
     env = anf(x)
     for key, value in env.items():
         if is_atom(value):
@@ -258,6 +211,45 @@ def stack_reinterpret(x):
                 type(value), *(c if is_atom(c) else env[c] for c in children(value))
             )
     return env[x]
+
+
+def _anf_recur(interpret, env, visited, key, value):
+    if is_atom(value) or key in visited:
+        return value
+    elif isinstance(value, (tuple, frozenset)):  # TODO absorb this into interpret
+        env[key] = type(value)(
+            c if is_atom(c) else _anf_recur(interpret, env, visited, c, env[c])
+            for c in children(value)
+        )
+        visited.add(key)
+        return env[key]
+    else:
+        env[key] = interpret(
+            type(value),
+            *(
+                c if is_atom(c) else _anf_recur(interpret, env, visited, c, env[c])
+                for c in children(value)
+            ),
+        )
+        visited.add(key)
+        return env[key]
+
+
+def recursion_reinterpret(x):
+    r"""
+    Overloaded reinterpretation of a deferred expression.
+    This interpreter uses the Python stack and is subject to the recursion limit.
+
+    This handles a limited class of expressions, raising
+    ``ValueError`` in unhandled cases.
+
+    :param x: An input, typically involving deferred
+        :class:`~funsor.terms.Funsor` s.
+    :type x: A funsor or data structure holding funsors.
+    :return: A reinterpreted version of the input.
+    :raises: ValueError
+    """
+    return _anf_recur(_STACK[-1].interpret, anf(x), set(), x, x)
 
 
 def reinterpret(x):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -214,6 +214,7 @@ def stack_reinterpret(x):
     return env[x]
 
 
+@instrument.debug_logged
 def recursion_reinterpret(x):
     r"""
     Overloaded reinterpretation of a deferred expression.

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -217,6 +217,10 @@ def gensym(x=None):
 
 
 class ANFDict(OrderedDict):
+    """
+    OrderedDict with slightly more liberal hashing semantics.
+    Used with cons-hashing for representing Funsor expression DAGs.
+    """
     @staticmethod
     def _key(x):
         return id(x) if is_numeric_array(x) or not isinstance(x, Hashable) else x

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -4,7 +4,6 @@
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 
-from funsor.interpreter import children, recursion_reinterpret
 from funsor.tensor import tensor_to_funsor
 from funsor.terms import to_funsor
 from funsor.util import quote
@@ -13,18 +12,6 @@ from . import distributions as _
 from . import ops as _
 
 del _  # flake8
-
-
-@recursion_reinterpret.register(DeviceArray)
-@recursion_reinterpret.register(Tracer)
-def _recursion_reinterpret_ground(x):
-    return x
-
-
-@children.register(DeviceArray)
-@children.register(Tracer)
-def _children_ground(x):
-    return ()
 
 
 to_funsor.register(DeviceArray)(tensor_to_funsor)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -726,7 +726,6 @@ def _(arg, indent, out):
         out[-1] = i, line + ")"
 
 
-interpreter.recursion_reinterpret.register(Funsor)(interpreter.reinterpret_funsor)
 interpreter.children.register(Funsor)(interpreter.children_funsor)
 
 

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -4,7 +4,6 @@
 import torch
 from multipledispatch import dispatch
 
-from funsor.interpreter import children, recursion_reinterpret
 from funsor.tensor import tensor_to_funsor
 from funsor.terms import to_funsor
 from funsor.util import quote
@@ -13,18 +12,6 @@ from . import distributions as _
 from . import ops as _
 
 del _  # flake8
-
-
-@recursion_reinterpret.register(torch.Tensor)
-@recursion_reinterpret.register(torch.nn.Module)
-def recursion_reinterpret_ground(x):
-    return x
-
-
-@children.register(torch.Tensor)
-@children.register(torch.nn.Module)
-def _children_ground(x):
-    return ()
 
 
 @quote.register(torch.Tensor)


### PR DESCRIPTION
This PR refactors `recursion_reinterpret` to use the same utilities (`is_atom` and `children`) as `stack_reinterpret` and simplifies its implementation by removing a `singledispatch`, which should also slightly simplify stack traces.

Tested: pure refactoring, exercised everywhere `reinterpret` is called