### PR TITLE
Include LICENSE.md in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+# This includes the license file(s) in the wheel.
+license_files = LICENSE.md
+
 [flake8]
 max-line-length = 120
 exclude = docs/src, build, dist


### PR DESCRIPTION
This ensures that the license is shipped in the sdist tarball on PyPI.