### PR TITLE
Update to PyTorch 1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install torch==1.8.0+cpu torchvision==0.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         # Keep track of Pyro master branch
         pip install https://github.com/pyro-ppl/pyro/archive/master.zip
         pip install .[test,torch]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,7 +289,7 @@ intersphinx_mapping = {
 # @jpchen's hack to get rtd builder to install latest pytorch
 if "READTHEDOCS" in os.environ:
     os.system(
-        "pip install torch==1.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+        "pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html"
     )
     # pyro needs to be installed after torch so pyro doesnt install the bloated torch-1.0 wheel
     os.system("pip install pyro-ppl")

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -14,10 +14,10 @@ from collections import OrderedDict
 
 import torch
 import torch.utils.data
-from pyro.contrib.examples.util import MNIST
 from torch import nn, optim
 from torch.nn import functional as F
 from torchvision import transforms
+from torchvision.datasets import MNIST
 
 import funsor
 import funsor.ops as ops

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -174,12 +174,12 @@ ops.cat.register(typing.Tuple[torch.Tensor, ...])(torch.cat)
 @ops.cholesky.register(torch.Tensor)
 def _cholesky(x):
     """
-    Like :func:`torch.cholesky` but uses sqrt for scalar matrices.
+    Like :func:`torch.linalg.cholesky` but uses sqrt for scalar matrices.
     Works around https://github.com/pytorch/pytorch/issues/24403 often.
     """
     if x.size(-1) == 1:
         return x.sqrt()
-    return x.cholesky()
+    return torch.linalg.cholesky(x)
 
 
 @ops.cholesky_inverse.register(torch.Tensor)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ filterwarnings = error
     ignore:Cannot memoize Op:UserWarning
     ignore::DeprecationWarning
     ignore:CUDA initialization:UserWarning
-    ignore:cholesky is deprecated:UserWarning
     ignore:floor_divide is deprecated:UserWarning
-    ignore:symeig is deprecated:UserWarning
+    ignore:torch.cholesky is deprecated:UserWarning
+    ignore:torch.symeig is deprecated:UserWarning
     once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,9 @@ filterwarnings = error
     ignore:Cannot memoize Op:UserWarning
     ignore::DeprecationWarning
     ignore:CUDA initialization:UserWarning
+    ignore:cholesky is deprecated:UserWarning
     ignore:floor_divide is deprecated:UserWarning
+    ignore:symeig is deprecated:UserWarning
     once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "typing_extensions",
     ],
     extras_require={
-        "torch": ["pyro-ppl>=1.6.0", "torch>=1.8.0"],
+        "torch": ["pyro-ppl>=1.6.0", "torch>=1.9.0"],
         "jax": ["numpyro>=0.2.4", "jax>=0.1.57", "jaxlib>=0.1.37"],
         "test": [
             "black",
@@ -50,7 +50,7 @@ setup(
             "pytest-xdist==1.27.0",
             "requests",
             "scipy",
-            "torchvision>=0.9.0",
+            "torchvision>=0.10.0",
         ],
         "dev": [
             "black",
@@ -64,7 +64,7 @@ setup(
             "sphinx>=2.0",
             "sphinx-gallery",
             "sphinx_rtd_theme",
-            "torchvision>=0.9.0",
+            "torchvision>=0.10.0",
         ],
     },
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             "flake8",
             "isort>=5.0",
             "pandas",
+            "pillow==8.2.0",  # https://github.com/pytorch/pytorch/issues/61125
             "pyro-api>=0.1.2",
             "pytest==4.3.1",
             "pytest-xdist==1.27.0",
@@ -58,6 +59,7 @@ setup(
             "isort>=5.0",
             "nbsphinx",
             "pandas",
+            "pillow==8.2.0",  # https://github.com/pytorch/pytorch/issues/61125
             "pytest==4.3.1",
             "pytest-xdist==1.27.0",
             "scipy",

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -619,7 +619,7 @@ def test_gaussian_probit_hmm_smoke(exact, jit):
                     loc = init_loc
                     scale_tril = init_scale
                 else:
-                    loc = trans_const + funsor.torch.torch_tensordot(
+                    loc = trans_const + torch.tensordot(
                         trans_coeff, state, 1
                     )
                     scale_tril = noise

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -393,10 +393,13 @@ def test_elbo_plate_plate(backend, outer_dim, inner_dim):
         assert ops.allclose(actual_grad, expected_grad, atol=1e-5)
 
 
-@pytest.mark.parametrize("backend", [
-    xfail_param("pyro", reason="https://github.com/pytorch/pytorch/issues/61096"),
-    "funsor",
-])
+@pytest.mark.parametrize(
+    "backend",
+    [
+        xfail_param("pyro", reason="https://github.com/pytorch/pytorch/issues/61096"),
+        "funsor",
+    ],
+)
 def test_elbo_enumerate_plates_1(backend):
     #  +-----------------+
     #  | a ----> b   M=2 |

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -619,9 +619,7 @@ def test_gaussian_probit_hmm_smoke(exact, jit):
                     loc = init_loc
                     scale_tril = init_scale
                 else:
-                    loc = trans_const + torch.tensordot(
-                        trans_coeff, state, 1
-                    )
+                    loc = trans_const + torch.tensordot(trans_coeff, state, 1)
                     scale_tril = noise
                 state = pyro.sample(
                     "state_{}".format(t),

--- a/test/test_minipyro.py
+++ b/test/test_minipyro.py
@@ -393,7 +393,10 @@ def test_elbo_plate_plate(backend, outer_dim, inner_dim):
         assert ops.allclose(actual_grad, expected_grad, atol=1e-5)
 
 
-@pytest.mark.parametrize("backend", ["pyro", "funsor"])
+@pytest.mark.parametrize("backend", [
+    xfail_param("pyro", reason="https://github.com/pytorch/pytorch/issues/61096"),
+    "funsor",
+])
 def test_elbo_enumerate_plates_1(backend):
     #  +-----------------+
     #  | a ----> b   M=2 |

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -916,6 +916,9 @@ def _numeric_tensordot(x, y, dim):
     if get_backend() == "torch":
         import torch
 
+        if dim == 0:
+            # Work around bug in torch.tensordot(-,-,0).
+            return x.reshape(x.shape + (1,) * y.dim()) * y
         return torch.tensordot(x, y, dim)
     else:
         return np.tensordot(x, y, axes=dim)


### PR DESCRIPTION
- Updates to torch>=1.9
- Replaces torch.cholesky -> torch.linalg.cholesky
- Ignores deprecation errors handled by upstream Pyro
- Works around https://github.com/pytorch/pytorch/issues/61096
- Works around https://github.com/pytorch/pytorch/issues/61125