### PR TITLE
Replace `np.bool` with `bool` to silence DeprecationWarning

### DIFF
--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -171,7 +171,7 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
             assert actual.dtype == expected.dtype, msg
 
         assert actual.shape == expected.shape, msg
-        if actual.dtype in (np.int32, np.int64, np.uint8, np.bool):
+        if actual.dtype in (np.int32, np.int64, np.uint8, bool):
             assert (actual == expected).all(), msg
         else:
             actual, expected = np.asarray(actual), np.asarray(expected)


### PR DESCRIPTION
```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```