### PR TITLE
Scale factors across plate dims in `partial_sum_product`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     env:
       CI: 1
       FUNSOR_BACKEND: jax

--- a/funsor/ops/builtin.py
+++ b/funsor/ops/builtin.py
@@ -8,6 +8,7 @@ from numbers import Number
 from .op import (
     BINARY_INVERSES,
     DISTRIBUTIVE_OPS,
+    PRODUCT_TO_POWER,
     SAFE_BINARY_INVERSES,
     UNARY_INVERSES,
     UNITS,
@@ -286,6 +287,9 @@ SAFE_BINARY_INVERSES[add] = safesub
 
 UNARY_INVERSES[mul] = reciprocal
 UNARY_INVERSES[add] = neg
+
+PRODUCT_TO_POWER[add] = mul
+PRODUCT_TO_POWER[mul] = pow
 
 __all__ = [
     "AssociativeOp",

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -421,6 +421,7 @@ UNITS = {}  # op -> value
 BINARY_INVERSES = {}  # binary op -> inverse binary op
 SAFE_BINARY_INVERSES = {}  # binary op -> numerically safe inverse binary op
 UNARY_INVERSES = {}  # binary op -> inverse unary op
+PRODUCT_TO_POWER = {}  # product op -> power op
 
 __all__ = [
     "BINARY_INVERSES",
@@ -430,6 +431,7 @@ __all__ = [
     "LogAbsDetJacobianOp",
     "NullaryOp",
     "Op",
+    "PRODUCT_TO_POWER",
     "SAFE_BINARY_INVERSES",
     "TernaryOp",
     "TransformOp",

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -224,15 +224,6 @@ def partial_sum_product(
     assert all(isinstance(f, Funsor) for f in factors)
     assert isinstance(eliminate, frozenset)
     assert isinstance(plates, frozenset)
-    assert isinstance(plate_to_scale, dict)
-
-    if plate_to_scale:
-        if sum_op is ops.logaddexp and prod_op is ops.add:
-            pow_op = ops.mul
-        elif sum_op is ops.add and prod_op is ops.mul:
-            pow_op = ops.pow
-        else:
-            raise ValueError("should not be here!")
 
     if plate_to_scale:
         if pow_op is None:

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -272,7 +272,11 @@ def partial_sum_product(
             remaining_sum_vars = sum_vars.intersection(f.inputs)
             if not remaining_sum_vars:
                 f = f.reduce(prod_op, leaf & eliminate)
-                f_scales = [plate_to_scale[plate] for plate in leaf & eliminate if plate in plate_to_scale]
+                f_scales = [
+                    plate_to_scale[plate]
+                    for plate in leaf & eliminate
+                    if plate in plate_to_scale
+                ]
                 if f_scales:
                     scale = reduce(ops.mul, f_scales)
                     f = pow_op(f, scale)
@@ -326,7 +330,11 @@ def partial_sum_product(
                 reduced_plates = leaf - new_plates
                 assert reduced_plates.issubset(eliminate)
                 f = f.reduce(prod_op, reduced_plates)
-                f_scales = [plate_to_scale[plate] for plate in reduced_plates if plate in plate_to_scale]
+                f_scales = [
+                    plate_to_scale[plate]
+                    for plate in reduced_plates
+                    if plate in plate_to_scale
+                ]
                 if f_scales:
                     scale = reduce(ops.mul, f_scales)
                     f = pow_op(f, scale)

--- a/funsor/sum_product.py
+++ b/funsor/sum_product.py
@@ -4,7 +4,7 @@
 import re
 from collections import OrderedDict, defaultdict
 from functools import reduce
-from math import gcd
+from math import gcd, prod
 
 import funsor
 import funsor.ops as ops
@@ -203,7 +203,14 @@ def partial_unroll(factors, eliminate=frozenset(), plate_to_step=dict()):
 
 
 def partial_sum_product(
-    sum_op, prod_op, factors, eliminate=frozenset(), plates=frozenset(), pedantic=False
+    sum_op,
+    prod_op,
+    factors,
+    eliminate=frozenset(),
+    plates=frozenset(),
+    pedantic=False,
+    pow_op=None,
+    scales={},
 ):
     """
     Performs partial sum-product contraction of a collection of factors.
@@ -217,6 +224,7 @@ def partial_sum_product(
     assert all(isinstance(f, Funsor) for f in factors)
     assert isinstance(eliminate, frozenset)
     assert isinstance(plates, frozenset)
+    assert isinstance(scales, dict)
 
     if pedantic:
         var_to_errors = defaultdict(lambda: eliminate)
@@ -250,10 +258,15 @@ def partial_sum_product(
         leaf = max(ordinal_to_factors, key=len)  # CHOICE
         leaf_factors = ordinal_to_factors.pop(leaf)
         leaf_reduce_vars = ordinal_to_vars[leaf]
+        leaf_scale = reduce(
+            ops.mul, [scales[plate] for plate in leaf if plate in scales], Number(1.0)
+        )
         for group_factors, group_vars in _partition(
             leaf_factors, leaf_reduce_vars
         ):  # CHOICE
             f = reduce(prod_op, group_factors).reduce(sum_op, group_vars & eliminate)
+            if pow_op is not None:
+                f = pow_op(f, leaf_scale)
             remaining_sum_vars = sum_vars.intersection(f.inputs)
             if not remaining_sum_vars:
                 results.append(f.reduce(prod_op, leaf & eliminate))
@@ -571,7 +584,14 @@ def modified_partial_sum_product(
 
 
 def sum_product(
-    sum_op, prod_op, factors, eliminate=frozenset(), plates=frozenset(), pedantic=False
+    sum_op,
+    prod_op,
+    factors,
+    eliminate=frozenset(),
+    plates=frozenset(),
+    pedantic=False,
+    pow_op=None,
+    scales={},
 ):
     """
     Performs sum-product contraction of a collection of factors.
@@ -579,7 +599,9 @@ def sum_product(
     :return: a single contracted Funsor.
     :rtype: :class:`~funsor.terms.Funsor`
     """
-    factors = partial_sum_product(sum_op, prod_op, factors, eliminate, plates, pedantic)
+    factors = partial_sum_product(
+        sum_op, prod_op, factors, eliminate, plates, pedantic, pow_op, scales
+    )
     return reduce(prod_op, factors, Number(UNITS[prod_op]))
 
 

--- a/funsor/testing.py
+++ b/funsor/testing.py
@@ -81,7 +81,7 @@ def id_from_inputs(inputs):
 
 @dispatch(object, object, Variadic[float])
 def allclose(a, b, rtol=1e-05, atol=1e-08):
-    if type(a) != type(b):
+    if type(a) is not type(b):
         return False
     return ops.abs(a - b) < rtol + atol * ops.abs(b)
 
@@ -125,7 +125,7 @@ def assert_close(actual, expected, atol=1e-6, rtol=1e-6):
     elif isinstance(actual, Gaussian):
         assert isinstance(expected, Gaussian)
     else:
-        assert type(actual) == type(expected), msg
+        assert type(actual) is type(expected), msg
 
     if isinstance(actual, Funsor):
         assert isinstance(expected, Funsor), msg

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -35,7 +35,7 @@ from funsor.sum_product import (
     sum_product,
 )
 from funsor.tensor import Tensor, get_default_prototype
-from funsor.terms import Variable
+from funsor.terms import Cat, Number, Variable
 from funsor.testing import assert_close, random_gaussian, random_tensor
 from funsor.util import get_backend
 
@@ -2899,3 +2899,53 @@ def test_mixed_sequential_sum_product(duration, num_segments):
     )
 
     assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "sum_op,prod_op,pow_op",
+    [(ops.logaddexp, ops.add, ops.mul), (ops.add, ops.mul, ops.pow)],
+)
+@pytest.mark.parametrize("scale", [2, 3])
+def test_partial_sum_product_scale_1(sum_op, prod_op, pow_op, scale):
+    f1 = random_tensor(OrderedDict(a=Bint[2]))
+    f2 = random_tensor(OrderedDict(a=Bint[2], b=Bint[3]))
+    f3 = Cat("b", (f2,) * scale)
+
+    eliminate = frozenset("ab")
+    plates = frozenset("b")
+
+    factors = [f1, f3]
+    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
+
+    factors = [f1, f2]
+    scales = {"b": Number(scale)}
+    actual = sum_product(
+        sum_op, prod_op, factors, eliminate, plates, pow_op=pow_op, scales=scales
+    )
+
+    assert_close(actual, expected, atol=5e-4, rtol=5e-4)
+
+
+@pytest.mark.parametrize(
+    "sum_op,prod_op,pow_op",
+    [(ops.logaddexp, ops.add, ops.mul), (ops.add, ops.mul, ops.pow)],
+)
+@pytest.mark.parametrize("scale", [2, 3])
+def test_partial_sum_product_scale_2(sum_op, prod_op, pow_op, scale):
+    f1 = random_tensor(OrderedDict(a=Bint[2]))
+    f2 = random_tensor(OrderedDict(a=Bint[2], b=Bint[3]))
+    f3 = Cat("b", (f2,) * scale)
+
+    eliminate = frozenset("ab")
+    plates = frozenset("b")
+
+    factors = [f1, f3]
+    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
+
+    factors = [f1, f2]
+    scales = {"b": Number(scale)}
+    actual = sum_product(
+        sum_op, prod_op, factors, eliminate, plates, pow_op=pow_op, scales=scales
+    )
+
+    assert_close(actual, expected, atol=5e-4, rtol=5e-4)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -35,7 +35,7 @@ from funsor.sum_product import (
     sum_product,
 )
 from funsor.tensor import Tensor, get_default_prototype
-from funsor.terms import Cat, Number, Variable
+from funsor.terms import Cat, Variable
 from funsor.testing import assert_close, random_gaussian, random_tensor
 from funsor.util import get_backend
 
@@ -2920,7 +2920,7 @@ def test_partial_sum_product_scale_1(sum_op, prod_op, scale):
     factors = [f1, f2]
     scales = {"i": scale}
     actual = sum_product(
-        sum_op, prod_op, factors, eliminate, plates, scales=scales
+        sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
     )
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -2948,7 +2948,7 @@ def test_partial_sum_product_scale_2(sum_op, prod_op, scale_i, scale_j):
     factors = [f1, f2, f3]
     scales = {"i": scale_i, "j": scale_j}
     actual = sum_product(
-        sum_op, prod_op, factors, eliminate, plates, scales=scales
+        sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
     )
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)
@@ -2983,7 +2983,7 @@ def test_partial_sum_product_scale_3(sum_op, prod_op, scale_i, scale_j, scale_k)
     factors = [f1, f2, f3]
     scales = {"i": scale_i, "j": scale_j, "k": scale_k}
     actual = sum_product(
-        sum_op, prod_op, factors, eliminate, plates, scales=scales
+        sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
     )
 
     assert_close(actual, expected, atol=5e-4, rtol=5e-4)

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -2905,66 +2905,82 @@ def test_mixed_sequential_sum_product(duration, num_segments):
     "sum_op,prod_op",
     [(ops.logaddexp, ops.add), (ops.add, ops.mul)],
 )
-@pytest.mark.parametrize("scale", [2, 3])
+@pytest.mark.parametrize("scale", [1, 2])
 def test_partial_sum_product_scale_1(sum_op, prod_op, scale):
     f1 = random_tensor(OrderedDict(a=Bint[2]))
     f2 = random_tensor(OrderedDict(a=Bint[2], i=Bint[3]))
-    f3 = Cat("i", (f2,) * scale)
 
     eliminate = frozenset("ai")
     plates = frozenset("i")
 
-    factors = [f1, f3]
-    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
-
+    # Actual result based on applying scaling
     factors = [f1, f2]
     scales = {"i": scale}
     actual = sum_product(
         sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
     )
 
-    assert_close(actual, expected, atol=5e-4, rtol=5e-4)
+    # Expected result based on concatenating factors
+    f3 = Cat("i", (f2,) * scale)
+    factors = [f1, f3]
+    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
+
+    assert_close(actual, expected, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.parametrize(
     "sum_op,prod_op",
     [(ops.logaddexp, ops.add), (ops.add, ops.mul)],
 )
-@pytest.mark.parametrize("scale_i", [2, 3])
-@pytest.mark.parametrize("scale_j", [2, 3])
+@pytest.mark.parametrize("scale_i", [1, 2])
+@pytest.mark.parametrize("scale_j", [1, 3])
 def test_partial_sum_product_scale_2(sum_op, prod_op, scale_i, scale_j):
     f1 = random_tensor(OrderedDict(a=Bint[2]))
     f2 = random_tensor(OrderedDict(a=Bint[2], i=Bint[3]))
     f3 = random_tensor(OrderedDict(a=Bint[2], j=Bint[4]))
-    f4 = Cat("i", (f2,) * scale_i)
-    f5 = Cat("j", (f3,) * scale_j)
 
     eliminate = frozenset("aij")
     plates = frozenset("ij")
 
-    factors = [f1, f4, f5]
-    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
-
+    # Actual result based on applying scaling
     factors = [f1, f2, f3]
     scales = {"i": scale_i, "j": scale_j}
     actual = sum_product(
         sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
     )
 
-    assert_close(actual, expected, atol=5e-4, rtol=5e-4)
+    # Expected result based on concatenating factors
+    f4 = Cat("i", (f2,) * scale_i)
+    f5 = Cat("j", (f3,) * scale_j)
+    factors = [f1, f4, f5]
+    expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
+
+    assert_close(actual, expected, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.parametrize(
     "sum_op,prod_op",
     [(ops.logaddexp, ops.add), (ops.add, ops.mul)],
 )
-@pytest.mark.parametrize("scale_i", [2, 3])
-@pytest.mark.parametrize("scale_j", [2, 3])
-@pytest.mark.parametrize("scale_k", [2, 3])
+@pytest.mark.parametrize("scale_i", [1, 2])
+@pytest.mark.parametrize("scale_j", [1, 3])
+@pytest.mark.parametrize("scale_k", [1, 4])
 def test_partial_sum_product_scale_3(sum_op, prod_op, scale_i, scale_j, scale_k):
     f1 = random_tensor(OrderedDict(a=Bint[2], i=Bint[2]))
     f2 = random_tensor(OrderedDict(a=Bint[2], i=Bint[2], j=Bint[3]))
     f3 = random_tensor(OrderedDict(a=Bint[2], i=Bint[2], j=Bint[3], k=Bint[3]))
+
+    eliminate = frozenset("aijk")
+    plates = frozenset("ijk")
+
+    # Actual result based on applying scaling
+    factors = [f1, f2, f3]
+    scales = {"i": scale_i, "j": scale_j, "k": scale_k}
+    actual = sum_product(
+        sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
+    )
+
+    # Expected result based on concatenating factors
     f4 = Cat("i", (f1,) * scale_i)
     # concatenate across multiple dims
     f5 = Cat("i", (f2,) * scale_i)
@@ -2973,17 +2989,7 @@ def test_partial_sum_product_scale_3(sum_op, prod_op, scale_i, scale_j, scale_k)
     f6 = Cat("i", (f3,) * scale_i)
     f6 = Cat("j", (f6,) * scale_j)
     f6 = Cat("k", (f6,) * scale_k)
-
-    eliminate = frozenset("aijk")
-    plates = frozenset("ijk")
-
     factors = [f4, f5, f6]
     expected = sum_product(sum_op, prod_op, factors, eliminate, plates)
 
-    factors = [f1, f2, f3]
-    scales = {"i": scale_i, "j": scale_j, "k": scale_k}
-    actual = sum_product(
-        sum_op, prod_op, factors, eliminate, plates, plate_to_scale=scales
-    )
-
-    assert_close(actual, expected, atol=5e-4, rtol=5e-4)
+    assert_close(actual, expected, atol=1e-4, rtol=1e-4)

--- a/test/test_terms.py
+++ b/test/test_terms.py
@@ -72,7 +72,7 @@ def test_to_funsor_error(x):
 def test_to_data():
     actual = to_data(Number(0.0))
     expected = 0.0
-    assert type(actual) == type(expected)
+    assert type(actual) is type(expected)
     assert actual == expected
 
 
@@ -569,7 +569,7 @@ def test_stack_slice(start, stop, step):
     xs = tuple(map(Number, range(10)))
     actual = Stack("i", xs)(i=Slice("j", start, stop, step, dtype=10))
     expected = Stack("j", xs[start:stop:step])
-    assert type(actual) == type(expected)
+    assert type(actual) is type(expected)
     assert actual.name == expected.name
     assert actual.parts == expected.parts
 


### PR DESCRIPTION
One of the features not supported by `TraceEnum_ELBO` is that you cannot subsample a local variable when it depends on a global variable that is enumerated in the model because it requires a common scale:

```py
@config_enumerate
def model(data):
    # Global variables.
    locs = torch.tensor([1., 10.])
    assignment = pyro.sample('assignment', dist.Categorical(torch.ones(2)))
    with pyro.plate('data', len(data), subsample_size=2) as ind:  # cannot subsample here
        # Local variables.
        pyro.sample('obs', dist.Normal(locs[assignment], 1.), obs=data[ind])

def guide(data):
    pass
``` 

This has been asked on the forum as well: https://forum.pyro.ai/t/enumeration-and-subsampling-expected-all-enumerated-sample-sites-to-share-common-poutine-scale/4938

A solution I'm proposing here is to perform plate-wise scaling inside the `partial_sum_product` by passing the `plate_to_scale` dictionary. Then whenever a plate is reduced we can scale the factor:

```py
# inside partial_sum_product
f = f.reduce(prod_op, reduced_plates)
f_scales = [plate_to_scale[plate] for plate in reduced_plates if plate in plate_to_scale]
if f_scales:
    scale = reduce(ops.mul, f_scales)
    f = pow_op(f, scale)
```

- Added tests