### PR TITLE
Add recipes.forward_filter_backward_rsample()

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Funsor is a tensor-like library for functions and distributions
    :maxdepth: 2
    :caption: Interfaces:
 
+   recipes
    pyro
    distributions
    minipyro

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -1,0 +1,4 @@
+.. automodule:: funsor.recipes
+    :members:
+    :show-inheritance:
+    :member-order: bysource

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -42,6 +42,7 @@ from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     joint,
     montecarlo,
     ops,
+    recipes,
     sum_product,
     terms,
     testing,
@@ -96,6 +97,7 @@ __all__ = [
     "pretty",
     "quote",
     "reals",
+    "recipes",
     "reinterpret",
     "set_backend",
     # 'minipyro',  # TODO: enable when minipyro is backend-agnostic

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -67,7 +67,9 @@ class AdjointTape(Interpretation):
         self._old_interpretation = interpreter.get_interpretation()
         return super().__enter__()
 
-    def adjoint(self, sum_op, bin_op, root, targets=None):
+    def adjoint(self, sum_op, bin_op, root, targets=None, *, batch_vars=frozenset()):
+        # TODO Replace this with root + Constant(...) after #548 merges.
+        root_vars = root.input_vars | batch_vars
 
         zero = to_funsor(ops.UNITS[sum_op])
         one = to_funsor(ops.UNITS[bin_op])
@@ -115,7 +117,9 @@ class AdjointTape(Interpretation):
 
             in_adjs = adjoint_ops(fn, sum_op, bin_op, adjoint_values[output], *inputs)
             for v, adjv in in_adjs:
-                agg_vars = adjv.input_vars - v.input_vars - root.input_vars
+                # Marginalize out message variables that don't appear in recipients.
+                agg_vars = adjv.input_vars - v.input_vars - root_vars
+                assert "particle" not in {var.name for var in agg_vars}  # DEBUG FIXME
                 old_value = adjoint_values[v]
                 adjoint_values[v] = sum_op(old_value, adjv.reduce(sum_op, agg_vars))
 
@@ -129,11 +133,11 @@ class AdjointTape(Interpretation):
         return {target: result[target] for target in targets}
 
 
-def forward_backward(sum_op, bin_op, expr):
+def forward_backward(sum_op, bin_op, expr, *, batch_vars=frozenset()):
     with AdjointTape() as tape:
         # TODO fix traversal order in AdjointTape instead of using stack_reinterpret
         forward = stack_reinterpret(expr)
-    backward = tape.adjoint(sum_op, bin_op, forward)
+    backward = tape.adjoint(sum_op, bin_op, forward, batch_vars=batch_vars)
     return forward, backward
 
 

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -129,11 +129,17 @@ class AdjointTape(Interpretation):
         return {target: result[target] for target in targets}
 
 
-def adjoint(sum_op, bin_op, expr):
+def forward_backward(sum_op, bin_op, expr):
     with AdjointTape() as tape:
         # TODO fix traversal order in AdjointTape instead of using stack_reinterpret
-        root = stack_reinterpret(expr)
-    return tape.adjoint(sum_op, bin_op, root)
+        forward = stack_reinterpret(expr)
+    backward = tape.adjoint(sum_op, bin_op, forward)
+    return forward, backward
+
+
+def adjoint(sum_op, bin_op, expr):
+    forward, backward = forward_backward(sum_op, bin_op, expr)
+    return backward
 
 
 # logaddexp/add

--- a/funsor/approximations.py
+++ b/funsor/approximations.py
@@ -66,7 +66,7 @@ def laplace_approximate_logaddexp(op, model, guide, approx_vars):
 ################################################################################
 # Computations.
 # TODO Consider either making these Funsor methods or making .sample() and
-# .unscaled_sample() singledispatch functions.
+# ._sample() singledispatch functions.
 
 
 @singledispatch

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -102,7 +102,7 @@ class Contraction(Funsor):
             )
         return super().__str__()
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self
@@ -119,7 +119,9 @@ class Contraction(Funsor):
                 # Design choice: we sample over logaddexp reductions, but leave logaddexp
                 # binary choices symbolic.
                 terms = [
-                    term._sample(sampled_vars.intersection(term.inputs), sample_inputs)
+                    term._sample(
+                        sampled_vars.intersection(term.inputs), sample_inputs, rng_key
+                    )
                     for term, rng_key in zip(self.terms, rng_keys)
                 ]
                 return Contraction(self.red_op, self.bin_op, self.reduced_vars, *terms)

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -102,7 +102,7 @@ class Contraction(Funsor):
             )
         return super().__str__()
 
-    def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self
@@ -119,9 +119,7 @@ class Contraction(Funsor):
                 # Design choice: we sample over logaddexp reductions, but leave logaddexp
                 # binary choices symbolic.
                 terms = [
-                    term.unscaled_sample(
-                        sampled_vars.intersection(term.inputs), sample_inputs
-                    )
+                    term._sample(sampled_vars.intersection(term.inputs), sample_inputs)
                     for term, rng_key in zip(self.terms, rng_keys)
                 ]
                 return Contraction(self.red_op, self.bin_op, self.reduced_vars, *terms)
@@ -146,9 +144,7 @@ class Contraction(Funsor):
                     ).append(term)
                 if len(greedy_terms) == 1:
                     term = greedy_terms[0]
-                    terms.append(
-                        term.unscaled_sample(greedy_vars, sample_inputs, rng_keys[0])
-                    )
+                    terms.append(term._sample(greedy_vars, sample_inputs, rng_keys[0]))
                     result = Contraction(
                         self.red_op, self.bin_op, self.reduced_vars, *terms
                     )
@@ -161,9 +157,7 @@ class Contraction(Funsor):
                     term = discrete + gaussian.log_normalizer
                     terms.append(gaussian)
                     terms.append(-gaussian.log_normalizer)
-                    terms.append(
-                        term.unscaled_sample(greedy_vars, sample_inputs, rng_keys[0])
-                    )
+                    terms.append(term._sample(greedy_vars, sample_inputs, rng_keys[0]))
                     result = Contraction(
                         self.red_op, self.bin_op, self.reduced_vars, *terms
                     )
@@ -173,7 +167,7 @@ class Contraction(Funsor):
                     for term in greedy_terms
                 ):
                     sampled_terms = [
-                        term.unscaled_sample(
+                        term._sample(
                             greedy_vars.intersection(term.value.inputs), sample_inputs
                         )
                         for term in greedy_terms
@@ -192,7 +186,7 @@ class Contraction(Funsor):
                             ", ".join(str(type(t)) for t in greedy_terms)
                         )
                     )
-                return result.unscaled_sample(
+                return result._sample(
                     sampled_vars - greedy_vars, sample_inputs, rng_keys[1]
                 )
 

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -170,9 +170,11 @@ class Contraction(Funsor):
                 ):
                     sampled_terms = [
                         term._sample(
-                            greedy_vars.intersection(term.value.inputs), sample_inputs
+                            greedy_vars.intersection(term.value.inputs),
+                            sample_inputs,
+                            rng_key,
                         )
-                        for term in greedy_terms
+                        for term, rng_key in zip(greedy_terms, rng_keys)
                         if isinstance(term, funsor.distribution.Distribution)
                         and not greedy_vars.isdisjoint(term.value.inputs)
                     ]

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -200,7 +200,7 @@ class Delta(Funsor, metaclass=DeltaMeta):
 
         return None  # defer to default implementation
 
-    def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
         return self
 
 

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -200,7 +200,7 @@ class Delta(Funsor, metaclass=DeltaMeta):
 
         return None  # defer to default implementation
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
         return self
 
 

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -206,7 +206,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             inputs.update(x.inputs)
         return log_prob.align(tuple(inputs))
 
-    def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
 
         # note this should handle transforms correctly via distribution_to_data
         raw_dist, value_name, value_output, dim_to_name = self._get_raw_dist()

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -206,7 +206,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             inputs.update(x.inputs)
         return log_prob.align(tuple(inputs))
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
 
         # note this should handle transforms correctly via distribution_to_data
         raw_dist, value_name, value_output, dim_to_name = self._get_raw_dist()

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -688,7 +688,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
         return None  # defer to default implementation
 
-    def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self

--- a/funsor/gaussian.py
+++ b/funsor/gaussian.py
@@ -688,7 +688,7 @@ class Gaussian(Funsor, metaclass=GaussianMeta):
 
         return None  # defer to default implementation
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:
             return self

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -34,15 +34,8 @@ def monte_carlo_integrate(state, log_measure, integrand, reduced_vars):
         sample_options["rng_key"], state.rng_key = jax.random.split(state.rng_key)
 
     sample = log_measure.sample(reduced_vars, state.sample_inputs, **sample_options)
-    if state.sample_inputs:
-        sample -= math.log(sum(v.size for v in state.sample_inputs.values))
     if sample is log_measure:
         return None  # cannot progress
-
-    # FIXME should we also avoid reducing over sample_inputs?
-    reduced_vars |= frozenset(
-        v for v in sample.input_vars if v.name in state.sample_inputs
-    )
 
     return Integrate(sample, integrand, reduced_vars)
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -67,7 +67,9 @@ def extract_samples(discrete_density):
     This is useful for extracting sample tensors from a Monte Carlo
     computation.
     """
-    raise ValueError(f"Could not extract point from {discrete_density} at name {name}")
+    raise ValueError(
+        f"Could not extract support from {type(discrete_density).__name__}"
+    )
 
 
 @extract_samples.register(Delta)

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -53,10 +53,18 @@ def monte_carlo_approximate(state, op, model, guide, approx_vars):
     sample = guide.sample(approx_vars, state.sample_inputs, **sample_options)
     if sample is guide:
         return model  # cannot progress
-    reduced_vars = frozenset(
-        v for v in sample.input_vars if v.name in state.sample_inputs
-    )
-    result = (sample + model - guide).reduce(op, reduced_vars)
+    result = sample + model - guide
+
+    #--------------------------------------------------------------------------
+    # Note: an earlier version of Funsor eagerly reduced here, effectively
+    # implementing Tensor Monte Carlo. Funsor now introduces fresh variables.
+    #
+    # reduced_vars = frozenset(
+    #     v for v in sample.input_vars if v.name in state.sample_inputs
+    # )
+    # result = result.reduce(op, reduced_vars)
+    #--------------------------------------------------------------------------
+
     return result
 
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -55,16 +55,6 @@ def monte_carlo_approximate(state, op, model, guide, approx_vars):
         return model  # cannot progress
     result = sample + model - guide
 
-    #--------------------------------------------------------------------------
-    # Note: an earlier version of Funsor eagerly reduced here, effectively
-    # implementing Tensor Monte Carlo. Funsor now introduces fresh variables.
-    #
-    # reduced_vars = frozenset(
-    #     v for v in sample.input_vars if v.name in state.sample_inputs
-    # )
-    # result = result.reduce(op, reduced_vars)
-    #--------------------------------------------------------------------------
-
     return result
 
 

--- a/funsor/montecarlo.py
+++ b/funsor/montecarlo.py
@@ -34,11 +34,16 @@ def monte_carlo_integrate(state, log_measure, integrand, reduced_vars):
         sample_options["rng_key"], state.rng_key = jax.random.split(state.rng_key)
 
     sample = log_measure.sample(reduced_vars, state.sample_inputs, **sample_options)
+    if state.sample_inputs:
+        sample -= math.log(sum(v.size for v in state.sample_inputs.values))
     if sample is log_measure:
         return None  # cannot progress
+
+    # FIXME should we also avoid reducing over sample_inputs?
     reduced_vars |= frozenset(
         v for v in sample.input_vars if v.name in state.sample_inputs
     )
+
     return Integrate(sample, integrand, reduced_vars)
 
 

--- a/funsor/recipes.py
+++ b/funsor/recipes.py
@@ -18,6 +18,7 @@ def forward_filter_backward_rsample(
     eliminate: FrozenSet[str],
     plates: FrozenSet[str],
     sample_inputs: Dict[str, funsor.domains.Domain] = {},
+    rng_key=None,
 ):
     """
     A forward-filter backward-batched-reparametrized-sample algorithm for use
@@ -31,6 +32,7 @@ def forward_filter_backward_rsample(
     :param plates: A set of names of plates to aggregate.
     :param dict sample_inputs: An optional dict of enclosing sample indices
         over which samples will be drawn in batch.
+    :param rng_key: A random number key for the JAX backend.
     :returns: A pair ``samples:Dict[str, Tensor], log_prob: Tensor`` of samples
         and log density evaluated at each of those samples. If ``sample_inputs``
         is nonempty, both outputs will be batched.
@@ -58,7 +60,7 @@ def forward_filter_backward_rsample(
         )
         log_Z = funsor.optimizer.apply_optimizer(log_Z)
     batch_vars = frozenset(funsor.Variable(k, v) for k, v in sample_inputs.items())
-    with funsor.montecarlo.MonteCarlo(**sample_inputs):
+    with funsor.montecarlo.MonteCarlo(**sample_inputs, rng_key=rng_key):
         log_Z, marginals = funsor.adjoint.forward_backward(
             funsor.ops.logaddexp, funsor.ops.add, log_Z, batch_vars=batch_vars
         )

--- a/funsor/recipes.py
+++ b/funsor/recipes.py
@@ -1,0 +1,70 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Recipes using Funsor
+--------------------
+This module provides a number of high-level algorithms using Funsor.
+
+"""
+
+from typing import Dict, FrozenSet
+
+import funsor
+
+
+def forward_filter_backward_rsample(
+    factors: Dict[str, funsor.Funsor],
+    eliminate: FrozenSet[str],
+    plates: FrozenSet[str],
+    sample_inputs: Dict[str, funsor.domains.Domain] = {},
+):
+    """
+    A forward-filter backward-batched-reparametrized-sample algorithm for use
+    in variational inference. The motivating use case is performing Gaussian
+    tensor variable elimination over structured variational posteriors.
+
+    :param dict factors: A dictionary mapping sample site name to a Funsor
+        factor created at that sample site.
+    :param frozenset: A set of names of latent variables to marginalize and
+        plates to aggregate.
+    :param plates: A set of names of plates to aggregate.
+    :param dict sample_inputs: An optional dict of enclosing sample indices
+        over which samples will be drawn in batch.
+    :returns: A pair ``samples:Dict[str, Tensor], log_prob: Tensor`` of samples
+        and log density evaluated at each of those samples. If ``sample_inputs``
+        is nonempty, both outputs will be batched.
+    :rtype: tuple
+    """
+    # Perform tensor variable elimination.
+    with funsor.interpretations.reflect:
+        log_Z = funsor.sum_product.sum_product(
+            funsor.ops.logaddexp,
+            funsor.ops.add,
+            list(factors.values()),
+            eliminate,
+            plates,
+        )
+        log_Z = funsor.optimizer.apply_optimizer(log_Z)
+    with funsor.montecarlo.MonteCarlo(**sample_inputs):
+        log_Z, marginals = funsor.adjoint.forward_backward(
+            funsor.ops.logaddexp, funsor.ops.add, log_Z
+        )
+
+    # Extract sample tensors.
+    samples = {}
+    for name, factor in factors.items():
+        if name in eliminate:
+            samples.update(funsor.montecarlo.extract_samples(marginals[factor]))
+    assert frozenset(samples) == eliminate - plates
+
+    # Compute log density at each sample.
+    log_prob = -log_Z
+    for f in factors.values():
+        term = f(**samples)
+        plates = eliminate.intersection(term.inputs)
+        term = term.reduce(funsor.ops.add, plates)
+        log_prob += term
+    assert set(log_prob.inputs) == set(sample_inputs)
+
+    return samples, log_prob

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -329,7 +329,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             return Tensor(data, inputs, dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
         assert self.output == Real
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -329,7 +329,7 @@ class Tensor(Funsor, metaclass=TensorMeta):
             return Tensor(data, inputs, dtype)
         return super(Tensor, self).eager_reduce(op, reduced_vars)
 
-    def unscaled_sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
         assert self.output == Real
         sampled_vars = sampled_vars.intersection(self.inputs)
         if not sampled_vars:

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -394,8 +394,9 @@ class Funsor(object, metaclass=FunsorMeta):
         if isinstance(op, ops.ReductionOp):
             if isinstance(op, ops.MeanOp):
                 reduced_vars &= self.input_vars
-                sizes = [v.output.num_elements for v in reduced_vars]
-                scale = 1.0 / reduce(ops.mul, sizes, 1.0)
+                if not reduced_vars:
+                    return self
+                scale = 1 / reduce(ops.mul, [v.output.size for v in reduced_vars], 1)
                 return self.reduce(ops.add, reduced_vars) * scale
             if isinstance(op, ops.VarOp):
                 diff = self - self.reduce(ops.mean, reduced_vars)

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -479,9 +479,9 @@ class Funsor(object, metaclass=FunsorMeta):
         )
         return result
 
-    def _sample(self, sampled_vars, sample_inputs, rng_key=None):
+    def _sample(self, sampled_vars, sample_inputs, rng_key):
         """
-        Internal method to draw an unscaled sample.
+        Internal method to draw samples.
         This should be overridden by subclasses.
         """
         assert self.output == Real

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -460,7 +460,8 @@ class Funsor(object, metaclass=FunsorMeta):
         :param OrderedDict sample_inputs: An optional mapping from variable
             name to :class:`~funsor.domains.Domain` over which samples will
             be batched.
-        :param rng_key: a PRNG state to be used by JAX backend to generate random samples
+        :param rng_key: a PRNG state to be used by JAX backend to generate
+            random samples
         :type rng_key: None or JAX's random.PRNGKey
         """
         assert self.output == Real

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -192,6 +192,11 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
             assert diff < (atol + abs(expected)) * rtol, msg
         elif atol is not None:
             assert diff < atol, msg
+    elif isinstance(actual, dict):
+        assert isinstance(expected, dict)
+        assert set(actual) == set(expected)
+        for k, actual_v in actual.items():
+            assert_close(actual_v, expected[k], atol=atol, rtol=rtol)
     else:
         raise ValueError("cannot compare objects of type {}".format(type(actual)))
 

--- a/test/test_approximations.py
+++ b/test/test_approximations.py
@@ -39,11 +39,6 @@ monte_carlo_10 = MonteCarlo(
     particle=Bint[10],
 )
 particles_10 = frozenset([Variable("particle", Bint[10])])
-monte_carlo_1e6 = MonteCarlo(
-    rng_key=np.array([0, 0], dtype=np.uint32),
-    particle=Bint[int(1e6)],
-)
-particles_1e6 = frozenset([Variable("particle", Bint[int(1e6)])])
 
 
 @pytest.mark.parametrize(
@@ -114,10 +109,7 @@ def test_tensor_linear(approximate):
         q2 = m2.approximate(ops.logaddexp, guide, "x")
     actual = q1 + s * q2
 
-    if approximate == monte_carlo_1e6:
-        actual = actual.reduce(ops.mean, particles_1e6)
-        assert_close(actual, expected, atol=0.1)
-    elif approximate != monte_carlo:
+    if approximate not in (monte_carlo, monte_carlo_10):
         assert_close(actual, expected)
 
 
@@ -129,7 +121,7 @@ def test_tensor_linear(approximate):
         laplace_approximate,
         mean_approximate,
         monte_carlo,
-        monte_carlo_1e6,
+        monte_carlo_10,
     ],
 )
 def test_gaussian_linear(approximate):
@@ -143,10 +135,7 @@ def test_gaussian_linear(approximate):
         q2 = m2.approximate(ops.logaddexp, guide, "x")
     actual = q1 + s * q2
 
-    if approximate == monte_carlo_1e6:
-        actual = actual.reduce(ops.mean, particles_1e6)
-        assert_close(actual, expected, atol=0.1)
-    elif approximate != monte_carlo:
+    if approximate not in (monte_carlo, monte_carlo_10):
         assert_close(actual, expected)
 
 

--- a/test/test_approximations.py
+++ b/test/test_approximations.py
@@ -95,8 +95,8 @@ def test_gaussian_smoke(approximate):
         eager,
         argmax_approximate,
         monte_carlo,
-        monte_carlo_10,
     ],
+    ids=str,
 )
 def test_tensor_linear(approximate):
     m1 = random_tensor(OrderedDict(i=Bint[2], x=Bint[4]))
@@ -109,7 +109,9 @@ def test_tensor_linear(approximate):
         q2 = m2.approximate(ops.logaddexp, guide, "x")
     actual = q1 + s * q2
 
-    if approximate not in (monte_carlo, monte_carlo_10):
+    if approximate == monte_carlo:
+        assert actual.inputs == expected.inputs
+    else:
         assert_close(actual, expected)
 
 
@@ -121,8 +123,8 @@ def test_tensor_linear(approximate):
         laplace_approximate,
         mean_approximate,
         monte_carlo,
-        monte_carlo_10,
     ],
+    ids=str,
 )
 def test_gaussian_linear(approximate):
     m1 = random_gaussian(OrderedDict(i=Bint[2], x=Real))
@@ -135,7 +137,9 @@ def test_gaussian_linear(approximate):
         q2 = m2.approximate(ops.logaddexp, guide, "x")
     actual = q1 + s * q2
 
-    if approximate not in (monte_carlo, monte_carlo_10):
+    if approximate == monte_carlo:
+        assert actual.inputs == expected.inputs
+    else:
         assert_close(actual, expected)
 
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -771,24 +771,24 @@ def _get_stat_diff(
                 sample_value,
                 Variable("value", funsor_dist.inputs["value"]),
                 frozenset(["value"]),
-            ).reduce(ops.add, frozenset(sample_inputs))
+            ).reduce(ops.mean, frozenset(sample_inputs))
             expected_stat = funsor_dist.mean()
         elif statistic == "variance":
             actual_mean = Integrate(
                 sample_value,
                 Variable("value", funsor_dist.inputs["value"]),
                 frozenset(["value"]),
-            ).reduce(ops.add, frozenset(sample_inputs))
+            ).reduce(ops.mean, frozenset(sample_inputs))
             actual_stat = Integrate(
                 sample_value,
                 (Variable("value", funsor_dist.inputs["value"]) - actual_mean) ** 2,
                 frozenset(["value"]),
-            ).reduce(ops.add, frozenset(sample_inputs))
+            ).reduce(ops.mean, frozenset(sample_inputs))
             expected_stat = funsor_dist.variance()
         elif statistic == "entropy":
             actual_stat = -Integrate(
                 sample_value, funsor_dist, frozenset(["value"])
-            ).reduce(ops.add, frozenset(sample_inputs))
+            ).reduce(ops.mean, frozenset(sample_inputs))
             expected_stat = funsor_dist.entropy()
         else:
             raise ValueError("invalid test statistic")
@@ -1187,7 +1187,7 @@ def _assert_conjugate_density_ok(
     expected = Integrate(
         latent_samples, conditional(value=obs).exp(), frozenset(["prior"])
     )
-    expected = expected.reduce(ops.add, frozenset(sample_inputs))
+    expected = expected.reduce(ops.mean, frozenset(sample_inputs))
     actual = (
         (latent + conditional).reduce(ops.logaddexp, set(["prior"]))(value=obs).exp()
     )

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -597,7 +597,8 @@ def test_integrate_variable(int_inputs, real_inputs):
     sampled_log_measure = log_measure.sample(
         reduced_vars, OrderedDict(particle=Bint[100000]), rng_key=rng_key
     )
-    approx = Integrate(sampled_log_measure, integrand, reduced_vars | {"particle"})
+    approx = Integrate(sampled_log_measure, integrand, reduced_vars)
+    approx = approx.reduce(ops.mean, "particle")
     assert isinstance(approx, Tensor)
 
     exact = Integrate(log_measure, integrand, reduced_vars)
@@ -639,7 +640,8 @@ def test_integrate_gaussian(int_inputs, real_inputs):
     sampled_log_measure = log_measure.sample(
         reduced_vars, OrderedDict(particle=Bint[100000]), rng_key=rng_key
     )
-    approx = Integrate(sampled_log_measure, integrand, reduced_vars | {"particle"})
+    approx = Integrate(sampled_log_measure, integrand, reduced_vars)
+    approx = approx.reduce(ops.mean, "particle")
     assert isinstance(approx, Tensor)
 
     exact = Integrate(log_measure, integrand, reduced_vars)

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -606,6 +606,7 @@ def test_integrate_variable(int_inputs, real_inputs):
     assert_close(approx, exact, atol=0.1, rtol=0.1)
 
 
+@pytest.mark.xfail(get_backend() == "jax", reason="numerically unstable in jax backend")
 @pytest.mark.parametrize(
     "int_inputs",
     [

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -8,13 +8,11 @@ from functools import reduce
 import numpy as np
 import pytest
 
-import funsor
 import funsor.ops as ops
 from funsor.cnf import Contraction, GaussianMixture
 from funsor.domains import Bint, Real, Reals
 from funsor.gaussian import BlockMatrix, BlockVector, Gaussian
 from funsor.integrate import Integrate
-from funsor.interpretations import reflect
 from funsor.tensor import Einsum, Tensor, numeric_array
 from funsor.terms import Number, Variable
 from funsor.testing import (

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -24,9 +24,10 @@ from funsor.testing import assert_close, random_tensor
         eager,
         moment_matching,
         MonteCarlo(rng_key=np.array([0, 0], dtype=np.uint32)),
+        MonteCarlo(rng_key=np.array([0, 0], dtype=np.uint32), particle=Bint[10]),
     ],
 )
-def test_integrate(interp):
+def test_integrate_smoke(interp):
     log_measure = random_tensor(OrderedDict([("i", Bint[2]), ("j", Bint[3])]))
     integrand = random_tensor(OrderedDict([("j", Bint[3]), ("k", Bint[4])]))
     with interp:

--- a/test/test_joint.py
+++ b/test/test_joint.py
@@ -347,16 +347,16 @@ def test_reduce_moment_matching_moments():
     with moment_matching:
         approx = gaussian.reduce(ops.logaddexp, "j")
     with MonteCarlo(s=Bint[100000]):
-        actual = Integrate(approx, Number(1.0), "x")
-        expected = Integrate(gaussian, Number(1.0), {"j", "x"})
+        actual = Integrate(approx, Number(1.0), "x").reduce(ops.mean, "s")
+        expected = Integrate(gaussian, Number(1.0), {"j", "x"}).reduce(ops.mean, "s")
         assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
-        actual = Integrate(approx, x, "x")
-        expected = Integrate(gaussian, x, {"j", "x"})
+        actual = Integrate(approx, x, "x").reduce(ops.mean, "s")
+        expected = Integrate(gaussian, x, {"j", "x"}).reduce(ops.mean, "s")
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
-        actual = Integrate(approx, x * x, "x")
-        expected = Integrate(gaussian, x * x, {"j", "x"})
+        actual = Integrate(approx, x * x, "x").reduce(ops.mean, "s")
+        expected = Integrate(gaussian, x * x, {"j", "x"}).reduce(ops.mean, "s")
         assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 

--- a/test/test_recipes.py
+++ b/test/test_recipes.py
@@ -93,7 +93,7 @@ def test_ffbr_1():
         a = pyro.sample("a", dist.Normal(0, 1))
         pyro.sample("b", dist.Normal(a, 1), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"a": Real})),
@@ -120,7 +120,7 @@ def test_ffbr_2():
         b = pyro.sample("b", dist.Normal(0, 1))
         pyro.sample("c", dist.Normal(a, b.exp()), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"a": Real})),
@@ -150,7 +150,7 @@ def test_ffbr_3():
             b = pyro.sample("b", dist.Normal(0, 1))
             pyro.sample("c", dist.Normal(a, b.exp()), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"a": Real})),
@@ -183,7 +183,7 @@ def test_ffbr_4():
             with pyro.plate("j", 3):
                 pyro.sample("e", dist.Normal(c, d.exp()), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"a": Real})),
@@ -222,7 +222,7 @@ def test_ffbr_5():
         d = pyro.sample("d", dist.MultivariateNormal(c, eye(2)))
         pyro.sample("e", dist.MultivariateNormal(d, eye(2)), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"a": Reals[2]})),
@@ -263,7 +263,7 @@ def test_ffbr_intractable_1():
         with i_plate, j_plate:
             pyro.sample("c", dist.Normal(a, b), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"i": Bint[2], "a": Real})),
@@ -295,7 +295,7 @@ def test_ffbr_intractable_2():
             a = pyro.sample("a", dist.Normal(0, 1))
         b = pyro.sample("b", dist.Normal(a.sum(), 1), obs=data)
     """
-    num_samples = 10000
+    num_samples = int(1e5)
 
     factors = {
         "a": random_gaussian(OrderedDict({"i": Bint[2], "a": Real})),

--- a/test/test_recipes.py
+++ b/test/test_recipes.py
@@ -3,11 +3,33 @@
 
 from collections import OrderedDict
 
-import funsor
-from funsor import Bint, Real
-from funsor.recipes import forward_filter_backward_rsample
-from funsor.testing import random_gaussian
+import funsor.ops as ops
+from funsor.domains import Bint, Real
 from funsor.montecarlo import extract_samples
+from funsor.recipes import forward_filter_backward_rsample
+from funsor.testing import assert_close, random_gaussian
+
+
+def get_moments(samples, sample_inputs):
+    reduced_vars = frozenset(sample_inputs)
+    moments = OrderedDict()
+
+    # Compute first moments.
+    diffs = OrderedDict()
+    for name, value in samples.items():
+        mean = value.reduce(ops.mean, reduced_vars)
+        moments[name] = mean
+        diffs[name] = value - mean
+
+    # Compute centered second moments.
+    for i, (name1, diff1) in enumerate(diffs.items()):
+        diff1_ = diff1.reshape((diff1.output.num_elements, 1))
+        for name2, diff2 in list(diffs.items())[:i]:
+            diff_2 = diff2.reshape((1, diff2.output.num_elements))
+            diff12 = diff1_ * diff_2
+            moments[name1, name2] = diff12.reduce(ops.mean, reduced_vars)
+
+    return moments
 
 
 def test_ffbr_1():
@@ -28,7 +50,8 @@ def test_ffbr_1():
     actual_samples, actual_log_prob = forward_filter_backward_rsample(
         factors, eliminate, plates, sample_inputs
     )
-    assert set(actual_samples.inputs) == {"a", "b", "particles"}
+    assert set(actual_samples.inputs) == {"a", "particles"}
+    actual_moments = get_moments(actual_samples, sample_inputs)
 
     # Check log_prob.
     guide = sum(factors.values())
@@ -38,7 +61,9 @@ def test_ffbr_1():
     # Check sample moments.
     joint = sum(factors.values())
     expected_samples = extract_samples(joint.sample(**sample_inputs))
-    assert set(expected_samples.inputs) == {"a", "b", "particles"}
+    assert set(expected_samples.inputs) == {"a", "particles"}
+    expected_moments = get_moments(expected_samples, sample_inputs)
+    assert_close(actual_moments, expected_moments)
 
 
 def test_ffbr_2():
@@ -62,6 +87,7 @@ def test_ffbr_2():
         factors, eliminate, plates, sample_inputs
     )
     assert set(actual_samples.inputs) == {"a", "b", "particles"}
+    actual_moments = get_moments(actual_samples, sample_inputs)
 
     # Check log_prob.
     guide = sum(factors.values())
@@ -72,3 +98,5 @@ def test_ffbr_2():
     joint = sum(factors.values())
     expected_samples = extract_samples(joint.sample(**sample_inputs))
     assert set(expected_samples.inputs) == {"a", "b", "particles"}
+    expected_moments = get_moments(expected_samples, sample_inputs)
+    assert_close(actual_moments, expected_moments)

--- a/test/test_recipes.py
+++ b/test/test_recipes.py
@@ -227,8 +227,8 @@ def test_ffbr_5():
     factors = {
         "a": random_gaussian(OrderedDict({"a": Reals[2]})),
         "b": random_gaussian(OrderedDict({"b": Reals[2], "a": Reals[2]})),
-        "c": random_gaussian(OrderedDict({"c": Reals[2], "c": Reals[2]})),
-        "d": random_gaussian(OrderedDict({"d": Reals[2], "d": Reals[2]})),
+        "c": random_gaussian(OrderedDict({"c": Reals[2], "b": Reals[2]})),
+        "d": random_gaussian(OrderedDict({"d": Reals[2], "c": Reals[2]})),
         "e": random_gaussian(OrderedDict({"d": Reals[2]})),
     }
     eliminate = frozenset(["a", "b", "c", "d"])

--- a/test/test_recipes.py
+++ b/test/test_recipes.py
@@ -3,8 +3,10 @@
 
 from collections import OrderedDict
 
+import pytest
+
 import funsor.ops as ops
-from funsor.domains import Bint, Real
+from funsor.domains import Bint, Real, Reals
 from funsor.montecarlo import extract_samples
 from funsor.recipes import forward_filter_backward_rsample
 from funsor.testing import assert_close, random_gaussian
@@ -46,12 +48,13 @@ def test_ffbr_1():
     }
     eliminate = frozenset(["a", "b"])
     plates = frozenset()
-    sample_inputs = {"particles": Bint[num_samples]}
+    sample_inputs = {"particle": Bint[num_samples]}
+
     actual_samples, actual_log_prob = forward_filter_backward_rsample(
         factors, eliminate, plates, sample_inputs
     )
-    assert set(actual_samples.inputs) == {"a", "particles"}
-    actual_moments = get_moments(actual_samples, sample_inputs)
+    assert set(actual_samples) == {"a"}
+    assert set(actual_samples["a"].inputs) == {"particle"}
 
     # Check log_prob.
     guide = sum(factors.values())
@@ -61,8 +64,8 @@ def test_ffbr_1():
     # Check sample moments.
     joint = sum(factors.values())
     expected_samples = extract_samples(joint.sample(**sample_inputs))
-    assert set(expected_samples.inputs) == {"a", "particles"}
     expected_moments = get_moments(expected_samples, sample_inputs)
+    actual_moments = get_moments(actual_samples, sample_inputs)
     assert_close(actual_moments, expected_moments)
 
 
@@ -82,12 +85,13 @@ def test_ffbr_2():
     }
     eliminate = frozenset(["a", "b"])
     plates = frozenset()
-    sample_inputs = {"particles": Bint[num_samples]}
+    sample_inputs = {"particle": Bint[num_samples]}
     actual_samples, actual_log_prob = forward_filter_backward_rsample(
         factors, eliminate, plates, sample_inputs
     )
-    assert set(actual_samples.inputs) == {"a", "b", "particles"}
-    actual_moments = get_moments(actual_samples, sample_inputs)
+    assert set(actual_samples) == {"a", "b"}
+    assert set(actual_samples["a"].inputs) == {"particle"}
+    assert set(actual_samples["b"].inputs) == {"particle"}
 
     # Check log_prob.
     guide = sum(factors.values())
@@ -97,6 +101,80 @@ def test_ffbr_2():
     # Check sample moments.
     joint = sum(factors.values())
     expected_samples = extract_samples(joint.sample(**sample_inputs))
-    assert set(expected_samples.inputs) == {"a", "b", "particles"}
     expected_moments = get_moments(expected_samples, sample_inputs)
+    actual_moments = get_moments(actual_samples, sample_inputs)
+    assert_close(actual_moments, expected_moments)
+
+
+def test_ffbr_3():
+    """
+    def model(data):
+        a = pyro.sample("a", dist.Normal(0, 1))
+        with pyro.plate("plate", 2):
+            b = pyro.sample("b", dist.Normal(0, 1))
+            c = pyro.sample("c", dist.Normal(a, b.exp()), obs=data)
+    """
+    num_samples = 1000
+
+    factors = {
+        "a": random_gaussian(OrderedDict({"a": Real})),
+        "b": random_gaussian(OrderedDict({"plate": Bint[2], "b": Real})),
+        "c": random_gaussian(OrderedDict({"plate": Bint[2], "a": Real, "b": Real})),
+    }
+    eliminate = frozenset(["a", "b", "plate"])
+    plates = frozenset(["plate"])
+    sample_inputs = {"particle": Bint[num_samples]}
+    actual_samples, actual_log_prob = forward_filter_backward_rsample(
+        factors, eliminate, plates, sample_inputs
+    )
+    assert set(actual_samples) == {"a", "b"}
+    assert set(actual_samples["a"].inputs) == {"particle"}
+    assert set(actual_samples["b"].inputs) == {"plate", "particle"}
+
+    # Check log_prob.
+    guide = sum(factors.values())
+    expected_log_prob = guide(**actual_samples)
+    assert_close(actual_log_prob, expected_log_prob)
+
+    # Check sample moments.
+    joint = sum(factors.values())
+    expected_samples = extract_samples(joint.sample(**sample_inputs))
+    expected_moments = get_moments(expected_samples, sample_inputs)
+    actual_moments = get_moments(actual_samples, sample_inputs)
+    assert_close(actual_moments, expected_moments)
+
+
+@pytest.mark.xfail(reason="TODO handle colliders via Lambda")
+def test_ffbr_4():
+    """
+    def model(data):
+        with pyro.plate("plate", 2):
+            a = pyro.sample("a", dist.Normal(0, 1))
+        b = pyro.sample("b", dist.Normal(a.sum(), 1), obs=data)
+    """
+    num_samples = 1000
+
+    factors = {
+        "a": random_gaussian(OrderedDict({"plate": Bint[2], "a": Real})),
+        "b": random_gaussian(OrderedDict({"a_plate": Reals[2]})),
+    }
+    eliminate = frozenset(["a", "plate"])
+    plates = frozenset(["plate"])
+    sample_inputs = {"particle": Bint[num_samples]}
+    actual_samples, actual_log_prob = forward_filter_backward_rsample(
+        factors, eliminate, plates, sample_inputs
+    )
+    assert set(actual_samples) == {"a"}
+    assert set(actual_samples["a"].inputs) == {"plate", "particle"}
+
+    # Check log_prob.
+    guide = sum(factors.values())
+    expected_log_prob = guide(**actual_samples)
+    assert_close(actual_log_prob, expected_log_prob)
+
+    # Check sample moments.
+    joint = sum(factors.values())
+    expected_samples = extract_samples(joint.sample(**sample_inputs))
+    expected_moments = get_moments(expected_samples, sample_inputs)
+    actual_moments = get_moments(actual_samples, sample_inputs)
     assert_close(actual_moments, expected_moments)

--- a/test/test_recipes.py
+++ b/test/test_recipes.py
@@ -1,0 +1,74 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import OrderedDict
+
+import funsor
+from funsor import Bint, Real
+from funsor.recipes import forward_filter_backward_rsample
+from funsor.testing import random_gaussian
+from funsor.montecarlo import extract_samples
+
+
+def test_ffbr_1():
+    """
+    def model(data):
+        a = pyro.sample("a", dist.Normal(0, 1))
+        b = pyro.sample("b", dist.Normal(a, 1), obs=data)
+    """
+    num_samples = 1000
+
+    factors = {
+        "a": random_gaussian(OrderedDict({"a": Real})),
+        "b": random_gaussian(OrderedDict({"a": Real})),
+    }
+    eliminate = frozenset(["a", "b"])
+    plates = frozenset()
+    sample_inputs = {"particles": Bint[num_samples]}
+    actual_samples, actual_log_prob = forward_filter_backward_rsample(
+        factors, eliminate, plates, sample_inputs
+    )
+    assert set(actual_samples.inputs) == {"a", "b", "particles"}
+
+    # Check log_prob.
+    guide = sum(factors.values())
+    expected_log_prob = guide(**actual_samples)
+    assert_close(actual_log_prob, expected_log_prob)
+
+    # Check sample moments.
+    joint = sum(factors.values())
+    expected_samples = extract_samples(joint.sample(**sample_inputs))
+    assert set(expected_samples.inputs) == {"a", "b", "particles"}
+
+
+def test_ffbr_2():
+    """
+    def model(data):
+        a = pyro.sample("a", dist.Normal(0, 1))
+        b = pyro.sample("b", dist.Normal(0, 1))
+        c = pyro.sample("c", dist.Normal(a, b.exp()), obs=data)
+    """
+    num_samples = 1000
+
+    factors = {
+        "a": random_gaussian(OrderedDict({"a": Real})),
+        "b": random_gaussian(OrderedDict({"b": Real})),
+        "c": random_gaussian(OrderedDict({"a": Real, "b": Real})),
+    }
+    eliminate = frozenset(["a", "b"])
+    plates = frozenset()
+    sample_inputs = {"particles": Bint[num_samples]}
+    actual_samples, actual_log_prob = forward_filter_backward_rsample(
+        factors, eliminate, plates, sample_inputs
+    )
+    assert set(actual_samples.inputs) == {"a", "b", "particles"}
+
+    # Check log_prob.
+    guide = sum(factors.values())
+    expected_log_prob = guide(**actual_samples)
+    assert_close(actual_log_prob, expected_log_prob)
+
+    # Check sample moments.
+    joint = sum(factors.values())
+    expected_samples = extract_samples(joint.sample(**sample_inputs))
+    assert set(expected_samples.inputs) == {"a", "b", "particles"}

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -372,6 +372,7 @@ def test_lognormal_distribution(moment):
     with MonteCarlo(particle=Bint[num_samples]):
         with xfail_if_not_implemented():
             actual = Integrate(log_measure, probe, frozenset(["x"]))
+        actual = actual.reduce(ops.mean, "particle")
 
     _, (loc_data, scale_data) = align_tensors(loc, scale)
     samples = backend_dist.LogNormal(loc_data, scale_data).sample((num_samples,))

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1383,6 +1383,18 @@ def test_reduction(op, event_shape):
             )
 
 
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("event_shape", [(), (4,), (3, 2)], ids=str)
+def test_reduce_reduction(batch_shape, event_shape):
+    x = Tensor(randn(*batch_shape, 5, *event_shape))
+    for name in "abc"[: len(batch_shape)]:
+        x = x[name]
+
+    assert_close(x["i"].reduce(ops.mean, "i"), x.mean(0))
+    assert_close(x["i"].reduce(ops.var, "i"), x.var(0))
+    assert_close(x["i"].reduce(ops.std, "i"), x.std(0))
+
+
 @pytest.mark.parametrize(
     "op",
     [


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro/pull/2929

This implements a multi-sample `forward_filter_backward_rsample()` for use in Pyro's `AutoGaussian` guide.

## Changes

- Modifying the semantics of `MonteCarlo`. These changes preserve semantics of single-sample `MonteCarlo()` but change semantics of `MonteCarlo(particles=Bint[n])` from mean-reducing over `particles` to introducing a new batch dimension over `particles`.
- Changes semantics of `Funsor.sample()` to avoid scaling by numel(sampled_inputs). Correspondingly `.unscaled_sample()` is renamed to `._sample()`.
- Supporting `.reduce(ops.mean, ...)`. This breaks from `.reduce(op, ...)` supporting only associative ops, but this does seem like the cleanest syntax to support `ReductionOp`s over discrete input variables, which will be an important pattern now that the `1/numel` scaling os no longer performed by `.sample()`.
- Adding a new `funsor.recipes` module with high-level algorithms intended for use in both Pyro and NumPyro. The idea so to  maximize test sharing of these recipes by testing all backends in the funsor repo.
- Adding a `batch_vars` arg to `AdjointTape` to support batched backward sample (this might be simplified by #548)
- Factoring out a new `forward_sample()` function from `adjoint()`.

## Tested
- [x] updated existing tests
- [x] add new tests
- [x] ensure this fixes https://github.com/pyro-ppl/pyro/pull/2929