### PR TITLE
Fix Independent() distribution conversion

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -20,7 +20,6 @@ from funsor.domains import Array, Real, Reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import (
-    Function,
     Tensor,
     align_tensors,
     dummy_numeric_array,
@@ -29,6 +28,7 @@ from funsor.tensor import (
     numeric_array,
 )
 from funsor.terms import (
+    Finitary,
     Funsor,
     FunsorMeta,
     Independent,
@@ -40,6 +40,7 @@ from funsor.terms import (
     to_data,
     to_funsor,
 )
+from funsor.typing import deep_isinstance
 from funsor.util import broadcast_shape, get_backend, getargspec, lazy_property
 
 BACKEND_TO_DISTRIBUTIONS_BACKEND = {
@@ -465,9 +466,9 @@ def indepdist_to_funsor(backend_dist, output=None, dim_to_name=None):
     )
     dim_to_name.update(event_dim_to_name)
     result = to_funsor(backend_dist.base_dist, dim_to_name=dim_to_name)
-    if isinstance(result, Distribution) and not isinstance(
-        result.value, Function
-    ):  # Function used in some eager patterns
+    if isinstance(result, Distribution) and not deep_isinstance(
+        result.value, Finitary[ops.StackOp, tuple]
+    ):  # ops.stack() used in some eager patterns
         params = tuple(result.params.values())[:-1]
         for dim, name in reversed(event_dim_to_name.items()):
             dim_var = to_funsor(name, result.inputs[name])

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -657,12 +657,13 @@ def test_generic_distribution_to_funsor(case):
 
 
 @pytest.mark.parametrize("case", TEST_CASES, ids=str)
-def test_generic_log_prob(case):
+@pytest.mark.parametrize("use_lazy", [True, False])
+def test_generic_log_prob(case, use_lazy):
     raw_dist = case.get_dist()
     expected_value_domain = case.expected_value_domain
 
     dim_to_name, name_to_dim = _default_dim_to_name(raw_dist.batch_shape)
-    with eager_no_dists:
+    with (eager_no_dists if use_lazy else eager):
         with xfail_if_not_implemented(match="try upgrading backend"):
             # some distributions have nontrivial eager patterns
             funsor_dist = to_funsor(


### PR DESCRIPTION
Unblocks https://github.com/pyro-ppl/pyro/pull/2786

This PR fixes conversion of some `Independent()` distributions to/from Funsors.  In #491 we changed `funsor.tensor.stack` from a `funsor.Function` to an `Op`, breaking some pattern-matching logic in `funsor.to_funsor` for distributions (see e.g. [`eager_beta`](https://github.com/pyro-ppl/funsor/blob/master/funsor/distribution.py#L771)).  This PR fixes that regression and reinstates the failing test cases in `test_distribution_generic.py` that were removed in #491.