### PR TITLE
Bump to version 0.4.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ipython<=8.6.0  # restrict for https://github.com/ipython/ipython/issues/13845
 makefun
 multipledispatch
-nbsphinx==0.8.1
+nbsphinx==0.8.9
 numpy>=1.7
 opt_einsum>=2.3.2
 pytest>=4.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,8 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = [".rst", ".ipynb"]
+# NOTE: `.rst` is the default suffix of sphinx, and nbsphinx will
+# automatically add support for `.ipynb` suffix.
 
 # do not execute cells
 nbsphinx_execute = "never"
@@ -106,7 +107,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -53,7 +53,7 @@ from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     testing,
 )
 
-__version__ = "0.4.3"  # mirrored in setup.py
+__version__ = "0.4.4"  # mirrored in setup.py
 
 __all__ = [
     "__version__",

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -245,7 +245,7 @@ def check_funsor(x, inputs, output, data=None):
             else:
                 assert (x_data == data).all()
         else:
-            if get_backend() == "jax":
+            if get_backend() in ["jax", "numpy"]:
                 # JAX has numerical errors for reducing ops.
                 assert_close(x_data, data)
             else:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ long_description = "\n".join(line for line in long_description.split("\n")[4:])
 
 setup(
     name="funsor",
-    version="0.4.3",  # mirrored in funsor/__init__.py
+    version="0.4.4",  # mirrored in funsor/__init__.py
     description="A tensor-like library for functions and distributions",
     packages=find_packages(include=["funsor", "funsor.*"]),
     url="https://github.com/pyro-ppl/funsor",

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -7,7 +7,7 @@ import itertools
 import pickle
 from collections import OrderedDict
 from functools import reduce
-from typing import get_type_hints
+from typing import Tuple, get_type_hints
 
 import numpy as np
 import pytest
@@ -863,7 +863,7 @@ def test_function_nested_eager_hint():
 
 
 def test_function_nested_eager():
-    @funsor.function(Reals[8], (Real, Bint[8]))
+    @funsor.function(Reals[8], Tuple[Real, Bint[8]])
     def max_and_argmax(x):
         return tuple(_numeric_max_and_argmax(x))
 
@@ -879,7 +879,7 @@ def test_function_nested_eager():
 
 
 def test_function_nested_lazy():
-    @funsor.function(Reals[8], (Real, Bint[8]))
+    @funsor.function(Reals[8], Tuple[Real, Bint[8]])
     def max_and_argmax(x):
         return tuple(_numeric_max_and_argmax(x))
 

--- a/test/test_transpose.py
+++ b/test/test_transpose.py
@@ -210,7 +210,8 @@ def test_tower_sum(height):
     assert transpose(top)[x] is Number(2.0**height)
 
 
-@pytest.mark.parametrize("height", [0, 1, 2, 3, 10])  # , 100, 1000])
+# Note: we get overflow issue for height=10.
+@pytest.mark.parametrize("height", [0, 1, 2, 3, 9])  # , 10, 100, 1000])
 def test_tower_prod(height):
     x = random_tensor(OrderedDict(i=Bint[2], j=Bint[3]))
     with lazy:


### PR DESCRIPTION
This is required for a breaking change in jax 0.4 which introduces `jax.Array`.