### PR TITLE
Improve pretty printing

### DIFF
--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -254,11 +254,8 @@ class Dependent(metaclass=DependentMeta):
 ################################################################################
 # Function registration
 
-
-@quote.register(BintType)
-@quote.register(RealsType)
-def _(arg, indent, out):
-    out.append((indent, repr(arg)))
+quote.register_repr(BintType)
+quote.register_repr(RealsType)
 
 
 @functools.singledispatch

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -23,6 +23,8 @@ def _quote(x, indent, out):
     """
     Work around JAX's DeviceArray not supporting reproducible repr.
     """
-    out.append(
-        (indent, "np.array({}, dtype=np.{})".format(repr(x.copy().tolist()), x.dtype))
-    )
+    if x.size >= quote.printoptions["threshold"]:
+        data = "..." + " x ".join(str(d) for d in x.shape) + "..."
+    else:
+        data = repr(x.copy().tolist())
+    out.append((indent, f"np.array({data}, dtype=np.{x.dtype})"))

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -316,8 +316,8 @@ class Funsor(object, metaclass=FunsorMeta):
     def quote(self):
         return quote(self)
 
-    def pretty(self, maxlen=40):
-        return pretty(self, maxlen=maxlen)
+    def pretty(self, *args, **kwargs):
+        return pretty(self, *args, **kwargs)
 
     def __contains__(self, item):
         raise TypeError

--- a/funsor/torch/__init__.py
+++ b/funsor/torch/__init__.py
@@ -23,7 +23,11 @@ def _quote(x, indent, out):
     """
     Work around PyTorch not supporting reproducible repr.
     """
-    out.append((indent, "torch.tensor({}, dtype={})".format(repr(x.tolist()), x.dtype)))
+    if x.numel() >= quote.printoptions["threshold"]:
+        data = "..." + " x ".join(str(int(d)) for d in x.shape) + "..."
+    else:
+        data = repr(x.tolist())
+    out.append((indent, f"torch.tensor({data}, dtype={x.dtype})"))
 
 
 @to_funsor.register(ProvenanceTensor)

--- a/test/test_tracer.py
+++ b/test/test_tracer.py
@@ -117,7 +117,6 @@ def test_sum_product():
         with reflect:
             expr = sum_product(ops.logaddexp, ops.add, factors, eliminate, plates)
             expr = apply_optimizer(expr)
-        print(f"DEBUG\n{expr.pretty()}")
         expr = reinterpret(expr)
         return expr.data
 


### PR DESCRIPTION
This makes a number of improvements to `funsor.util.pretty()` and `Funsor.pretty()`. New options conform to the [np.set_printoptions()](https://numpy.org/doc/stable/reference/generated/numpy.set_printoptions.html#numpy.set_printoptions) interface.

- renames `maxlen` -> `linewidth` and changes default to 75 (as in numpy)
- adds a `threshold` parameter to avoid printing large arrays (as in numpy)
- when arrays are summarized, prints the array shape rather than contents
- optimizes printing of tuples of short objects, specifically aimed at cleaner `.inputs`

**Example:** this large contraction failed to print before this PR due to large tensor sizes

<details>

```
(Pdb) print(log_Z.pretty(1000,0))
Contraction(ops.null, ops.add,
 frozenset(),
 (Contraction(ops.logaddexp, ops.add,
   frozenset({Variable('rate_loc_scale__BOUND_13', Real)}),
   (Gaussian(
   │ torch.tensor(...1..., dtype=torch.float32),
   │ torch.tensor(...1 x 1..., dtype=torch.float32),
   │ (('rate_loc_scale__BOUND_13', Real),)),
   │Contraction(ops.logaddexp, ops.add,
   │ frozenset({Variable('rate_scale__BOUND_14', Real)}),
   │ (Gaussian(
   │   torch.tensor(...1..., dtype=torch.float32),
   │   torch.tensor(...1 x 1..., dtype=torch.float32),
   │   (('rate_scale__BOUND_14', Real),)),
   │  Contraction(ops.logaddexp, ops.add,
   │   frozenset({Variable('coef__BOUND_12', Reals[2367])}),
   │   (Gaussian(
   │   │ torch.tensor(...2367..., dtype=torch.float32),
   │   │ torch.tensor(...2367 x 2367..., dtype=torch.float32),
   │   │ (('coef__BOUND_12', Reals[2367]),)),
   │   │Contraction(ops.add, ops.null,
   │   │ frozenset({Variable('strain__BOUND_11', Bint[1343])}),
   │   │ (Contraction(ops.logaddexp, ops.add,
   │   │   frozenset({Variable('rate_loc__BOUND_10', Real)}),
   │   │   (Gaussian(
   │   │   │ torch.tensor(...1343 x 2369..., dtype=torch.float32),
   │   │   │ torch.tensor(...1343 x 2369 x 2369..., dtype=torch.float32),
   │   │   │ (('strain__BOUND_11', Bint[1343]),
   │   │   │  ('rate_loc__BOUND_10', Real),
   │   │   │  ('rate_loc_scale__BOUND_13', Real),
   │   │   │  ('coef__BOUND_12', Reals[2367]),)),
   │   │   │Contraction(ops.add, ops.null,
   │   │   │ frozenset({Variable('place__BOUND_4', Bint[1372])}),
   │   │   │ (Contraction(ops.logaddexp, ops.null,
   │   │   │   frozenset({Variable('rate__BOUND_3', Real)}),
   │   │   │   (Gaussian(
   │   │   │   │ torch.tensor(...1372 x 1343 x 3..., dtype=torch.float32),
   │   │   │   │ torch.tensor(...1372 x 1343 x 3 x 3..., dtype=torch.float32),
   │   │   │   │ (('place__BOUND_4', Bint[1372]),
   │   │   │   │  ('strain__BOUND_11', Bint[1343]),
   │   │   │   │  ('rate__BOUND_3', Real),
   │   │   │   │  ('rate_scale__BOUND_14', Real),
   │   │   │   │  ('rate_loc__BOUND_10', Real),)),)),)),)),)),)),)),)),
  Contraction(ops.null, ops.add,
   frozenset(),
   (Contraction(ops.logaddexp, ops.add,
   │ frozenset({Variable('pois_loc__BOUND_16', Real)}),
   │ (Gaussian(
   │   torch.tensor(...1..., dtype=torch.float32),
   │   torch.tensor(...1 x 1..., dtype=torch.float32),
   │   (('pois_loc__BOUND_16', Real),)),
   │  Contraction(ops.logaddexp, ops.add,
   │   frozenset({Variable('pois_scale__BOUND_15', Real)}),
   │   (Gaussian(
   │   │ torch.tensor(...1..., dtype=torch.float32),
   │   │ torch.tensor(...1 x 1..., dtype=torch.float32),
   │   │ (('pois_scale__BOUND_15', Real),)),
   │   │Contraction(ops.add, ops.null,
   │   │ frozenset({Variable('place__BOUND_6', Bint[1372]), Variable('time__BOUND_7', Bint[49])}),
   │   │ (Contraction(ops.logaddexp, ops.null,
   │   │   frozenset({Variable('pois__BOUND_5', Real)}),
   │   │   (Gaussian(
   │   │   │ torch.tensor(...49 x 1372 x 3..., dtype=torch.float32),
   │   │   │ torch.tensor(...49 x 1372 x 3 x 3..., dtype=torch.float32),
   │   │   │ (('time__BOUND_7', Bint[49]),
   │   │   │  ('place__BOUND_6', Bint[1372]),
   │   │   │  ('pois__BOUND_5', Real),
   │   │   │  ('pois_loc__BOUND_16', Real),
   │   │   │  ('pois_scale__BOUND_15', Real),)),)),)),)),)),
   │Contraction(ops.logaddexp, ops.add,
   │ frozenset({Variable('init_loc_scale__BOUND_17', Real)}),
   │ (Gaussian(
   │   torch.tensor(...1..., dtype=torch.float32),
   │   torch.tensor(...1 x 1..., dtype=torch.float32),
   │   (('init_loc_scale__BOUND_17', Real),)),
   │  Contraction(ops.logaddexp, ops.add,
   │   frozenset({Variable('init_scale__BOUND_18', Real)}),
   │   (Gaussian(
   │   │ torch.tensor(...1..., dtype=torch.float32),
   │   │ torch.tensor(...1 x 1..., dtype=torch.float32),
   │   │ (('init_scale__BOUND_18', Real),)),
   │   │Contraction(ops.add, ops.null,
   │   │ frozenset({Variable('strain__BOUND_9', Bint[1343])}),
   │   │ (Contraction(ops.logaddexp, ops.add,
   │   │   frozenset({Variable('init_loc__BOUND_8', Real)}),
   │   │   (Gaussian(
   │   │   │ torch.tensor(...1343 x 2..., dtype=torch.float32),
   │   │   │ torch.tensor(...1343 x 2 x 2..., dtype=torch.float32),
   │   │   │ (('strain__BOUND_9', Bint[1343]),
   │   │   │  ('init_loc__BOUND_8', Real),
   │   │   │  ('init_loc_scale__BOUND_17', Real),)),
   │   │   │Contraction(ops.add, ops.null,
   │   │   │ frozenset({Variable('place__BOUND_2', Bint[1372])}),
   │   │   │ (Contraction(ops.logaddexp, ops.null,
   │   │   │   frozenset({Variable('init__BOUND_1', Real)}),
   │   │   │   (Gaussian(
   │   │   │   │ torch.tensor(...1372 x 1343 x 3..., dtype=torch.float32),
   │   │   │   │ torch.tensor(...1372 x 1343 x 3 x 3..., dtype=torch.float32),
   │   │   │   │ (('place__BOUND_2', Bint[1372]),
   │   │   │   │  ('strain__BOUND_9', Bint[1343]),
   │   │   │   │  ('init__BOUND_1', Real),
   │   │   │   │  ('init_scale__BOUND_18', Real),
   │   │   │   │  ('init_loc__BOUND_8', Real),)),)),)),)),)),)),)),)),))
```

</details>

## Tested
- [x] quote is covered by existing tests
- [x] manually examined some large strings