### PR TITLE
Update __torch_function__ idiom

### DIFF
--- a/funsor/torch/provenance.py
+++ b/funsor/torch/provenance.py
@@ -27,7 +27,8 @@ class ProvenanceTensor(torch.Tensor):
     def __repr__(self):
         return "Provenance:\n{}\nTensor:\n{}".format(self._provenance, self._t)
 
-    def __torch_function__(self, func, types, args=(), kwargs=None):
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
         # collect provenance information from args


### PR DESCRIPTION
Blocking #598 

This unblocks CI by fixing to the newer PyTorch idiom of declaring `.__torch_function__()` methods as `@classmethod`.