### PR TITLE
Delta integrate pattern

### DIFF
--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -180,7 +180,7 @@ def eager_integrate(delta, integrand, reduced_vars):
     new_integrand = integrand
     new_log_measure = delta
 
-    # substitute vars that are both in delta and integrand
+    # reduced_vars that are in integrand.inputs are substituted in delta and integrand
     subs = tuple(
         (name, point)
         for name, (point, log_density) in delta.terms
@@ -189,7 +189,7 @@ def eager_integrate(delta, integrand, reduced_vars):
     if subs:
         new_integrand = Subs(new_integrand, subs)
         new_log_measure = Subs(new_log_measure, subs)
-    # reduce delta over reduced_vars that are not in integrand
+    # reduced vars that are not in integrand.inputs are reduced over in delta
     reduced_names = reduced_names.difference(integrand.inputs)
     if reduced_names:
         new_log_measure = new_log_measure.reduce(ops.logaddexp, reduced_names)

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -177,13 +177,23 @@ def eager_integrate(delta, integrand, reduced_vars):
     if reduced_vars.isdisjoint(delta_fresh):
         return None
     reduced_names = frozenset(v.name for v in reduced_vars)
+    new_integrand = integrand
+    new_log_measure = delta
+
+    # substitute vars that are both in delta and integrand
     subs = tuple(
         (name, point)
         for name, (point, log_density) in delta.terms
-        if name in reduced_names
+        if name in reduced_names and name in integrand.inputs
     )
-    new_integrand = Subs(integrand, subs)
-    new_log_measure = Subs(delta, subs)
+    if subs:
+        new_integrand = Subs(new_integrand, subs)
+        new_log_measure = Subs(new_log_measure, subs)
+    # reduce delta over reduced_vars that are not in integrand
+    reduced_names = reduced_names.difference(integrand.inputs)
+    if reduced_names:
+        new_log_measure = new_log_measure.reduce(ops.logaddexp, reduced_names)
+
     result = Integrate(new_log_measure, new_integrand, reduced_vars - delta_fresh)
     return result
 


### PR DESCRIPTION
(Separating this from #593 PR)

This proposes the following logic for the Delta Integrate pattern:

- If `reduced_var` is in `integrand.inputs` then apply substitution to `delta` and `integrand`:

```py
delta = Delta("x",  (point, log_density))
integrand = Variable("x")
Integrate(delta, integrand, reduced_vars="x")
  => delta(x=point).exp() * integrand(x=point)
  => log_density.exp() * point
``` 
where `log_density` can be a Dice factor or an importance weight in general.

- If `reduced_var` is not in `integrand.inputs` then just reduce `delta`:

```py
delta = Delta("x",  (point, log_density))
integrand = Number(3.0)
Integrate(delta, integrand, reduced_vars="x")
  => delta.reduce(logaddexp, "x").exp() * integrand
  => 1 * 3.0
  => 3.0
``` 

where `delta` is normalized.