### PR TITLE
Add a generic op factory make_op

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from funsor.domains import Array, Bint, Domain, Real, Reals, bint, find_domain, reals
+from funsor.factory import make_funsor
 from funsor.integrate import Integrate
 from funsor.interpreter import interpretation, reinterpret
+from funsor.op_factory import make_op
 from funsor.sum_product import MarkovProduct
 from funsor.tensor import Tensor, function
 from funsor.terms import (
@@ -84,7 +86,8 @@ __all__ = [
     "interpretations",
     "interpreter",
     "joint",
-    # 'minipyro',  # TODO: enable when minipyro is backend-agnostic
+    "make_funsor",
+    "make_op",
     "montecarlo",
     "of_shape",
     "ops",
@@ -93,6 +96,7 @@ __all__ = [
     "reals",
     "reinterpret",
     "set_backend",
+    # 'minipyro',  # TODO: enable when minipyro is backend-agnostic
     "sum_product",
     "symbolic",
     "terms",

--- a/funsor/op_factory.py
+++ b/funsor/op_factory.py
@@ -70,7 +70,7 @@ def make_op(fn):
 
     # Register an eager funsor rule.
     # TODO generalize to more funsor types, ideally to Funsor itself.
-    pattern = [funsor_cls, op_cls] + [(Number, Tuple, Tensor)] * arity
+    pattern = [funsor_cls, type(op)] + [(Number, Tuple, Tensor)] * arity
     eager.register(*pattern)(eager_tensor_made_op)
 
     return op

--- a/funsor/op_factory.py
+++ b/funsor/op_factory.py
@@ -1,0 +1,75 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import typing
+
+from funsor import interpreter
+from funsor.domains import BintType, find_domain
+from funsor.interpretations import eager
+from funsor.interpreter import PatternMissingError
+from funsor.tensor import Tensor
+from funsor.terms import Binary, Number, Tuple, Unary, to_data, to_funsor
+from funsor.typing import deep_issubclass
+
+from . import ops
+
+
+def eager_tensor_made_op(op, *args):
+    name_to_dim = {}
+    for arg in args:
+        for k, v in reversed(arg.inputs.items()):
+            if isinstance(v, BintType):
+                name_to_dim.setdefault(k, -1 - len(name_to_dim))
+    dim_to_name = {dim: name for name, dim in name_to_dim.items()}
+    try:
+        raw_args = [to_data(arg, name_to_dim=name_to_dim) for arg in args]
+    except PatternMissingError:
+        return None  # give up
+    data = op(*raw_args)
+    output = find_domain(op, *(arg.output for arg in args))
+    return to_funsor(data, output, dim_to_name=dim_to_name)
+
+
+def make_op(fn):
+    """
+    Wrap a python function for use in Funsor.
+
+    1. Creates a new ``Op`` subclass and instance ``op``.
+    2. Registers a :func:`~funsor.domains.find_domain` rule based on ``fn``'s
+        return type.
+    3. Registers an eager rule.
+
+    This assumes ``fn`` is compatible with broadcasting.
+    """
+    input_types = typing.get_type_hints(fn)
+    output_type = input_types.pop("return")
+    parameters = inspect.Signature.from_callable(fn).parameters
+    hints = tuple(input_types.get(name) for name in parameters)
+    arity = len(parameters)
+    if arity == 1:
+        op_cls = ops.UnaryOp
+        funsor_cls = Unary
+    elif arity == 2:
+        op_cls = ops.BinaryOp
+        funsor_cls = Binary
+    else:
+        raise NotImplementedError("TODO convert to a finitary")
+    op = op_cls.make(fn)
+
+    # Register a find_domain implementation.
+    # TODO generalize to dependent output types.
+    @find_domain.register(type(op))
+    def find_domain_made_op(op, *args):
+        if interpreter._TYPECHECK:
+            for arg, hint in zip(args, hints):
+                if hint is not None:
+                    assert deep_issubclass(arg, hint)
+        return output_type
+
+    # Register an eager funsor rule.
+    # TODO generalize to more funsor types, ideally to Funsor itself.
+    pattern = [funsor_cls, op_cls] + [(Number, Tuple, Tensor)] * arity
+    eager.register(*pattern)(eager_tensor_made_op)
+
+    return op

--- a/funsor/op_factory.py
+++ b/funsor/op_factory.py
@@ -58,7 +58,6 @@ def make_op(fn):
     op = op_cls.make(fn)
 
     # Register a find_domain implementation.
-    # TODO generalize to dependent output types.
     @find_domain.register(type(op))
     def find_domain_made_op(op, *args):
         if interpreter._TYPECHECK:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -15,7 +15,15 @@ from multipledispatch import dispatch
 
 import funsor.interpreter as interpreter
 import funsor.ops as ops
-from funsor.domains import Array, Bint, Domain, Product, Real, find_domain
+from funsor.domains import (
+    Array,
+    Bint,
+    Domain,
+    Product,
+    ProductDomain,
+    Real,
+    find_domain,
+)
 from funsor.interpretations import (
     Interpretation,
     die,
@@ -28,7 +36,7 @@ from funsor.interpretations import (
 from funsor.interpreter import PatternMissingError, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.syntax import INFIX_OPERATORS, PREFIX_OPERATORS
-from funsor.typing import GenericTypeMeta, Variadic, deep_type, get_origin
+from funsor.typing import GenericTypeMeta, Variadic, deep_type, get_args, get_origin
 from funsor.util import getargspec, lazy_property, pretty, quote
 
 from . import instrument, interpreter, ops
@@ -1790,6 +1798,19 @@ class Tuple(Funsor):
     def __iter__(self):
         for i in range(len(self.args)):
             yield self[i]
+
+
+@to_funsor.register(tuple)
+def tuple_to_funsor(args, output=None, dim_to_name=None):
+    if not isinstance(output, ProductDomain):
+        raise NotImplementedError("TODO")
+    outputs = get_args(output)
+    assert len(outputs) == len(args)
+    funsor_args = tuple(
+        to_funsor(arg, output=arg_output, dim_to_name=dim_to_name)
+        for arg, arg_output in zip(args, outputs)
+    )
+    return Tuple(funsor_args)
 
 
 @lazy.register(Binary, GetitemOp, Tuple, Number)

--- a/funsor/typing.py
+++ b/funsor/typing.py
@@ -223,7 +223,7 @@ def _type_to_typing(tp):
 
 
 def get_args(tp):
-    if isinstance(tp, GenericTypeMeta) or sys.version_info[:2] < (3, 7):
+    if isinstance(tp, (GenericTypeMeta, type)) or sys.version_info[:2] < (3, 7):
         result = getattr(tp, "__args__", None)
     else:
         result = typing_extensions.get_args(tp)

--- a/test/test_op_factory.py
+++ b/test/test_op_factory.py
@@ -7,8 +7,7 @@ from collections import OrderedDict
 
 import pytest
 
-from funsor.domains import Array, Bint, Product, Reals
-from funsor.factory import Fresh as Dependent
+from funsor.domains import Array, Bint, Dependent, Product, Reals
 from funsor.op_factory import make_op
 from funsor.tensor import Tensor
 from funsor.terms import Binary, Tuple, Unary, Variable
@@ -88,7 +87,6 @@ def test_make_op_2(batch_shape):
     assert_close(actual, Tensor(actual_data, inputs))
 
 
-@pytest.mark.xfail(reason="Dependent annotations are not implemented")
 @pytest.mark.parametrize("batch_shape", [(), (10,)], ids=str)
 def test_make_op_3(batch_shape):
     inputs = OrderedDict((k, Bint[s]) for k, s in zip("abc", batch_shape))

--- a/test/test_op_factory.py
+++ b/test/test_op_factory.py
@@ -1,0 +1,123 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-License-Ldentifier: Apache-2.0
+
+from collections import OrderedDict
+
+import pytest
+
+from funsor.domains import Array, Bint, Product, Reals
+from funsor.factory import Fresh as Dependent
+from funsor.op_factory import make_op
+from funsor.tensor import Tensor
+from funsor.terms import Binary, Tuple, Unary, Variable
+from funsor.testing import assert_close, randn
+
+
+@pytest.mark.parametrize("batch_shape", [(), (10,)], ids=str)
+def test_make_op_1(batch_shape):
+    inputs = OrderedDict((k, Bint[s]) for k, s in zip("abc", batch_shape))
+
+    weights = randn(28 * 28, 2 * 20)
+    bias = randn(2 * 20)
+
+    @make_op
+    def encode(image: Reals[28, 28]) -> Product[Reals[20], Reals[20]]:
+        batch_shape = image.shape[:-2]
+        loc_scale = image.reshape(*batch_shape, 28 * 28) @ weights + bias
+        loc_scale = loc_scale.reshape(*batch_shape, 2, 20)
+        loc = loc_scale[..., 0, :]
+        scale = loc_scale[..., 1, :]
+        assert loc.shape == batch_shape + (20,)
+        assert scale.shape == batch_shape + (20,)
+        return loc, scale
+
+    # Check symbolic.
+    image = Variable("image", Reals[28, 28])
+    actual = encode(image)
+    assert isinstance(actual, Unary)
+    assert actual.output == Product[Reals[20], Reals[20]]
+
+    # Check on ground term.
+    image_data = randn(*batch_shape, 28, 28)
+    actual_data = encode(image_data)
+    assert isinstance(actual_data, tuple)
+    assert len(actual_data) == 2
+    assert isinstance(actual_data[0], type(image_data))
+    assert isinstance(actual_data[1], type(image_data))
+
+    # Check on funsor.Tensors.
+    image = Tensor(image_data, inputs)
+    actual = encode(image)
+    assert isinstance(actual, Tuple)
+    assert len(actual) == 2
+    assert isinstance(actual[0], Tensor)
+    assert isinstance(actual[1], Tensor)
+    assert_close(actual[0].data, actual_data[0])
+    assert_close(actual[1].data, actual_data[1])
+
+
+@pytest.mark.parametrize("batch_shape", [(), (10,)], ids=str)
+def test_make_op_2(batch_shape):
+    inputs = OrderedDict((k, Bint[s]) for k, s in zip("abc", batch_shape))
+
+    @make_op
+    def matmul(x: Reals[2, 3], y: Reals[3, 4]) -> Reals[2, 4]:
+        return x @ y
+
+    # Check symbolic.
+    x = Variable("x", Reals[2, 3])
+    y = Variable("y", Reals[3, 4])
+    actual = matmul(x, y)
+    assert isinstance(actual, Binary)
+    assert actual.output == Reals[2, 4]
+
+    # Check on ground term.
+    x_data = randn(*batch_shape, 2, 3)
+    y_data = randn(*batch_shape, 3, 4)
+    actual_data = matmul(x_data, y_data)
+    assert isinstance(actual_data, type(x_data))
+    assert_close(actual_data, x_data @ y_data)
+
+    # Check on funsor.Tensors.
+    x = Tensor(x_data, inputs)
+    y = Tensor(y_data, inputs)
+    actual = matmul(x, y)
+    assert isinstance(actual, Tensor)
+    assert_close(actual, Tensor(actual_data, inputs))
+
+
+@pytest.mark.xfail(reason="Dependent annotations are not implemented")
+@pytest.mark.parametrize("batch_shape", [(), (10,)], ids=str)
+def test_make_op_3(batch_shape):
+    inputs = OrderedDict((k, Bint[s]) for k, s in zip("abc", batch_shape))
+
+    @make_op
+    def matmul(
+        x: Array,
+        y: Array,
+    ) -> Dependent[lambda x, y: Reals[x.shape[0], y.shape[1]]]:
+        return x @ y
+
+    for L, J, K in [(2, 3, 4), (5, 6, 7)]:
+        # Check symbolic.
+        x = Variable("x", Reals[L, J])
+        y = Variable("y", Reals[J, K])
+        actual = matmul(x, y)
+        assert isinstance(actual, Binary)
+        assert actual.output == Reals[L, K]
+
+        # Check on ground term.
+        x_data = randn(*batch_shape, L, J)
+        y_data = randn(*batch_shape, J, K)
+        actual_data = matmul(x_data, y_data)
+        assert isinstance(actual_data, type(x_data))
+        assert_close(actual_data, x_data @ y_data)
+
+        # Check on funsor.Tensors.
+        x = Tensor(x_data, inputs)
+        y = Tensor(y_data, inputs)
+        actual = matmul(x, y)
+        assert isinstance(actual, Tensor)
+        assert_close(actual, Tensor(actual_data, inputs))

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -62,7 +62,7 @@ def test_to_funsor():
     assert to_funsor(0) is Number(0)
 
 
-@pytest.mark.parametrize("x", ["foo", list(), tuple(), set(), dict()])
+@pytest.mark.parametrize("x", ["foo", list(), set(), dict()])
 def test_to_funsor_error(x):
     with pytest.raises(ValueError):
         to_funsor(x)


### PR DESCRIPTION
Addresses #351
pair coded with @eb8680 @ordabayevy @fehiepsi 

Implements a `@make_op` decorator, automating e.g. `@BinaryOp.make` + `@find_domain.register` + `@eager.register`.

## Tested
- three unit tests of different domains