### PR TITLE
Dispatch to `Integrate(Delta, ...)` in `normalize_integrate_contraction`

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -232,6 +232,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             tuple(sample_inputs)
             + tuple(inp for inp in self.inputs if inp in funsor_value.inputs)
         )
+        result = funsor.delta.Delta(value_name, funsor_value)
         if not raw_dist.has_rsample:
             # scaling of dice_factor by num samples should already be handled by Funsor.sample
             raw_log_prob = raw_dist.log_prob(raw_value)
@@ -240,9 +241,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
                 output=self.output,
                 dim_to_name=dim_to_name,
             )
-            result = funsor.delta.Delta(value_name, funsor_value, dice_factor)
-        else:
-            result = funsor.delta.Delta(value_name, funsor_value)
+            result = result + dice_factor
         return result
 
     def enumerate_support(self, expand=False):

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -232,7 +232,6 @@ class Distribution(Funsor, metaclass=DistributionMeta):
             tuple(sample_inputs)
             + tuple(inp for inp in self.inputs if inp in funsor_value.inputs)
         )
-        result = funsor.delta.Delta(value_name, funsor_value)
         if not raw_dist.has_rsample:
             # scaling of dice_factor by num samples should already be handled by Funsor.sample
             raw_log_prob = raw_dist.log_prob(raw_value)
@@ -241,7 +240,9 @@ class Distribution(Funsor, metaclass=DistributionMeta):
                 output=self.output,
                 dim_to_name=dim_to_name,
             )
-            result = result + dice_factor
+            result = funsor.delta.Delta(value_name, funsor_value, dice_factor)
+        else:
+            result = funsor.delta.Delta(value_name, funsor_value)
         return result
 
     def enumerate_support(self, expand=False):

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -102,13 +102,8 @@ def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
         and t.fresh.intersection(reduced_names, integrand.inputs)
     ]
     for delta in delta_terms:
-        integrand = integrand(
-            **{
-                name: point
-                for name, (point, log_density) in delta.terms
-                if name in reduced_names.intersection(integrand.inputs)
-            }
-        )
+        args = delta, integrand, reduced_vars & delta.input_vars
+        integrand = eager.dispatch(Integrate, *args)(*args)
     return normalize_integrate(log_measure, integrand, reduced_vars)
 
 

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -102,7 +102,8 @@ def normalize_integrate_contraction(log_measure, integrand, reduced_vars):
         and t.fresh.intersection(reduced_names, integrand.inputs)
     ]
     for delta in delta_terms:
-        args = delta, integrand, reduced_vars & delta.input_vars
+        delta_fresh = frozenset(Variable(k, delta.inputs[k]) for k in delta.fresh)
+        args = delta, integrand, delta_fresh
         integrand = eager.dispatch(Integrate, *args)(*args)
     return normalize_integrate(log_measure, integrand, reduced_vars)
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1427,7 +1427,7 @@ def test_categorical_event_dim_conversion(batch_shape, event_shape):
 
     name_to_dim = {batch_dim: -1 - i for i, batch_dim in enumerate(batch_dims)}
     rng_key = None if get_backend() == "torch" else np.array([0, 0], dtype=np.uint32)
-    data = actual.sample(frozenset(["value"]), rng_key=rng_key).terms[0].terms[0][1][0]
+    data = actual.sample(frozenset(["value"]), rng_key=rng_key).terms[0][1][0]
 
     actual_log_prob = funsor.to_data(actual(value=data), name_to_dim=name_to_dim)
     expected_log_prob = funsor.to_data(actual, name_to_dim=name_to_dim).log_prob(


### PR DESCRIPTION
Addresses #550 .

`pytest contrib/funsor/` tests pass locally:

```
contrib/funsor/test_enum_funsor.py .........................x...................x.x.....                [ 16%]
contrib/funsor/test_infer_discrete.py ..........................                                        [ 23%]
contrib/funsor/test_named_handlers.py ......                                                            [ 25%]
contrib/funsor/test_pyroapi_funsor.py ................x                                                 [ 30%]
contrib/funsor/test_tmc.py ............................................................................ [ 53%]
............                                                                                            [ 57%]
contrib/funsor/test_valid_models_enum.py ................xxxx....................................       [ 74%]
contrib/funsor/test_valid_models_plate.py ........X.X.X.X................                               [ 83%]
contrib/funsor/test_valid_models_sequential_plate.py .........                                          [ 86%]
contrib/funsor/test_vectorized_markov.py ........................XXXXXXXXXXXX.....x...                  [100%]

============================ 306 passed, 9 xfailed, 16 xpassed in 91.92s (0:01:31) ============================
```