### PR TITLE
Update to PyTorch 1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     env:
       CI: 1
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     env:
       CI: 1
       FUNSOR_BACKEND: torch
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     env:
       CI: 1
       FUNSOR_BACKEND: jax

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ for a system description.
 
 **Install using pip:**
 
-Funsor supports Python 3.6+.
+Funsor supports Python 3.7+.
 
 ```sh
 pip install funsor

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,7 +289,7 @@ intersphinx_mapping = {
 # @jpchen's hack to get rtd builder to install latest pytorch
 if "READTHEDOCS" in os.environ:
     os.system(
-        "pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+        "pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html"
     )
     # pyro needs to be installed after torch so pyro doesnt install the bloated torch-1.0 wheel
     os.system("pip install pyro-ppl")

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -41,7 +41,13 @@ from funsor.terms import (
     to_funsor,
 )
 from funsor.typing import deep_isinstance
-from funsor.util import broadcast_shape, get_backend, getargspec, lazy_property
+from funsor.util import (
+    broadcast_shape,
+    get_backend,
+    get_default_dtype,
+    getargspec,
+    lazy_property,
+)
 
 BACKEND_TO_DISTRIBUTIONS_BACKEND = {
     "torch": "funsor.torch.distributions",
@@ -512,7 +518,7 @@ def expandeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
 
 def maskeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
     mask = to_funsor(
-        ops.astype(backend_dist._mask, "float32"),
+        ops.astype(backend_dist._mask, get_default_dtype()),
         output=output,
         dim_to_name=dim_to_name,
     )

--- a/funsor/domains.py
+++ b/funsor/domains.py
@@ -405,6 +405,13 @@ def _find_domain_pointwise_binary_generic(op, lhs, rhs):
     raise NotImplementedError("TODO")
 
 
+@find_domain.register(ops.ComparisonOp)
+def _find_domain_comparison(op, lhs, rhs):
+    if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):
+        return Array[2, broadcast_shape(lhs.shape, rhs.shape)]
+    raise NotImplementedError("TODO")
+
+
 @find_domain.register(ops.FloordivOp)
 def _find_domain_floordiv(op, lhs, rhs):
     if isinstance(lhs, ArrayType) and isinstance(rhs, ArrayType):

--- a/funsor/interpreter.py
+++ b/funsor/interpreter.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from funsor.domains import ArrayType
 from funsor.ops import Op, is_numeric_array
-from funsor.util import is_nn_module
+from funsor.util import is_jax_compiled_function, is_nn_module
 
 from . import instrument
 
@@ -137,7 +137,12 @@ def _children_tuple(x):
 def is_atom(x):
     if isinstance(x, (tuple, frozenset)):
         return all(is_atom(c) for c in x)
-    return isinstance(x, _ground_types) or is_numeric_array(x) or is_nn_module(x)
+    return (
+        isinstance(x, _ground_types)
+        or is_numeric_array(x)
+        or is_nn_module(x)
+        or is_jax_compiled_function(x)
+    )
 
 
 def gensym(x=None):

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -31,6 +31,10 @@ class AssociativeOp(BinaryOp):
     pass
 
 
+class ComparisonOp(BinaryOp):
+    pass
+
+
 @AssociativeOp.make
 def null(x, y):
     """Placeholder associative op that unifies with any other op"""
@@ -144,13 +148,13 @@ def parse_slice(s, size):
 
 
 abs = UnaryOp.make(_builtin_abs)
-eq = BinaryOp.make(operator.eq)
-ge = BinaryOp.make(operator.ge)
-gt = BinaryOp.make(operator.gt)
+eq = ComparisonOp.make(operator.eq)
+ge = ComparisonOp.make(operator.ge)
+gt = ComparisonOp.make(operator.gt)
 invert = UnaryOp.make(operator.invert)
-le = BinaryOp.make(operator.le)
-lt = BinaryOp.make(operator.lt)
-ne = BinaryOp.make(operator.ne)
+le = ComparisonOp.make(operator.le)
+lt = ComparisonOp.make(operator.lt)
+ne = ComparisonOp.make(operator.ne)
 pos = UnaryOp.make(operator.pos)
 neg = UnaryOp.make(operator.neg)
 pow = BinaryOp.make(operator.pow)
@@ -285,6 +289,7 @@ UNARY_INVERSES[add] = neg
 
 __all__ = [
     "AssociativeOp",
+    "ComparisonOp",
     "abs",
     "add",
     "and_",

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -238,7 +238,11 @@ def check_funsor(x, inputs, output, data=None):
         else:
             x_data = x.align(tuple(inputs)).data
         if inputs or output.shape:
-            assert (x_data == data).all()
+            if get_backend() == "jax":
+                # JAX has numerical errors for reducing ops.
+                assert_close(x_data, data)
+            else:
+                assert (x_data == data).all()
         else:
             assert x_data == data
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -244,7 +244,11 @@ def check_funsor(x, inputs, output, data=None):
             else:
                 assert (x_data == data).all()
         else:
-            assert x_data == data
+            if get_backend() == "jax":
+                # JAX has numerical errors for reducing ops.
+                assert_close(x_data, data)
+            else:
+                assert x_data == data
 
 
 def xfail_param(*args, **kwargs):

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -205,11 +205,12 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
             elif atol is not None:
                 assert diff.max() < atol, msg
     elif isinstance(actual, numbers.Number):
-        diff = abs(actual - expected)
-        if rtol is not None:
-            assert diff < (atol + abs(expected)) * rtol, msg
-        elif atol is not None:
-            assert diff < atol, msg
+        if actual != expected:
+            diff = abs(actual - expected)
+            if rtol is not None:
+                assert diff < (atol + abs(expected)) * rtol, msg
+            elif atol is not None:
+                assert diff < atol, msg
     elif isinstance(actual, dict):
         assert isinstance(expected, dict)
         assert set(actual) == set(expected)

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -347,7 +347,7 @@ def _pow(x, y):
 
 @ops.reciprocal.register(torch.Tensor)
 def _reciprocal(x):
-    if x.dtype in (torch.complex32, torch.complex64):
+    if torch.is_complex(x):
         return x.reciprocal()
     result = x.reciprocal().clamp(max=torch.finfo(x.dtype).max)
     return result

--- a/funsor/torch/ops.py
+++ b/funsor/torch/ops.py
@@ -198,7 +198,7 @@ def _cholesky_inverse(x):
 def _triangular_inv(x, upper=False):
     if x.size(-1) == 1:
         return x.reciprocal()
-    return torch.eye(x.size(-1)).triangular_solve(x, upper=upper).solution
+    return torch.linalg.solve_triangular(x, torch.eye(x.size(-1)), upper=upper)
 
 
 @ops.detach.register(torch.Tensor)
@@ -393,4 +393,7 @@ ops.stack.register(typing.Tuple[torch.Tensor, ...])(torch.stack)
 def _triangular_solve(x, y, upper=False, transpose=False):
     if y.size(-1) == 1:
         return x / y
-    return x.triangular_solve(y, upper, transpose).solution
+    if transpose:
+        y = y.transpose(-1, -2)
+        upper = not upper
+    return torch.linalg.solve_triangular(y, x, upper=upper)

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -11,6 +11,7 @@ import numpy as np
 
 _FUNSOR_BACKEND = "numpy"
 _JAX_LOADED = False
+_JAX_COMPILED_FUNCTION_TYPE = None
 
 
 class lazy_property(object):
@@ -246,10 +247,14 @@ def set_backend(backend):
     elif backend == "jax":
         _FUNSOR_BACKEND = "jax"
         _JAX_LOADED = True
+        global _JAX_COMPILED_FUNCTION_TYPE
 
         import jax  # noqa: F401
 
         import funsor.jax  # noqa: F401
+
+        if _JAX_COMPILED_FUNCTION_TYPE is None:
+            _JAX_COMPILED_FUNCTION_TYPE = type(jax.jit(lambda: 0))
     else:
         raise ValueError(
             "backend should be either 'numpy', 'torch', or 'jax'"
@@ -297,6 +302,13 @@ def is_nn_module(x):
     torch = sys.modules.get("torch")
     if torch is not None:
         return isinstance(x, torch.nn.Module)
+    return False
+
+
+def is_jax_compiled_function(x):
+    jax = sys.modules.get("jax")
+    if jax is not None:
+        return isinstance(x, _JAX_COMPILED_FUNCTION_TYPE)
     return False
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ filterwarnings = error
     ignore:CUDA initialization:UserWarning
     ignore:floor_divide is deprecated:UserWarning
     ignore:__floordiv__ is deprecated:UserWarning
+    ignore:__rfloordiv__ is deprecated:UserWarning
     ignore:torch.cholesky is deprecated:UserWarning
     ignore:torch.symeig is deprecated:UserWarning
     once::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="https://github.com/pyro-ppl/funsor",
     project_urls={"Documentation": "https://funsor.pyro.ai"},
     author="Uber AI Labs",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "makefun",
         "multipledispatch",
@@ -38,7 +38,7 @@ setup(
         "typing_extensions",
     ],
     extras_require={
-        "torch": ["pyro-ppl>=1.6.0", "torch>=1.9.0"],
+        "torch": ["pyro-ppl>=1.8.0", "torch>=1.11.0"],
         "jax": ["numpyro>=0.7.0", "jax>=0.2.13", "jaxlib>=0.1.65"],
         "test": [
             "black",
@@ -51,7 +51,7 @@ setup(
             "pytest-xdist==1.27.0",
             "requests",
             "scipy",
-            "torchvision>=0.10.0",
+            "torchvision>=0.12.0",
         ],
         "dev": [
             "black",
@@ -66,7 +66,7 @@ setup(
             "sphinx>=2.0",
             "sphinx-gallery",
             "sphinx_rtd_theme",
-            "torchvision>=0.10.0",
+            "torchvision>=0.12.0",
         ],
     },
     long_description=long_description,
@@ -79,10 +79,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.10",  # for jax but not torch
     ],
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,12 +22,15 @@ def pytest_runtest_setup(item):
     np.random.seed(0)
     if _BACKEND == "torch":
         import pyro
+        import torch
 
+        torch.set_default_dtype(torch.double)
         pyro.set_rng_seed(0)
         pyro.enable_validation(True)
     elif _BACKEND == "jax":
         from jax.config import config
 
         config.update("jax_platform_name", "cpu")
+        config.update("jax_enable_x64", True)
 
     funsor.util.set_backend = _disallow_set_backend

--- a/test/examples/test_sensor_fusion.py
+++ b/test/examples/test_sensor_fusion.py
@@ -100,7 +100,7 @@ def test_affine_subs():
                     0.5321089029312134,
                     -0.9039931297302246,
                 ],
-                dtype=torch.float32,
+                dtype=torch.float64,
             ),  # noqa
             torch.tensor(
                 [
@@ -140,7 +140,7 @@ def test_affine_subs():
                         0.6450173854827881,
                     ],
                 ],
-                dtype=torch.float32,
+                dtype=torch.float64,
             ),  # noqa
             (
                 (
@@ -165,7 +165,7 @@ def test_affine_subs():
                         Tensor(
                             torch.tensor(
                                 [-2.1787893772125244, 0.5684312582015991],
-                                dtype=torch.float32,
+                                dtype=torch.float64,
                             ),  # noqa
                             (),
                             "real",

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -148,6 +148,7 @@ def test_discrete_diag_normal_log_prob(init_shape, trans_shape, obs_shape, state
     check_expand(actual_dist, data)
 
 
+@pytest.mark.filterwarnings("ignore:torch.triangular_solve is deprecated")
 @pytest.mark.parametrize(
     "obs_dim,hidden_dim", [(1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2)]
 )

--- a/test/pyro/test_hmm.py
+++ b/test/pyro/test_hmm.py
@@ -211,6 +211,7 @@ def test_gaussian_hmm_log_prob(
     check_expand(actual_dist, data)
 
 
+@pytest.mark.filterwarnings("ignore:torch.triangular_solve is deprecated")
 @pytest.mark.parametrize("obs_dim", [1, 2, 3])
 @pytest.mark.parametrize("hidden_dim", [1, 2, 3])
 @pytest.mark.parametrize(

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -869,13 +869,13 @@ def _check_sample(
 @pytest.mark.parametrize(
     "sample_inputs", [(), ("ii",), ("ii", "jj"), ("ii", "jj", "kk")]
 )
-@pytest.mark.parametrize("batch_shape", [(), (5,), (2, 3)], ids=str)
-@pytest.mark.parametrize("reparametrized", [True, False])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
+@pytest.mark.parametrize("reparametrized", [True, False], ids=["reparam", "nonrepa"])
 def test_gamma_sample(batch_shape, sample_inputs, reparametrized):
     batch_dims = ("i", "j", "k")[: len(batch_shape)]
     inputs = OrderedDict((k, Bint[v]) for k, v in zip(batch_dims, batch_shape))
 
-    concentration = rand(batch_shape)
+    concentration = rand(batch_shape) + 0.5
     rate = rand(batch_shape)
     funsor_dist_class = dist.Gamma if reparametrized else dist.NonreparameterizedGamma
     params = (concentration, rate)
@@ -885,7 +885,7 @@ def test_gamma_sample(batch_shape, sample_inputs, reparametrized):
         params,
         sample_inputs,
         inputs,
-        num_samples=200000,
+        num_samples=1000000,
         atol=5e-2 if reparametrized else 1e-1,
     )
 

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -33,7 +33,7 @@ from funsor.testing import (
     xfail_if_not_implemented,
     xfail_param,
 )
-from funsor.util import get_backend
+from funsor.util import get_backend, get_default_dtype
 
 pytestmark = excludes_backend("numpy", reason="requires a distributions library")
 if get_backend() != "numpy":
@@ -225,7 +225,7 @@ def test_delta_density(batch_shape, event_shape):
         eq = v == value
         for _ in range(len(event_shape)):
             eq = ops.all(eq, -1)
-        return ops.log(ops.astype(eq, "float32")) + log_density
+        return ops.log(ops.astype(eq, get_default_dtype())) + log_density
 
     check_funsor(
         delta,
@@ -311,10 +311,10 @@ def test_dirichlet_multinomial_density(batch_shape, event_shape):
 
     concentration = Tensor(ops.exp(randn(batch_shape + event_shape)), inputs)
     value_data = ops.astype(
-        randint(0, max_count, size=batch_shape + event_shape), "float32"
+        randint(0, max_count, size=batch_shape + event_shape), get_default_dtype()
     )
     total_count_data = value_data.sum(-1) + ops.astype(
-        randint(0, max_count, size=batch_shape), "float32"
+        randint(0, max_count, size=batch_shape), get_default_dtype()
     )
     value = Tensor(value_data, inputs)
     total_count = Tensor(total_count_data, inputs)
@@ -675,7 +675,10 @@ def test_poisson_probs_density(batch_shape, syntax):
 
     rate = Tensor(rand(batch_shape), inputs)
     value = Tensor(
-        ops.astype(ops.astype(ops.exp(randn(batch_shape)), "int32"), "float32"), inputs
+        ops.astype(
+            ops.astype(ops.exp(randn(batch_shape)), "int32"), get_default_dtype()
+        ),
+        inputs,
     )
     expected = poisson(rate, value)
     check_funsor(expected, inputs, Real)
@@ -1251,7 +1254,7 @@ def test_dirichlet_multinomial_conjugate_plate(batch_shape, size):
     prior = Variable("prior", Reals[size])
     concentration = Tensor(ops.exp(randn(full_shape)), inputs)
     value_data = ops.astype(
-        randint(0, max_count, size=batch_shape + (7, size)), "float32"
+        randint(0, max_count, size=batch_shape + (7, size)), get_default_dtype()
     )
     obs_inputs = inputs.copy()
     obs_inputs["plate"] = Bint[7]
@@ -1276,7 +1279,7 @@ def test_dirichlet_multinomial_conjugate(batch_shape, size):
     full_shape = batch_shape + (size,)
     prior = Variable("prior", Reals[size])
     concentration = Tensor(ops.exp(randn(full_shape)), inputs)
-    value_data = ops.astype(randint(0, max_count, size=full_shape), "float32")
+    value_data = ops.astype(randint(0, max_count, size=full_shape), get_default_dtype())
     obs = Tensor(value_data, inputs)
     total_count_data = value_data.sum(-1)
     total_count = Tensor(total_count_data, inputs)
@@ -1328,7 +1331,10 @@ def test_gamma_poisson_conjugate(batch_shape):
     assert_close(reduced.rate, rate)
 
     obs = Tensor(
-        ops.astype(ops.astype(ops.exp(randn(batch_shape)), "int32"), "float32"), inputs
+        ops.astype(
+            ops.astype(ops.exp(randn(batch_shape)), "int32"), get_default_dtype()
+        ),
+        inputs,
     )
     _assert_conjugate_density_ok(latent, conditional, obs)
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1574,7 +1574,7 @@ def test_scatter_substitute():
                         ),
                     )
                 ),
-                Tensor(np.array(0.3386716842651367, dtype=np.float32), (), "real"),
+                Tensor(np.array(0.3386716842651367, dtype=np.float64), (), "real"),
             ),
         ),
         frozenset(),

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -267,7 +267,7 @@ def unary_eval(symbol, x):
     return getattr(ops, symbol)(x)
 
 
-@pytest.mark.parametrize("data", [0, 0.5, 1])
+@pytest.mark.parametrize("data", [0.0, 0.5, 1.0])
 @pytest.mark.parametrize(
     "symbol",
     ["~", "-", "atanh", "abs", "sqrt", "exp", "log", "log1p", "sigmoid", "tanh"],
@@ -334,8 +334,8 @@ def binary_eval(symbol, x, y):
     return eval("x {} y".format(symbol))
 
 
-@pytest.mark.parametrize("data1", [0, 0.2, 1])
-@pytest.mark.parametrize("data2", [0, 0.8, 1])
+@pytest.mark.parametrize("data1", [0.0, 0.2, 1.0])
+@pytest.mark.parametrize("data2", [0.0, 0.8, 1.0])
 @pytest.mark.parametrize("symbol", BINARY_OPS + BOOLEAN_OPS)
 def test_binary(symbol, data1, data2):
     dtype = "real"
@@ -347,11 +347,15 @@ def test_binary(symbol, data1, data2):
         expected_data = binary_eval(symbol, data1, data2)
     except ZeroDivisionError:
         return
+    expected_dtype = dtype
+    if isinstance(expected_data, bool):
+        expected_dtype = 2
+        expected_data = int(expected_data)
 
     x1 = Number(data1, dtype)
     x2 = Number(data2, dtype)
     actual = binary_eval(symbol, x1, x2)
-    check_funsor(actual, {}, Array[dtype, ()], expected_data)
+    check_funsor(actual, {}, Array[expected_dtype, ()], expected_data)
     with normalize:
         actual_reflect = binary_eval(symbol, x1, x2)
     assert actual.output == actual_reflect.output

--- a/test/torch/test_ops.py
+++ b/test/torch/test_ops.py
@@ -21,22 +21,22 @@ def test_triangular_solve(batch_shape, m, n):
     U = L.transpose(-1, -2)
 
     actual = ops.triangular_solve(b, L, upper=False)
-    expected = torch.triangular_solve(b, L, upper=False).solution
+    expected = torch.linalg.solve_triangular(L, b, upper=False)
     assert_close(actual, expected)
     assert_close(L @ actual, b, atol=1e-4, rtol=1e-3)
 
     actual = ops.triangular_solve(b, U, upper=True)
-    expected = torch.triangular_solve(b, U, upper=True).solution
+    expected = torch.linalg.solve_triangular(U, b, upper=True)
     assert_close(actual, expected)
     assert_close(U @ actual, b, atol=1e-4, rtol=1e-3)
 
     actual = ops.triangular_solve(b, L, upper=False, transpose=True)
-    expected = torch.triangular_solve(b, L, upper=False, transpose=True).solution
+    expected = torch.linalg.solve_triangular(L.transpose(-1, -2), b, upper=True)
     assert_close(actual, expected)
     assert_close(L.transpose(-1, -2) @ actual, b, atol=1e-4, rtol=1e-3)
 
     actual = ops.triangular_solve(b, U, upper=True, transpose=True)
-    expected = torch.triangular_solve(b, U, upper=True, transpose=True).solution
+    expected = torch.linalg.solve_triangular(U.transpose(-1, -2), b, upper=False)
     assert_close(actual, expected)
     assert_close(U.transpose(-1, -2) @ actual, b, atol=1e-4, rtol=1e-3)
 

--- a/test/torch/test_provenance.py
+++ b/test/torch/test_provenance.py
@@ -105,7 +105,7 @@ def test_vindex(data1, provenance1, data2, provenance2, data3, provenance3):
 
 def test_namedtuple():
     a = ProvenanceTensor(torch.randn(3, 3), frozenset({"a"}))
-    b = ProvenanceTensor(torch.randn(3, 3).tril(), frozenset({"b"}))
-    result = a.triangular_solve(b).solution
+    b = ProvenanceTensor(torch.randn(3, 3), frozenset({"b"}))
+    result = torch.linalg.solve_triangular(b, a, upper=True)
     actual = getattr(result, "_provenance", frozenset())
     assert actual == frozenset({"a", "b"})


### PR DESCRIPTION
Similar to https://github.com/pyro-ppl/pyro/pull/3045

- Bump Python version to 3.7, drops support for 3.6 (which reached end of life [last December](https://endoflife.date/python))
- Bump PyTorch to 1.11.0, torchvision to 0.12.0
- Convert `torch.triangular_solve()` -> `torch.linalg.solve_triangular()`
- Ignore irrelevant `__rfloordiv__` warnings
- Replace `isinstance(x.dtype, torch.complex??)` with `torch.is_complex(x)`
- Resolves #573
- Add a `ComparisonOp` subclass of `BinaryOp`, plus dtype inference rules in domains.py