### PR TITLE
Add ops.getslice for complex indexing by int,slice,None,Ellipsis

### DIFF
--- a/funsor/affine.py
+++ b/funsor/affine.py
@@ -61,7 +61,9 @@ def _(fn):
 
 @affine_inputs.register(Unary)
 def _(fn):
-    if fn.op in (ops.neg, ops.sum) or isinstance(fn.op, ops.ReshapeOp):
+    if fn.op in (ops.neg, ops.sum) or isinstance(
+        fn.op, (ops.ReshapeOp, ops.GetsliceOp)
+    ):
         return affine_inputs(fn.arg)
     return frozenset()
 

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -13,6 +13,7 @@ from .op import (
     UNITS,
     BinaryOp,
     Op,
+    OpMeta,
     TransformOp,
     UnaryOp,
     declare_op_types,
@@ -41,6 +42,88 @@ def getitem(lhs, rhs, offset=0):
     if offset == 0:
         return lhs[rhs]
     return lhs[(slice(None),) * offset + (rhs,)]
+
+
+class GetsliceMeta(OpMeta):
+    """
+    Works around slice objects not being hashable.
+    """
+
+    def hash_args_kwargs(cls, args, kwargs):
+        index = args[0] if args else kwargs["index"]
+        if not isinstance(index, tuple):
+            index = (index,)
+        key = tuple(
+            (x.start, x.stop, x.step) if isinstance(x, slice) else x for x in index
+        )
+        return key
+
+
+@UnaryOp.make(metaclass=GetsliceMeta)
+def getslice(x, index=Ellipsis):
+    return x[index]
+
+
+getslice.supported_types = (type(None), type(Ellipsis), int, slice)
+
+
+def parse_ellipsis(index):
+    """
+    Helper to split a slice into parts left and right of Ellipses.
+
+    :param index: A tuple, or other object (None, int, slice, Funsor).
+    :returns: a pair of tuples ``left, right``.
+    :rtype: tuple
+    """
+    if not isinstance(index, tuple):
+        index = (index,)
+    left = []
+    for i, part in enumerate(index):
+        if part is Ellipsis:
+            break
+        left.append(part)
+    right = []
+    for part in reversed(index[i:]):
+        if part is Ellipsis:
+            break
+        right.append(part)
+    right.reverse()
+    return tuple(left), tuple(right)
+
+
+def parse_slice(s, size):
+    """
+    Helper to determine nonnegative integer start, stop, and step of a slice.
+
+    :param slice s: A slice.
+    :param int size: The size of the array being indexed into.
+    :returns: A tuple of nonnegative integers ``start, stop, step``.
+    :rtype: tuple
+    """
+    start = s.start
+    if start is None:
+        start = 0
+    assert isinstance(start, int)
+    if start >= 0:
+        start = min(size, start)
+    else:
+        start = max(0, size + start)
+
+    stop = s.stop
+    if stop is None:
+        stop = size
+    assert isinstance(stop, int)
+    if stop >= 0:
+        stop = min(size, stop)
+    else:
+        stop = max(0, size + stop)
+
+    step = s.step
+    if step is None:
+        step = 1
+    assert isinstance(step, int)
+
+    return start, stop, step
 
 
 abs = UnaryOp.make(_builtin_abs)
@@ -194,6 +277,7 @@ __all__ = [
     "floordiv",
     "ge",
     "getitem",
+    "getslice",
     "gt",
     "invert",
     "le",

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -78,7 +78,9 @@ def parse_ellipsis(index):
     if not isinstance(index, tuple):
         index = (index,)
     left = []
-    for i, part in enumerate(index):
+    i = 0
+    for part in index:
+        i += 1
         if part is Ellipsis:
             break
         left.append(part)
@@ -91,9 +93,24 @@ def parse_ellipsis(index):
     return tuple(left), tuple(right)
 
 
+def normalize_ellipsis(index, size):
+    """
+    Expand Ellipses in an index to fill the given number of dimensions.
+
+    This should satisfy the equation::
+
+        x[i] == x[normalize_ellipsis(i, len(x.shape))]
+    """
+    left, right = parse_ellipsis(index)
+    if len(left) + len(right) > size:
+        raise ValueError(f"Index is too wide: {index}")
+    middle = (slice(None),) * (size - len(left) - len(right))
+    return left + middle + right
+
+
 def parse_slice(s, size):
     """
-    Helper to determine nonnegative integer start, stop, and step of a slice.
+    Helper to determine nonnegative integers (start, stop, step) of a slice.
 
     :param slice s: A slice.
     :param int size: The size of the array being indexed into.

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -859,7 +859,7 @@ def eager_getitem_tensor_tensor(op, lhs, rhs):
     return Tensor(data, inputs, lhs.dtype)
 
 
-@eager.register(Binary, ops.GetsliceOp, Tensor)
+@eager.register(Unary, ops.GetsliceOp, Tensor)
 def eager_getslice_tensor(op, x):
     index = op.defaults["index"]
     if not isinstance(index, tuple):

--- a/funsor/tensor.py
+++ b/funsor/tensor.py
@@ -859,6 +859,16 @@ def eager_getitem_tensor_tensor(op, lhs, rhs):
     return Tensor(data, inputs, lhs.dtype)
 
 
+@eager.register(Binary, ops.GetsliceOp, Tensor)
+def eager_getslice_tensor(op, x):
+    index = op.defaults["index"]
+    if not isinstance(index, tuple):
+        index = (index,)
+    index = (slice(None),) * len(x.inputs) + index
+    data = x.data[index]
+    return Tensor(data, x.inputs, x.dtype)
+
+
 @eager.register(
     Finitary, ops.StackOp, typing.Tuple[typing.Union[(Number, Tensor)], ...]
 )

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -34,7 +34,7 @@ from funsor.interpretations import (
 )
 from funsor.interpreter import PatternMissingError, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
-from funsor.ops.builtin import parse_ellipsis
+from funsor.ops.builtin import normalize_ellipsis, parse_ellipsis
 from funsor.syntax import INFIX_OPERATORS, PREFIX_OPERATORS
 from funsor.typing import GenericTypeMeta, Variadic, deep_type, get_args, get_origin
 from funsor.util import getargspec, lazy_property, pretty, quote
@@ -731,6 +731,11 @@ class Funsor(object, metaclass=FunsorMeta):
         return Binary(ops.ge, self, to_funsor(other))
 
     def __getitem__(self, other):
+        """
+        Helper to desugar into either ops.getitem (for advanced indexing
+        involving Funsors as indices) or ops.getslice (for simple indexing
+        involving only integers, slices, None, and Ellipsis).
+        """
         if type(other) is not tuple:
             if isinstance(other, ops.getslice.supported_types):
                 return ops.getslice(self, other)
@@ -1753,6 +1758,20 @@ def eager_getitem_lambda(op, lhs, rhs):
     return Lambda(lhs.var, expr)
 
 
+@eager.register(Unary, ops.GetsliceOp, Lambda)
+def eager_getslice_lambda(op, x):
+    index = normalize_ellipsis(op.defaults["index"], len(x.shape))
+    head, tail = index[0], index[1:]
+    expr = x.expr
+    if head != slice(None):
+        expr = expr(**{x.var.name: head})
+        if x.var.name not in expr.inputs:
+            return expr
+    if tail:
+        expr = ops.getslice(expr, tail)
+    return Lambda(x.var, expr)
+
+
 class Independent(Funsor):
     """
     Creates an independent diagonal distribution.
@@ -1882,6 +1901,21 @@ def tuple_to_funsor(args, output=None, dim_to_name=None):
 @eager.register(Binary, GetitemOp, Tuple, Number)
 def eager_getitem_tuple(op, lhs, rhs):
     return op(lhs.args, rhs.data)
+
+
+@lazy.register(Unary, ops.GetsliceOp, Tuple)
+@eager.register(Unary, ops.GetsliceOp, Tuple)
+def eager_getslice_tuple(op, x):
+    index = op.defaults["index"]
+    if isinstance(index, tuple):
+        assert len(index) == 1
+        index = index[0]
+    if isinstance(index, int):
+        return op(x.args)
+    elif isinstance(index, slice):
+        return Tuple(op(x.args))
+    else:
+        raise ValueError(index)
 
 
 def _symbolic(inputs, output, fn):

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -34,6 +34,7 @@ from funsor.interpretations import (
 )
 from funsor.interpreter import PatternMissingError, interpret
 from funsor.ops import AssociativeOp, GetitemOp, Op
+from funsor.ops.builtin import parse_ellipsis
 from funsor.syntax import INFIX_OPERATORS, PREFIX_OPERATORS
 from funsor.typing import GenericTypeMeta, Variadic, deep_type, get_args, get_origin
 from funsor.util import getargspec, lazy_property, pretty, quote
@@ -731,22 +732,18 @@ class Funsor(object, metaclass=FunsorMeta):
 
     def __getitem__(self, other):
         if type(other) is not tuple:
+            if isinstance(other, ops.getslice.supported_types):
+                return ops.getslice(self, other)
             other = to_funsor(other, Bint[self.output.shape[0]])
             return Binary(ops.getitem, self, other)
 
+        # Handle complex slicing operations involving no funsors.
+        if all(isinstance(part, ops.getslice.supported_types) for part in other):
+            return ops.getslice(self, other)
+
         # Handle Ellipsis slicing.
         if any(part is Ellipsis for part in other):
-            left = []
-            for part in other:
-                if part is Ellipsis:
-                    break
-                left.append(part)
-            right = []
-            for part in reversed(other):
-                if part is Ellipsis:
-                    break
-                right.append(part)
-            right.reverse()
+            left, right = parse_ellipsis(other)
             missing = len(self.output.shape) - len(left) - len(right)
             assert missing >= 0
             middle = [slice(None)] * missing
@@ -756,6 +753,8 @@ class Funsor(object, metaclass=FunsorMeta):
         result = self
         offset = 0
         for part in other:
+            if part is None:
+                raise NotImplementedError("TODO")
             if isinstance(part, slice):
                 if part != slice(None):
                     raise NotImplementedError("TODO support nontrivial slicing")

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -478,3 +478,20 @@ def iter_subsets(iterable, *, min_size=None, max_size=None):
         max_size = len(iterable)
     for size in range(min_size, max_size + 1):
         yield from itertools.combinations(iterable, size)
+
+
+class DesugarGetitem:
+    """
+    Helper to desugar ``.__getitem__()`` syntax.
+
+    Example::
+
+        >>> desugar_getitem[1:3, ..., None]
+        (slice(1, 3), Ellipsis, None)
+    """
+
+    def __getitem__(self, index):
+        return index
+
+
+desugar_getitem = DesugarGetitem()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -608,6 +608,51 @@ def test_lambda_getitem():
     assert Lambda(i, y) is x
 
 
+class _Slice:
+    def __getitem__(self, index):
+        return index
+
+
+_slice = _Slice()
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        _slice[0],
+        _slice[1, 2],
+        _slice[None],
+        _slice[None, 1],
+        _slice[2, None],
+        _slice[None, 0, None],
+        _slice[:],
+        _slice[:, :],
+        _slice[1:],
+        _slice[1:3],
+        _slice[::2],
+        _slice[1::2],
+        _slice[:, None],
+        _slice[None, :],
+        _slice[None, :, 1],
+        _slice[...],
+        _slice[..., 0],
+        _slice[..., 0, 1],
+        _slice[..., 0, :],
+        _slice[..., None, :],
+        _slice[..., 1:-1:2, :],
+        _slice[:, 0, ...],
+        _slice[:, None, ...],
+        _slice[:, 1:-1:2, ...],
+    ],
+    ids=str,
+)
+def test_getslice_shape(index):
+    data = randn(6, 5, 4, 3)
+    expected = Tensor(data[index])
+    actual = Tensor(data)[index]
+    assert_close(actual, expected)
+
+
 REDUCE_OPS = [
     ops.add,
     ops.mul,

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -629,6 +629,35 @@ def test_stack_lambda(dtype):
     assert z[1] is x2
 
 
+@pytest.mark.parametrize("dtype", ["real", 4, 5])
+def test_stack_lambda_2(dtype):
+
+    x1 = Number(0, dtype)
+    x2 = Number(1, dtype)
+    x3 = Number(2, dtype)
+    x4 = Number(3, dtype)
+    x = [[x1, x2, x3], [x2, x3, x4]]
+
+    i = Variable("i", Bint[3])
+    y1 = Lambda(i, Stack("i", (x1, x2, x3)))
+    y2 = Lambda(i, Stack("i", (x2, x3, x4)))
+
+    j = Variable("j", Bint[2])
+    z = Lambda(j, Stack("j", (y1, y2)))
+    assert not z.inputs
+    assert z.output == Array[dtype, (2, 3)]
+
+    assert z[0] is y1
+    assert z[1] is y2
+    for i, j in itertools.product(range(2), range(3)):
+        assert z[i, j] is x[i][j]
+        assert z[:, j][i] is x[i][j]
+        assert z[i, :][j] is x[i][j]
+        # TODO support advanced slicing of Stack
+        # assert z[0:9, j][i] is x[i][j]
+        # assert z[i, 0:9][j] is x[i][j]
+
+
 def test_funsor_tuple():
     x = Number(1, 3)
     y = Number(2.5, "real")

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -643,6 +643,10 @@ def test_funsor_tuple():
     assert xyz[0] is x
     assert xyz[1] is y
     assert xyz[2] is z
+    assert xyz[:] is xyz
+    assert xyz[1:] is Tuple((y, z))
+    assert xyz[:2] is Tuple((x, y))
+    assert xyz[::2] is Tuple((x, z))
 
     x1, y1, z1 = xyz
     assert x1 is x


### PR DESCRIPTION
Addresses #556
Blocking #553 

This adds `ops.getslice` to perform fancy slice operations like `x[..., 0, ::2, None, :]`, in particular supporting nontrivial slicing, and supporting unsqueezing via None. These fancier slicing ops will be needed for symbolic Gaussians #556. Note this now distinguishes between `ops.getitem` which supports "advanced indexing" where funsors can appear in the index, from `ops.getslice` which supports only indexing of ground values. Numpy distinguishes semantics of these two types of indexing, and it is much easier to fully implement ground indexing (which I believe this PR does for `ops.getitem`).

## Tested
- [x] unit tests
- [x] pass existing tests