### PR TITLE
BindReturn type hint for make_funsor

### DIFF
--- a/funsor/factory.py
+++ b/funsor/factory.py
@@ -10,7 +10,15 @@ from functools import singledispatch
 import makefun
 
 from funsor.instrument import debug_logged
-from funsor.terms import Funsor, FunsorMeta, Subs, Variable, eager, to_funsor, substitute
+from funsor.terms import (
+    Funsor,
+    FunsorMeta,
+    Subs,
+    Variable,
+    eager,
+    substitute,
+    to_funsor,
+)
 from funsor.util import as_callable
 
 
@@ -217,7 +225,9 @@ def make_funsor(fn):
             # Bind-and-return variables
             if bind_return is None:
                 bind_return = frozenset(
-                    (arg, arg) for hint, arg in zip(hints, args) if isinstance(hint, BindReturn)
+                    (arg, arg)
+                    for hint, arg in zip(hints, args)
+                    if isinstance(hint, BindReturn)
                 )
 
             # Compute domains of bound variables.
@@ -250,7 +260,6 @@ def make_funsor(fn):
                 elif isinstance(hint, BindReturn):
                     domain = hint(**dependent_args)
                     args[i] = to_funsor(arg.name, domain)
-
 
             # Append bind_return to args
             if bind_return:
@@ -310,18 +319,22 @@ def make_funsor(fn):
             else:
                 result.append(substitute(value, new_alpha_subs))
         if hasattr(self, "bind_return"):
-            result.append(frozenset(
-                (alpha_subs.get(k, k), v) for k, v in self.bind_return.items()
-            ))
+            result.append(
+                frozenset(
+                    (alpha_subs.get(k, k), v) for k, v in self.bind_return.items()
+                )
+            )
         return tuple(result)
 
     if bind_return:
+
         def new_fn(*args, **kwargs):
             args, bind_return = args[:-1], args[-1]
             result = fn(*args)
             if bind_return:
                 result = Subs(result, bind_return)
             return result
+
     else:
         new_fn = fn
 

--- a/funsor/factory.py
+++ b/funsor/factory.py
@@ -217,7 +217,7 @@ def make_funsor(fn):
         bind_return_kwarg = ["bind_return"]
         bind_return_pattern = (frozenset,)
 
-        def new_fn(*args, **kwargs):
+        def new_fn(*args):
             args, bind_return = args[:-1], args[-1]
             result = fn(*args)
             if bind_return:

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -304,7 +304,7 @@ def test_softmax():
     @make_funsor
     def Softmax(
         x: Funsor,
-        ax: BindReturn,
+        ax: BindReturn[lambda ax: ax],
     ) -> Fresh[lambda x: x]:
         y = x - x.reduce(ops.logaddexp, ax)
         return y.exp()

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -11,9 +11,8 @@ from funsor.domains import Array, Bint, Real, Reals
 from funsor.factory import BindReturn, Bound, Fresh, Has, Value, make_funsor, to_funsor
 from funsor.interpretations import reflect
 from funsor.interpreter import reinterpret
-from funsor.optimizer import apply_optimizer
 from funsor.tensor import Tensor
-from funsor.terms import Cat, Funsor, Lambda, Number, eager, lazy
+from funsor.terms import Cat, Funsor, Lambda, Number, eager
 from funsor.testing import assert_close, check_funsor, random_tensor
 from funsor.util import get_backend
 
@@ -303,10 +302,10 @@ def test_matmul_has():
 def test_unroll():
     @make_funsor
     def Unroll(
-        x: Has[{"ax"}],
+        x: Has[{"ax"}],  # noqa: F821
         ax: BindReturn[lambda ax, k: Bint[ax.size - k + 1]],
         k: Value[int],
-        kernel: Fresh[lambda k: Bint[k]]
+        kernel: Fresh[lambda k: Bint[k]],
     ) -> Fresh[lambda x: x]:
         return x(**{ax.name: ax + kernel})
 
@@ -323,7 +322,7 @@ def test_unroll():
 def test_softmax():
     @make_funsor
     def Softmax(
-        x: Has[{"ax"}],
+        x: Has[{"ax"}],  # noqa: F821
         ax: BindReturn[lambda ax: ax],
     ) -> Fresh[lambda x: x]:
         y = x - x.reduce(ops.logaddexp, ax)

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -316,7 +316,7 @@ def test_unroll():
     assert all(bound in y.x.inputs and bound[1:8] == "__BOUND" for bound in y.bound)
     z = reinterpret(y)
     assert isinstance(z, Tensor)
-    check_funsor(z, {"a": Bint[4], "kernel": Bint[2]}, Real)
+    check_funsor(z, {"a": Bint[5 - 2 + 1], "kernel": Bint[2]}, Real)
 
 
 def test_softmax():


### PR DESCRIPTION
Addresses #481.

`BindReturn` type hint is used for binding and returning a variable. For example:

```py
@make_funsor
def Unroll(
    x: Has[{"ax"}],  # noqa: F821
    ax: BindReturn[lambda ax, k: Bint[ax.size - k + 1]],
    k: Value[int],
    kernel: Fresh[lambda k: Bint[k]],
) -> Fresh[lambda x: x]:
    return x(**{ax.name: ax + kernel})

x = random_tensor(OrderedDict(a=Bint[5]))
y = Unroll(x, "a", 2, "kernel")
check_funsor(y, {"a": Bint[5 - 2 + 1], "kernel": Bint[2]}, Real)
```

or

```py
@make_funsor
def Softmax(
    x: Has[{"ax"}],  # noqa: F821
    ax: BindReturn[lambda ax: ax],
) -> Fresh[lambda x: x]:
    y = x - x.reduce(ops.logaddexp, ax)
    return y.exp()

x = random_tensor(OrderedDict(a=Bint[3], b=Bint[4]))
y = Softmax(x, "a")
check_funsor(y, {"a": Bint[3], "b": Bint[4]}, Real)
```