### PR TITLE
Fix printing of Tensors

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -47,7 +47,7 @@ class ArrayType(Domain):
                 result = RealsType(name, (), {"shape": shape})
             elif isinstance(dtype, int):
                 assert dtype >= 0
-                name = "Bint[{}, {}]".format(dtype, ",".join(map(str, shape)))
+                name = "Bint[{}]".format(",".join(map(str, (dtype,) + shape)))
                 result = BintType(name, (), {"dtype": dtype, "shape": shape})
             else:
                 raise ValueError("invalid dtype: {}".format(dtype))

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -151,7 +151,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     @ignore_jit_warnings()
     def __repr__(self):
-        data = str(self.data).replace("\n", "\n       ")
+        data = repr(self.data).replace("\n", "\n       ")
         inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
             return "Tensor({}, {}, {})".format(data, inputs, repr(self.dtype))

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -102,7 +102,7 @@ class TensorMeta(FunsorMeta):
     def __call__(cls, data, inputs=None, dtype="real"):
         if inputs is None:
             inputs = tuple()
-        elif isinstance(inputs, OrderedDict):
+        elif isinstance(inputs, dict):
             inputs = tuple(inputs.items())
         # XXX: memoize tests fail for np.generic because those scalar values are hashable?
         # it seems that there is no harm with the conversion generic -> ndarray here
@@ -122,14 +122,14 @@ class Tensor(Funsor, metaclass=TensorMeta):
     For example::
 
         data = torch.zeros(5,4,3,2)
-        x = Tensor(data, OrderedDict([("i", Bint[5]), ("j", Bint[4])]))
+        x = Tensor(data, {"i": Bint[5], "j": Bint[4]})
         assert x.output == Reals[3, 2]
 
     Operators like ``matmul`` and ``.sum()`` operate only on the output shape,
     and will not change the named inputs.
 
     :param numeric_array data: A PyTorch tensor or NumPy ndarray.
-    :param OrderedDict inputs: An optional mapping from input name (str) to
+    :param dict inputs: An optional mapping from input name (str) to
         datatype (``funsor.domains.Domain``). Defaults to empty.
     :param dtype: optional output datatype. Defaults to "real".
     :type dtype: int or the string "real".
@@ -151,19 +151,21 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     @ignore_jit_warnings()
     def __repr__(self):
-        if self.output != "real":
-            return "Tensor({}, {}, {})".format(self.data, self.inputs, repr(self.dtype))
+        inputs = dict.__repr__(self.inputs)
+        if self.dtype != "real":
+            return "Tensor({}, {}, {})".format(self.data, inputs, repr(self.dtype))
         elif self.inputs:
-            return "Tensor({}, {})".format(self.data, self.inputs)
+            return "Tensor({}, {})".format(self.data, inputs)
         else:
             return "Tensor({})".format(self.data)
 
     @ignore_jit_warnings()
     def __str__(self):
+        inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
-            return "Tensor({}, {}, {})".format(self.data, self.inputs, repr(self.dtype))
+            return "Tensor({}, {}, {})".format(self.data, inputs, repr(self.dtype))
         elif self.inputs:
-            return "Tensor({}, {})".format(self.data, self.inputs)
+            return "Tensor({}, {})".format(self.data, inputs)
         else:
             return str(self.data)
 

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -151,23 +151,25 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     @ignore_jit_warnings()
     def __repr__(self):
+        data = repr(self.data)
         inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
-            return "Tensor({}, {}, {})".format(self.data, inputs, repr(self.dtype))
+            return "Tensor({}, {}, {})".format(data, inputs, repr(self.dtype))
         elif self.inputs:
-            return "Tensor({}, {})".format(self.data, inputs)
+            return "Tensor({}, {})".format(data, inputs)
         else:
-            return "Tensor({})".format(self.data)
+            return "Tensor({})".format(data)
 
     @ignore_jit_warnings()
     def __str__(self):
+        data = str(self.data)
         inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
-            return "Tensor({}, {}, {})".format(self.data, inputs, repr(self.dtype))
+            return "Tensor({}, {}, {})".format(data, inputs, repr(self.dtype))
         elif self.inputs:
-            return "Tensor({}, {})".format(self.data, inputs)
+            return "Tensor({}, {})".format(data, inputs)
         else:
-            return str(self.data)
+            return data
 
     def __int__(self):
         return int(self.data)

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -151,7 +151,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     @ignore_jit_warnings()
     def __repr__(self):
-        data = repr(self.data)
+        data = str(self.data).replace("\n", "\n       ")
         inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
             return "Tensor({}, {}, {})".format(data, inputs, repr(self.dtype))
@@ -162,7 +162,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
 
     @ignore_jit_warnings()
     def __str__(self):
-        data = str(self.data)
+        data = str(self.data).replace("\n", "\n       ")
         inputs = dict.__repr__(self.inputs)
         if self.dtype != "real":
             return "Tensor({}, {}, {})".format(data, inputs, repr(self.dtype))

--- a/test/test_domains.py
+++ b/test/test_domains.py
@@ -6,7 +6,14 @@ import pickle
 
 import pytest
 
-from funsor.domains import Bint, Real, Reals  # noqa F401
+from funsor.domains import Bint, Real, Reals
+
+
+def test_str():
+    assert str(Bint[3]) == "Bint[3]"
+    assert str(Real) == "Real"
+    assert str(Reals[2]) == "Reals[2]"
+    assert str(Reals[2, 3]) == "Reals[2,3]"
 
 
 @pytest.mark.parametrize(

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -41,13 +41,13 @@ from funsor.util import get_backend
 
 def test_repr():
     data = randn(())
-    assert repr(Tensor(data)) == f"Tensor({str(data)})"
+    assert repr(Tensor(data)) == f"Tensor({repr(data)})"
 
     data = randn((2,))
-    assert repr(Tensor(data)) == f"Tensor({str(data)})"
+    assert repr(Tensor(data)) == f"Tensor({repr(data)})"
 
     data = ops.astype(zeros((2,)), "int64")
-    assert repr(Tensor(data, {}, 3)) == f"Tensor({str(data)}, {{}}, 3)"
+    assert repr(Tensor(data, {}, 3)) == f"Tensor({repr(data)}, {{}}, 3)"
 
 
 @pytest.mark.parametrize("output_shape", [(), (2,), (3, 2)], ids=str)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -39,6 +39,17 @@ from funsor.testing import (
 from funsor.util import get_backend
 
 
+def test_repr():
+    data = randn(())
+    assert repr(Tensor(data)) == f"Tensor({str(data)})"
+
+    data = randn((2,))
+    assert repr(Tensor(data)) == f"Tensor({str(data)})"
+
+    data = ops.astype(zeros((2,)), "int64")
+    assert repr(Tensor(data, {}, 3)) == f"Tensor({str(data)}, {{}}, 3)"
+
+
 @pytest.mark.parametrize("output_shape", [(), (2,), (3, 2)], ids=str)
 @pytest.mark.parametrize("inputs", [(), ("a",), ("a", "b"), ("b", "a", "c")], ids=str)
 def test_quote(output_shape, inputs):


### PR DESCRIPTION
Addresses ugly printing in #509 

I'd like to merge this before #509 so the tutorial looks nice.

## Tested
- [x] unit test for domains
- [x] unit test for tensors