### PR TITLE
Optimize ops.triangular_solve() for 1x1 matrices

### DIFF
--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -376,16 +376,6 @@ ops.stack.register(typing.Tuple[torch.Tensor, ...])(torch.stack)
 
 @ops.triangular_solve.register(torch.Tensor, torch.Tensor)
 def _triangular_solve(x, y, upper=False, transpose=False):
-    from timeit import default_timer
-
-    from funsor.instrument import COUNTERS
-
-    key = tuple(x.shape), tuple(y.shape)
-    start = default_timer()
     if y.size(-1) == 1:
-        result = x / y
-    else:
-        result = x.triangular_solve(y, upper, transpose).solution
-    COUNTERS["triangular_solve.time"][key] += default_timer() - start
-    COUNTERS["triangular_solve.count"][key] += 1
-    return result
+        return x / y
+    return x.triangular_solve(y, upper, transpose).solution

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -376,4 +376,16 @@ ops.stack.register(typing.Tuple[torch.Tensor, ...])(torch.stack)
 
 @ops.triangular_solve.register(torch.Tensor, torch.Tensor)
 def _triangular_solve(x, y, upper=False, transpose=False):
-    return x.triangular_solve(y, upper, transpose).solution
+    from timeit import default_timer
+
+    from funsor.instrument import COUNTERS
+
+    key = tuple(x.shape), tuple(y.shape)
+    start = default_timer()
+    if y.size(-1) == 1:
+        result = x / y
+    else:
+        result = x.triangular_solve(y, upper, transpose).solution
+    COUNTERS["triangular_solve.time"][key] += default_timer() - start
+    COUNTERS["triangular_solve.count"][key] += 1
+    return result

--- a/test/torch/test_ops.py
+++ b/test/torch/test_ops.py
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import funsor.ops as ops
+from funsor.testing import assert_close
+from funsor.util import get_backend
+
+pytestmark = pytest.mark.skipif(get_backend() != "torch", reason="torch specific")
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("m", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5])
+def test_triangular_solve(batch_shape, m, n):
+    import torch
+
+    b = torch.randn(batch_shape + (n, m))
+    A = torch.randn(batch_shape + (n, n)).tril_()
+    A.diagonal(dim1=-2, dim2=-1).abs_()
+
+    actual = ops.triangular_solve(b, A, upper=False)
+    expected = torch.triangular_solve(b, A, upper=False).solution
+    assert_close(actual, expected)


### PR DESCRIPTION
Addresses #559 

This adds a scalar special case for the torch implementation of `ops.triangular_solve`. This op is frequently used in Gaussian funsor variable elimination, and the scalar case is very common.

## Profiling results
I've tested on both a profiling jig (big speedup!) and the full [pyro-cov model](https://github.com/broadinstitute/pyro-cov/blob/9496e8d2d78239950f58470afd516b9dd9e5d594/pyrocov/mutrans.py#L400) (minor speedup). The jig is invoked via
```sh
FUNSOR_PROFILE=100 python -m tests.infer.autoguide.test_gaussian -s 700 -n 10 --cuda --no-jit
```
The full model is invoked with the jit enabled.

**Before:** full model speed = 11.14 iters/sec

<details>

```
     count triangular_solve(b.shape, A.shape)
       682 total
       341 ((1, 1), (1, 1))
        88 ((701, 702, 1, 1), (701, 702, 1, 1))
        88 ((702, 1, 1), (702, 1, 1))
        44 ((50, 701, 1, 1), (50, 701, 1, 1))
        44 ((703, 1), (703, 703))
        22 ((701, 702, 1, 2), (701, 702, 1, 1))
        11 ((50, 701, 1, 2), (50, 701, 1, 1))
        11 ((702, 1, 2), (702, 1, 1))
        11 ((702, 1, 705), (702, 1, 1))
        11 ((703, 3), (703, 703))
        11 ((1, 2), (1, 1))
```
```
      time triangular_solve(b.shape, A.shape)
  1.359707 total
  0.889114 ((702, 1, 705), (702, 1, 1))
  0.213148 ((701, 702, 1, 1), (701, 702, 1, 1))
  0.125360 ((702, 1, 1), (702, 1, 1))
  0.050415 ((1, 1), (1, 1))
  0.048711 ((701, 702, 1, 2), (701, 702, 1, 1))
  0.013856 ((50, 701, 1, 1), (50, 701, 1, 1))
  0.009279 ((703, 1), (703, 703))
  0.003506 ((50, 701, 1, 2), (50, 701, 1, 1))
  0.002740 ((703, 3), (703, 703))
  0.001800 ((702, 1, 2), (702, 1, 1))
  0.001777 ((1, 2), (1, 1))
```

</details>

**After:** full model speed = 11.75 iters/sec

<details>

```
     count triangular_solve(b.shape, A.shape)
       682 total
       341 ((1, 1), (1, 1))
        88 ((701, 702, 1, 1), (701, 702, 1, 1))
        88 ((702, 1, 1), (702, 1, 1))
        44 ((50, 701, 1, 1), (50, 701, 1, 1))
        44 ((703, 1), (703, 703))
        22 ((701, 702, 1, 2), (701, 702, 1, 1))
        11 ((50, 701, 1, 2), (50, 701, 1, 1))
        11 ((702, 1, 2), (702, 1, 1))
        11 ((702, 1, 705), (702, 1, 1))
        11 ((703, 3), (703, 703))
        11 ((1, 2), (1, 1))
```
```
      time triangular_solve(b.shape, A.shape)
  0.035639 total
  0.012077 ((1, 1), (1, 1))
  0.009859 ((703, 1), (703, 703))
  0.003245 ((702, 1, 1), (702, 1, 1))
  0.003106 ((701, 702, 1, 1), (701, 702, 1, 1))
  0.003078 ((703, 3), (703, 703))
  0.001585 ((50, 701, 1, 1), (50, 701, 1, 1))
  0.000910 ((701, 702, 1, 2), (701, 702, 1, 1))
  0.000463 ((702, 1, 705), (702, 1, 1))
  0.000459 ((50, 701, 1, 2), (50, 701, 1, 1))
  0.000438 ((702, 1, 2), (702, 1, 1))
  0.000419 ((1, 2), (1, 1))
```

</details>

## Tested
- [x] added a unit test