### PR TITLE
Bump to version 0.4.6

### DIFF
--- a/funsor/__init__.py
+++ b/funsor/__init__.py
@@ -53,7 +53,7 @@ from . import (  # minipyro,  # TODO: enable when minipyro is backend-agnostic
     testing,
 )
 
-__version__ = "0.4.5"  # mirrored in setup.py
+__version__ = "0.4.6"  # mirrored in setup.py
 
 __all__ = [
     "__version__",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ long_description = "\n".join(line for line in long_description.split("\n")[4:])
 
 setup(
     name="funsor",
-    version="0.4.5",  # mirrored in funsor/__init__.py
+    version="0.4.6",  # mirrored in funsor/__init__.py
     description="A tensor-like library for functions and distributions",
     packages=find_packages(include=["funsor", "funsor.*"]),
     url="https://github.com/pyro-ppl/funsor",


### PR DESCRIPTION
Temporarily pinned https://github.com/pyro-ppl/numpyro/pull/1572 to funsor master branch to make sure that tests pass before bumping funsor version here.

@fehiepsi can you also please confirm that this funsor version integrates nicely with NumPyro and nothing is broken?