### PR TITLE
Avoid trivial subs

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -873,8 +873,12 @@ class SubsMeta(FunsorMeta):
 
     def __call__(cls, arg, subs):
         subs = tuple(
-            (k, to_funsor(v, arg.inputs[k])) for k, v in subs if k in arg.inputs
+            (k, to_funsor(v, arg.inputs[k]))
+            for k, v in subs
+            if k in arg.inputs and k is not v
         )
+        if not subs:
+            return arg
         return super().__call__(arg, subs)
 
 


### PR DESCRIPTION
This proposes to avoid any trivial `subs` (do not call `interpret` if all `subs` are trivial).

Trivial subs can arise for example in eager `MarkovProduct` with `step_names = {"prev": "prev", "curr": "curr"}`:

```py
def eager_markov_product(sum_op, prod_op, trans, time, step, step_names):
    ...
    return Subs(result, step_names)
``` 

which can pollute `AdjointTape.tape` under `adjoint` interpretation (#493 #544).