### PR TITLE
Reshape using Variable in Named Tensor tutorial Part 1

### DIFF
--- a/tutorials/named_tensor_notation_i.ipynb
+++ b/tutorials/named_tensor_notation_i.ipynb
@@ -42,7 +42,8 @@
     "\n",
     "import funsor\n",
     "import funsor.ops as ops\n",
-    "from funsor import Number, Tensor\n",
+    "from funsor import Number, Tensor, Variable\n",
+    "from funsor.domains import Bint\n",
     "\n",
     "funsor.set_backend(\"torch\")"
    ]
@@ -943,6 +944,7 @@
     }
    ],
    "source": [
+    "# A(height=Variable(\"height2\", Bint[3]))\n",
     "A(height=\"height2\")"
    ]
   },
@@ -975,9 +977,50 @@
     }
    ],
    "source": [
-    "layer = Tensor(tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]), dtype=9)[\"layer\"]\n",
+    "layer = Variable(\"layer\", Bint[9])\n",
     "\n",
-    "A(height=layer // Number(3, 4), width=layer % Number(3, 4))"
+    "A_layer = A(height=layer // Number(3, 4), width=layer % Number(3, 4))\n",
+    "A_layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$\n",
+    "A_{\\mathsf{\\vphantom{fg}layer}\\rightarrow(\\mathsf{\\vphantom{fg}height},\\mathsf{\\vphantom{fg}width})} = \\mathsf{\\vphantom{fg}height}\n",
+    "\\begin{array}[b]{@{}c@{}}\\mathsf{\\vphantom{fg}width}\n",
+    "\\\\\\begin{bmatrix}\n",
+    "  3 & 1 & 4 \\\\\n",
+    "  1 & 5 & 9 \\\\\n",
+    "  2 & 6 & 5 \\\\\n",
+    "\\end{bmatrix}\\end{array}.\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Tensor(tensor([[3, 1, 4],\n",
+       "               [1, 5, 9],\n",
+       "               [2, 6, 5]]), {'height': Bint[3], 'width': Bint[3]})"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "height = Variable(\"height\", Bint[3])\n",
+    "width = Variable(\"width\", Bint[3])\n",
+    "\n",
+    "A_layer(layer=height * Number(3, 4) + width % Number(3, 4))"
    ]
   },
   {
@@ -1027,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1036,7 +1079,7 @@
        "Tensor(tensor([1, 3, 7]), {'emb': Bint[3]})"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1062,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1074,7 +1117,7 @@
        "               [2, 1, 5]]), {'seq': Bint[4], 'emb': Bint[3]})"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1094,7 +1137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1103,7 +1146,7 @@
        "Tensor(tensor([1, 5, 2, 2]), {'seq': Bint[4]})"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1139,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1148,7 +1191,7 @@
        "Tensor(tensor([3, 4, 5]), {'subseq': Bint[3]})"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
I want to change reshaping in the tutorial to use `Variable` instead of `Tensor`. (Using `Tensor` feels more like indexing rather than reshaping.)

Use

```py
layer = Variable("layer", Bint[9])

A_layer = A(height=layer // Number(3, 4), width=layer % Number(3, 4))
```

instead of

```py
layer = Tensor(tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]), dtype=9)["layer"]

A(height=layer // Number(3, 4), width=layer % Number(3, 4))
```

Also add reshaping back `layer->(height,width)` example:

```py
height = Variable("height", Bint[3])
width = Variable("width", Bint[3])

A_layer(layer=height * Number(3, 4) + width % Number(3, 4))
```