### PR TITLE
Support funsors in pprint module

### DIFF
--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -38,7 +38,7 @@ from funsor.ops import AssociativeOp, GetitemOp, Op
 from funsor.ops.builtin import normalize_ellipsis, parse_ellipsis, parse_slice
 from funsor.syntax import INFIX_OPERATORS, PREFIX_OPERATORS
 from funsor.typing import GenericTypeMeta, Variadic, deep_type, get_args, get_origin
-from funsor.util import getargspec, lazy_property, pretty, quote
+from funsor.util import getargspec, lazy_property, pretty, quote, register_pprint
 
 from . import instrument, interpreter, ops
 
@@ -182,7 +182,8 @@ class FunsorMeta(GenericTypeMeta):
     """
 
     def __init__(cls, name, bases, dct):
-        super(FunsorMeta, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
+        register_pprint(cls)
         if not cls.__args__:
             cls._ast_fields = getargspec(cls.__init__)[0][1:]
             cls._cons_cache = WeakValueDictionary()

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+import pprint
 from collections import OrderedDict
 from functools import reduce
 
@@ -211,6 +212,9 @@ def test_smoke(expr, expected_type):
 
     result = eval(expr)
     assert isinstance(result, expected_type)
+
+    print("Pretty:")
+    pprint.pprint(result)
 
 
 @pytest.mark.parametrize(

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -5,6 +5,7 @@ import copy
 import io
 import itertools
 import pickle
+import pprint
 import typing
 from collections import OrderedDict
 from functools import reduce
@@ -147,6 +148,15 @@ EXPR_STRINGS = [
     "Cat('i', (Stack('i', (Number(0),)), Stack('i', (Number(1), Number(2)))))",
     "Stack('t', (Number(1), Variable('x', Real))).reduce(ops.logaddexp, 't')",
 ]
+
+
+@pytest.mark.parametrize("expr", EXPR_STRINGS)
+def test_pprint_smoke(expr):
+    x = eval(expr)
+    print("Pretty:")
+    pprint.pprint(x)
+    pprint.pprint([x])
+    pprint.pprint({"foo": x})
 
 
 @pytest.mark.parametrize("expr", EXPR_STRINGS)


### PR DESCRIPTION
This adds [pprint](https://docs.python.org/3/library/pprint.html) support for Funsors, enabling the use of `pp my_funsor` in pdb, e.g.
```
(Pdb) pp log_Z
Contraction(ops.logaddexp, ops.add,
 frozenset({Variable('a__BOUND_6', Real)}),
 (Gaussian(
   torch.tensor(...1..., dtype=torch.float32),
   torch.tensor(...1 x 1..., dtype=torch.float32),
   (('a__BOUND_6', Real),)),
  Contraction(ops.logaddexp, ops.add,
   frozenset({Variable('b__BOUND_5', Real)}),
   (Gaussian(
     torch.tensor(...1..., dtype=torch.float32),
     torch.tensor(...1 x 1..., dtype=torch.float32),
     (('b__BOUND_5', Real),)),
    Contraction(ops.add, ops.null,
     frozenset({Variable('i__BOUND_4', Bint[2])}),
     (Contraction(ops.logaddexp, ops.add,
       frozenset({Variable('c__BOUND_2', Real)}),
       (Gaussian(
         torch.tensor(...2 x 2..., dtype=torch.float32),
         torch.tensor(...2 x 2 x 2..., dtype=torch.float32),
         (('i__BOUND_4', Bint[2]),
          ('a__BOUND_6', Real),
          ('c__BOUND_2', Real),)),
        Contraction(ops.logaddexp, ops.add,
         frozenset({Variable('d__BOUND_3', Real)}),
         (Gaussian(
           torch.tensor(...2 x 2..., dtype=torch.float32),
           torch.tensor(...2 x 2 x 2..., dtype=torch.float32),
           (('i__BOUND_4', Bint[2]),
            ('b__BOUND_5', Real),
            ('d__BOUND_3', Real),)),
          Contraction(ops.add, ops.null,
           frozenset({Variable('j__BOUND_1', Bint[3])}),
           (Gaussian(
             torch.tensor(...2 x 3 x 2..., dtype=torch.float32),
             torch.tensor(...2 x 3 x 2 x 2..., dtype=torch.float32),
             (('i__BOUND_4', Bint[2]),
              ('j__BOUND_1', Bint[3]),
              ('c__BOUND_2', Real),
              ('d__BOUND_3', Real),)),)),)),)),)),)),))
```
Note that while the pprint module is extensible, the extension interface is private, so we may need to update this in a future Python version. It appears this should work at least through Python 3.10

## Tested
- [x] added smoke tests
- [x] inspected results in a debugger