### PR TITLE
Fix provenance tensor to work with PyTorch 1.11

### DIFF
--- a/funsor/torch/provenance.py
+++ b/funsor/torch/provenance.py
@@ -14,9 +14,7 @@ class ProvenanceTensor(torch.Tensor):
     def __new__(cls, data, provenance=frozenset(), **kwargs):
         if not provenance:
             return data
-        instance = torch.Tensor.__new__(cls)
-        instance.__init__(data, provenance)
-        return instance
+        return torch.Tensor.__new__(cls)
 
     def __init__(self, data, provenance=frozenset()):
         assert isinstance(provenance, frozenset)


### PR DESCRIPTION
Note that [`__init__` is automatically called after `__new__`](https://stackoverflow.com/questions/674304/why-is-init-always-called-after-new). I've already made this change in Pyro's fork of `ProvenanceTensor` in https://github.com/pyro-ppl/pyro/pull/3045