### PR TITLE
Remove github_url link when render tutorial

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = funsor
 SOURCEDIR     = source
@@ -18,3 +18,5 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	git clean -dfx source/examples
+	git clean -dfx source/tutorials

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 makefun
 multipledispatch
-nbsphinx
+nbsphinx==0.8.1
 numpy>=1.7
 opt_einsum>=2.3.2
 pytest>=4.1

--- a/tutorials/named_tensor_notation_i.ipynb
+++ b/tutorials/named_tensor_notation_i.ipynb
@@ -25,6 +25,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install funsor[torch]@git+https://github.com/pyro-ppl/funsor"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -1186,5 +1195,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This remove `github_url` link at the top of a [rendered tutorial](https://funsor.pyro.ai/en/latest/tutorials/named_tensor_notation_i.html). Also, this does
+ raise error if `make docs` throws some warnings
+ clean up temporary examples/tutorials folders after `make docs`
+ add `pip install` statement at the top of the notebook