### PR TITLE
Support ops with namedtuple output in ProvenanceTensor

### DIFF
--- a/funsor/torch/provenance.py
+++ b/funsor/torch/provenance.py
@@ -61,5 +61,5 @@ class ProvenanceTensor(torch.Tensor):
                     _ret.append(ProvenanceTensor(r, provenance=provenance))
                 else:
                     _ret.append(r)
-            return tuple(_ret)
+            return type(ret)(_ret)
         return ret

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -261,7 +261,7 @@ def test_compress_rank_gaussian(dim, rank):
     assert isinstance(g2, Gaussian)
     assert g2.rank == dim
 
-    assert_close(g1._mean, g2._mean, atol=1e-4, rtol=1e-4)
+    assert_close(g1._mean, g2._mean, atol=1e-4, rtol=1e-3)
     assert_close(g1._precision, g2._precision, atol=1e-4, rtol=1e-3)
 
     actual = g1.reduce(ops.logaddexp)

--- a/test/torch/test_provenance.py
+++ b/test/torch/test_provenance.py
@@ -101,3 +101,11 @@ def test_vindex(data1, provenance1, data2, provenance2, data3, provenance3):
     result = Vindex(data1)[data2.long().unsqueeze(-1), data3]
     actual = getattr(result, "_provenance", frozenset())
     assert actual == expected
+
+
+def test_namedtuple():
+    a = ProvenanceTensor(torch.randn(3, 3), frozenset({"a"}))
+    b = ProvenanceTensor(torch.randn(3, 3).tril(), frozenset({"b"}))
+    result = a.triangular_solve(b).solution
+    actual = getattr(result, "_provenance", frozenset())
+    assert actual == frozenset({"a", "b"})


### PR DESCRIPTION
This adds support for pytorch ops that return a namedtuple, e.g. `torch.triangular_solve`.

## Tested
- [x] added a regression test