### PR TITLE
Importance funsor

### DIFF
--- a/funsor/constant.py
+++ b/funsor/constant.py
@@ -10,6 +10,7 @@ from funsor.terms import (
     Binary,
     Funsor,
     FunsorMeta,
+    Importance,
     Number,
     Reduce,
     Unary,
@@ -165,7 +166,7 @@ def eager_binary_constant_constant(op, lhs, rhs):
     return op(lhs.arg, rhs.arg)
 
 
-@eager.register(Binary, ops.BinaryOp, Constant, (Number, Tensor))
+@eager.register(Binary, ops.BinaryOp, Constant, (Importance, Number, Tensor))
 def eager_binary_constant_tensor(op, lhs, rhs):
     const_inputs = OrderedDict(
         (k, v) for k, v in lhs.const_inputs.items() if k not in rhs.inputs
@@ -175,7 +176,7 @@ def eager_binary_constant_tensor(op, lhs, rhs):
     return op(lhs.arg, rhs)
 
 
-@eager.register(Binary, ops.BinaryOp, (Number, Tensor), Constant)
+@eager.register(Binary, ops.BinaryOp, (Importance, Number, Tensor), Constant)
 def eager_binary_tensor_constant(op, lhs, rhs):
     const_inputs = OrderedDict(
         (k, v) for k, v in rhs.const_inputs.items() if k not in lhs.inputs

--- a/funsor/delta.py
+++ b/funsor/delta.py
@@ -145,15 +145,15 @@ class Delta(Funsor, metaclass=DeltaMeta):
                     new_terms.append((value.name, (point, log_density)))
                     continue
 
-                if not any(
-                    d.dtype == "real"
-                    for side in (value, point)
-                    for d in side.inputs.values()
-                ):
-                    dtype = get_default_dtype()
-                    is_equal = ops.astype((value == point).all(), dtype)
-                    log_densities.append(is_equal.log() + log_density)
-                    continue
+                #  if not any(
+                #      d.dtype == "real"
+                #      for side in (value, point)
+                #      for d in side.inputs.values()
+                #  ):
+                dtype = get_default_dtype()
+                is_equal = ops.astype((value == point).all(), dtype)
+                log_densities.append(is_equal.log() + log_density)
+                continue
 
                 # Try to invert the substitution.
                 soln = solve(value, point)

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -235,12 +235,21 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         if not raw_dist.has_rsample:
             # scaling of dice_factor by num samples should already be handled by Funsor.sample
             raw_log_prob = raw_dist.log_prob(raw_value)
-            dice_factor = to_funsor(
-                raw_log_prob - ops.detach(raw_log_prob),
+            log_prob = to_funsor(
+                raw_log_prob,
                 output=self.output,
                 dim_to_name=dim_to_name,
             )
-            result = funsor.delta.Delta(value_name, funsor_value, dice_factor)
+            model_sample = funsor.delta.Delta(value_name, funsor_value, log_prob)
+            guide_sample = funsor.delta.Delta(
+                value_name, funsor_value, ops.detach(log_prob)
+            )
+            result = funsor.terms.Importance(
+                ops.logaddexp,
+                model_sample,
+                guide_sample,
+                frozenset({Variable(value_name, self.inputs[value_name])}),
+            )
         else:
             result = funsor.delta.Delta(value_name, funsor_value)
         return result

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -183,7 +183,7 @@ def eager_integrate(delta, integrand, reduced_vars):
         if name in reduced_names
     )
     new_integrand = Subs(integrand, subs)
-    new_log_measure = Subs(delta, subs)
+    new_log_measure = delta.reduce(ops.logaddexp, reduced_names)
     result = Integrate(new_log_measure, new_integrand, reduced_vars - delta_fresh)
     return result
 

--- a/funsor/terms.py
+++ b/funsor/terms.py
@@ -1333,6 +1333,43 @@ def eager_approximate(op, model, guide, approx_vars):
     return model  # exact
 
 
+class Importance(Funsor):
+    """
+    Interpretation-specific approximation wrt a set of variables.
+
+    The default eager interpretation should be exact.
+    The user-facing interface is the :meth:`Funsor.approximate` method.
+
+    :param op: An associative operator.
+    :type op: ~funsor.ops.AssociativeOp
+    :param Funsor model: An exact funsor depending on ``reduced_vars``.
+    :param Funsor guide: A proposal funsor guiding optional approximation.
+    :param frozenset approx_vars: A set of variables over which to approximate.
+    """
+
+    def __init__(self, op, model, guide, approx_vars):
+        assert isinstance(op, AssociativeOp)
+        assert isinstance(model, Funsor)
+        assert isinstance(guide, Funsor)
+        assert model.output is guide.output
+        assert isinstance(approx_vars, frozenset), approx_vars
+        inputs = model.inputs.copy()
+        inputs.update(guide.inputs)
+        output = model.output
+        super().__init__(inputs, output)
+        self.op = op
+        self.model = model
+        self.guide = guide
+        self.approx_vars = approx_vars
+
+    def eager_reduce(self, op, reduced_vars):
+        assert reduced_vars.issubset(self.inputs)
+        if not reduced_vars:
+            return self
+
+        return self.model.reduce(op, reduced_vars)
+
+
 class NumberMeta(FunsorMeta):
     """
     Wrapper to fill in default ``dtype``.


### PR DESCRIPTION
`Importance` funsor is similar to `Approximate` but with the main difference that `Importance` funsor is lazy.

1. Signature is `Importance(op, model, guide, sampled_vars)` (`op` might be unnecessary).
2. Reduction is delegated to `self.model.reduce`.
3. `MonteCarlo` interpretation returns `sample + model - guide` where `sample = guide._sample(...)`.
4. `Distribution._sample` returns `Importance(ops.logaddexp, model_sample, guide_sample, name)` where `model_sample = Delta(name, point, log_prob)` and `guide_sample = Delta(name, point, ops.detach(log_prob)`  if `has_rsample`.

From 3. and 4. it follows that:

```py
log_measure = Distribution._sample(...)
with MonteCarlo():
    # log_measure
    #    => guide_sample + model_sample - guide_sample
    #    => guide_sample + model_sample(name=point) - guide_sample(name=point)
    #    => guide_sample + log_prob - ops.detach(log_prob)
    #    => guide_sample + dice_factor
    log_measure = reinterpret(log_measure)
```