### PR TITLE
Replace the deprecated index_update

### DIFF
--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -286,7 +286,7 @@ def _safesub(x, y):
 
 @ops.scatter.register(array, tuple, array)
 def _scatter(dest, indices, src):
-    return index_update(dest, indices, src)
+    return np.asarray(dest).at(indices).set(src)
 
 
 @ops.stack.register(typing.Tuple[typing.Union[array + (int, float)], ...])

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -285,7 +285,7 @@ def _safesub(x, y):
 
 @ops.scatter.register(array, tuple, array)
 def _scatter(dest, indices, src):
-    return np.asarray(dest).at(indices).set(src)
+    return np.asarray(dest).at[indices].set(src)
 
 
 @ops.stack.register(typing.Tuple[typing.Union[array + (int, float)], ...])

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -9,7 +9,6 @@ import numpy as onp
 from jax import lax
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
-from jax.ops import index_update
 from jax.scipy.linalg import cho_solve, solve_triangular
 from jax.scipy.special import expit, gammaln, logsumexp
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     extras_require={
         "torch": ["pyro-ppl>=1.6.0", "torch>=1.9.0"],
-        "jax": ["numpyro>=0.2.4", "jax>=0.1.57", "jaxlib>=0.1.37"],
+        "jax": ["numpyro>=0.3.0", "jax>=0.1.73", "jaxlib>=0.1.51"],
         "test": [
             "black",
             "flake8",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     extras_require={
         "torch": ["pyro-ppl>=1.6.0", "torch>=1.9.0"],
-        "jax": ["numpyro>=0.3.0", "jax>=0.1.73", "jaxlib>=0.1.51"],
+        "jax": ["numpyro>=0.7.0", "jax>=0.2.13", "jaxlib>=0.1.65"],
         "test": [
             "black",
             "flake8",


### PR DESCRIPTION
`index_update` is deprecated in favor of `src.at(indices).set(desc)`. See [its docs](https://jax.readthedocs.io/en/latest/_autosummary/jax.ops.index_update.html#jax.ops.index_update)