### PR TITLE
Allow stack Numbers

### DIFF
--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -409,7 +409,7 @@ def stack(parts, dim=0):
     raise NotImplementedError
 
 
-stack.register(arraylist)(np.stack)
+stack.register(typing.Tuple[typing.Union[array + (int, float)], ...])(np.stack)
 
 
 @UnaryOp.make

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -848,7 +848,7 @@ def eager_getitem_tensor_tensor(op, lhs, rhs):
     return Tensor(data, inputs, lhs.dtype)
 
 
-@eager.register(Finitary, ops.StackOp, typing.Tuple[Tensor, ...])
+@eager.register(Finitary, ops.StackOp, typing.Tuple[typing.Union[(Number, Tensor)], ...])
 def eager_finitary_stack(op, parts):
     dim = op.defaults["dim"]
     if dim >= 0:
@@ -860,7 +860,7 @@ def eager_finitary_stack(op, parts):
     return Tensor(raw_result, inputs, parts[0].dtype)
 
 
-@eager.register(Finitary, FinitaryOp, typing.Tuple[Tensor, ...])
+@eager.register(Finitary, FinitaryOp, typing.Tuple[typing.Union[(Number, Tensor)], ...])
 def eager_finitary_generic_tensors(op, args):
     inputs, raw_args = align_tensors(*args)
     raw_result = op(raw_args)

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -848,7 +848,9 @@ def eager_getitem_tensor_tensor(op, lhs, rhs):
     return Tensor(data, inputs, lhs.dtype)
 
 
-@eager.register(Finitary, ops.StackOp, typing.Tuple[typing.Union[(Number, Tensor)], ...])
+@eager.register(
+    Finitary, ops.StackOp, typing.Tuple[typing.Union[(Number, Tensor)], ...]
+)
 def eager_finitary_stack(op, parts):
     dim = op.defaults["dim"]
     if dim >= 0:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1874,6 +1874,7 @@ def symbolic(*signature):
             return _symbolic(inputs, output, fn)
     # Usage: @symbolic(Real, Reals[3], Bint[3])
     output = None
+    # FIXME: what is inputs?
     return functools.partial(_symbolic, inputs, output)
 
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -975,10 +975,12 @@ def test_funsor_stack(output):
         assert_close(xyz(t=2, j=j), z)
 
 
-@pytest.mark.skipif(get_backend() == "torch", reason="torck.stack does not support Python scalars")
+@pytest.mark.skipif(
+    get_backend() == "torch", reason="torck.stack does not support Python scalars"
+)
 def test_number_stack():
     actual = ops.stack((Number(2.0), Number(3)))
-    assert_close(actual, Tensor(numeric_array([2., 3.])))
+    assert_close(actual, Tensor(numeric_array([2.0, 3.0])))
 
 
 @pytest.mark.parametrize("output", [Bint[2], Real, Reals[4], Reals[2, 3]], ids=str)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -975,6 +975,12 @@ def test_funsor_stack(output):
         assert_close(xyz(t=2, j=j), z)
 
 
+@pytest.mark.skipif(get_backend() == "torch", reason="torck.stack does not support Python scalars")
+def test_number_stack():
+    actual = ops.stack((Number(2.0), Number(3)))
+    assert_close(actual, Tensor(numeric_array([2., 3.])))
+
+
 @pytest.mark.parametrize("output", [Bint[2], Real, Reals[4], Reals[2, 3]], ids=str)
 def test_cat_simple(output):
     x = random_tensor(OrderedDict(i=Bint[2]), output)


### PR DESCRIPTION
Fixes https://github.com/pyro-ppl/numpyro/issues/964

After https://github.com/pyro-ppl/funsor/pull/491, we are no longer able to stack Numbers. This PR relaxes this restriction because `numpy`, `jax` backends can perform stack over Python scalars

```python
import funsor; funsor.set_backend("jax")
from funsor import ops, Number
ops.stack((Number(2.), Number(3)))
```