### PR TITLE
Use new ops to reduce multiple dims in eager_reduce

### DIFF
--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -305,22 +305,15 @@ class Tensor(Funsor, metaclass=TensorMeta):
             assert isinstance(reduced_vars, frozenset)
             self_vars = frozenset(self.inputs)
             reduced_vars = reduced_vars & self_vars
-            if reduced_vars == self_vars and not self.output.shape:
-                return Tensor(numeric_op(self.data, None), dtype=self.dtype)
-
-            # Reduce one dim at a time.
-            data = self.data
-            offset = 0
-            for k, domain in self.inputs.items():
-                if k in reduced_vars:
-                    assert not domain.shape
-                    data = numeric_op(data, offset)
-                else:
-                    offset += 1
+            dtype = find_domain(op, self.output).dtype
+            reduced_dims = tuple(
+                d for d, var in enumerate(self.inputs) if var in reduced_vars
+            )
             inputs = OrderedDict(
                 (k, v) for k, v in self.inputs.items() if k not in reduced_vars
             )
-            return Tensor(data, inputs, self.dtype)
+            data = numeric_op(self.data, reduced_dims)
+            return Tensor(data, inputs, dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 
     def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -305,11 +305,11 @@ class Tensor(Funsor, metaclass=TensorMeta):
             assert isinstance(reduced_vars, frozenset)
             self_vars = frozenset(self.inputs)
             reduced_vars = reduced_vars & self_vars
+            if not reduced_vars:
+                return self
             reduced_dims = tuple(
                 d for d, var in enumerate(self.inputs) if var in reduced_vars
             )
-            if not reduced_dims:
-                return self
             dtype = find_domain(op, self.output).dtype
             inputs = OrderedDict(
                 (k, v) for k, v in self.inputs.items() if k not in reduced_vars

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -305,10 +305,12 @@ class Tensor(Funsor, metaclass=TensorMeta):
             assert isinstance(reduced_vars, frozenset)
             self_vars = frozenset(self.inputs)
             reduced_vars = reduced_vars & self_vars
-            dtype = find_domain(op, self.output).dtype
             reduced_dims = tuple(
                 d for d, var in enumerate(self.inputs) if var in reduced_vars
             )
+            if not reduced_dims:
+                return self
+            dtype = find_domain(op, self.output).dtype
             inputs = OrderedDict(
                 (k, v) for k, v in self.inputs.items() if k not in reduced_vars
             )


### PR DESCRIPTION
This simplifies `eager_reduce` by using new `ops` (#482) that can reduce over multiple dims.