### PR TITLE
Fix funsor for JAX 0.10 / NumPy 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.11, 3.12, 3.13, 3.14]
     env:
       CI: 1
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.13]
     env:
       CI: 1
       FUNSOR_BACKEND: torch
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.13]
     env:
       CI: 1
       FUNSOR_BACKEND: jax

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
         pip install jax<0.10
         # Keep track of NumPyro master branch
-        pip install https://github.com/saitcakmak/numpyro/archive/master.zip
+        pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
         pip install .[test]
         pip freeze
     - name: Run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install jax<0.10
+        pip install "jax<0.10"
         # Keep track of NumPyro master branch
         pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
         pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11, 3.12, 3.13, 3.14]
+        python-version: [3.8, 3.9]
     env:
       CI: 1
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.13]
+        python-version: [3.9]
     env:
       CI: 1
       FUNSOR_BACKEND: torch
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.13]
+        python-version: [3.9]
     env:
       CI: 1
       FUNSOR_BACKEND: jax

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.11"]
     env:
       CI: 1
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.11"]
     env:
       CI: 1
       FUNSOR_BACKEND: torch
@@ -53,7 +53,7 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install torch==1.11.0 torchvision==0.20.0 -f https://download.pytorch.org/whl/torch_stable.html
+        pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cpu
         # Keep track of Pyro master branch
         pip install https://github.com/pyro-ppl/pyro/archive/master.zip
         pip install .[test,torch]
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: ["3.11"]
     env:
       CI: 1
       FUNSOR_BACKEND: jax
@@ -82,8 +82,8 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        # Keep track of NumPyro master branch
-        pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
+        # Track numpyro PR #2173 (xla_pmap_p import fix for JAX>=0.10) until it merges into master
+        pip install https://github.com/saitcakmak/numpyro/archive/fix-xla-pmap-p-import.zip
         pip install .[test,jax]
         pip freeze
     - name: Run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
     env:
       CI: 1
       FUNSOR_BACKEND: torch
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     env:
       CI: 1
       FUNSOR_BACKEND: jax

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        # Track numpyro PR #2173 (xla_pmap_p import fix for JAX>=0.10) until it merges into master
-        pip install https://github.com/saitcakmak/numpyro/archive/fix-xla-pmap-p-import.zip
-        pip install .[test,jax]
+        pip install jax<0.10
+        pip install https://github.com/saitcakmak/numpyro/archive/master.zip
+        pip install .[test]
         pip freeze
     - name: Run test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         python -m pip install --upgrade pip
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install torch==1.11.0 torchvision==0.20.0 -f https://download.pytorch.org/whl/torch_stable.html
         # Keep track of Pyro master branch
         pip install https://github.com/pyro-ppl/pyro/archive/master.zip
         pip install .[test,torch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         # Keep track of pyro-api master branch
         pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
         pip install jax<0.10
+        # Keep track of NumPyro master branch
         pip install https://github.com/saitcakmak/numpyro/archive/master.zip
         pip install .[test]
         pip freeze

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,10 @@ ifeq (${FUNSOR_BACKEND}, torch)
 	python examples/talbot.py -n 2
 	python examples/vae.py --smoke-test
 	python examples/eeg_slds.py --num-steps 2 --fon --test
-	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
-	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
+	# TODO: re-enable once the seal dataset is mirrored at a reachable URL.
+	# The upstream CSV at d2hg8soec8ck9v.cloudfront.net now returns 403 AccessDenied.
+	# python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
+	# python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
 	python examples/sensor.py --seed=0 --num-frames=2 -n 1
 	python examples/adam.py --num-steps=21
 	@echo PASS

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -166,16 +166,12 @@ def run_expt(args):
         re_str = "g" + (
             "n"
             if args["group"] is None
-            else "d"
-            if args["group"] == "discrete"
-            else "c"
+            else "d" if args["group"] == "discrete" else "c"
         )
         re_str += "i" + (
             "n"
             if args["individual"] is None
-            else "d"
-            if args["individual"] == "discrete"
-            else "c"
+            else "d" if args["individual"] == "discrete" else "c"
         )
         results_filename = "expt_{}_{}_{}.json".format(
             args["dataset"], re_str, str(uuid.uuid4().hex)[0:5]

--- a/funsor/adjoint.py
+++ b/funsor/adjoint.py
@@ -51,9 +51,11 @@ class AdjointTape(Interpretation):
             result = self._old_interpretation.interpret(cls, *args)
         lazy_args = [
             self._eager_to_lazy.get(
-                id(arg)
-                if ops.is_numeric_array(arg) or not isinstance(arg, Hashable)
-                else arg,
+                (
+                    id(arg)
+                    if ops.is_numeric_array(arg) or not isinstance(arg, Hashable)
+                    else arg
+                ),
                 arg,
             )
             for arg in args

--- a/funsor/cnf.py
+++ b/funsor/cnf.py
@@ -547,9 +547,11 @@ def do_fresh_subs(arg, subs):
 @normalize.register(Subs, Contraction, tuple)
 def distribute_subs_contraction(arg, subs):
     new_terms = tuple(
-        Subs(v, tuple((name, sub) for name, sub in subs if name in v.inputs))
-        if any(name in v.inputs for name, sub in subs)
-        else v
+        (
+            Subs(v, tuple((name, sub) for name, sub in subs if name in v.inputs))
+            if any(name in v.inputs for name, sub in subs)
+            else v
+        )
         for v in arg.terms
     )
     return Contraction(arg.red_op, arg.bin_op, arg.reduced_vars, *new_terms)

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -71,9 +71,11 @@ def numbers_to_tensors(*args):
                 break
         with ignore_jit_warnings():
             args = tuple(
-                Tensor(numeric_array(x.data, **options), dtype=x.dtype)
-                if isinstance(x, Number)
-                else x
+                (
+                    Tensor(numeric_array(x.data, **options), dtype=x.dtype)
+                    if isinstance(x, Number)
+                    else x
+                )
                 for x in args
             )
     return args
@@ -129,6 +131,7 @@ class Distribution(Funsor, metaclass=DistributionMeta):
         funsors or objects that can be coerced to funsors via
         :func:`~funsor.terms.to_funsor` . See derived classes for details.
     """
+
     dist_class = "defined by derived classes"
 
     def __init__(self, *args):

--- a/funsor/integrate.py
+++ b/funsor/integrate.py
@@ -282,9 +282,11 @@ def eager_distribute_integrate(log_measure, integrand, reduced_vars):
     return reduce(
         ops.add,
         [
-            -Integrate(log_measure, term.arg, reduced_vars)
-            if isinstance(term, Unary)
-            else Integrate(log_measure, term, reduced_vars)
+            (
+                -Integrate(log_measure, term.arg, reduced_vars)
+                if isinstance(term, Unary)
+                else Integrate(log_measure, term, reduced_vars)
+            )
             for term in integrand.terms
         ],
     )

--- a/funsor/interpretations.py
+++ b/funsor/interpretations.py
@@ -58,9 +58,11 @@ class Interpretation(ContextDecorator, ABC):
             from torch import Tensor
 
             return tuple(
-                id(arg)
-                if isinstance(arg, Tensor) or not isinstance(arg, Hashable)
-                else arg
+                (
+                    id(arg)
+                    if isinstance(arg, Tensor) or not isinstance(arg, Hashable)
+                    else arg
+                )
                 for arg in args
             )
         return tuple(id(arg) if not isinstance(arg, Hashable) else arg for arg in args)

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -3,7 +3,7 @@
 
 import re
 
-from jax.core import Tracer
+from jax.core import Tracer  # singledispatch needs the concrete type; jax.Array isn't a base of Tracer
 from jax.numpy import ndarray
 
 from funsor.tensor import tensor_to_funsor

--- a/funsor/jax/__init__.py
+++ b/funsor/jax/__init__.py
@@ -3,7 +3,7 @@
 
 import re
 
-from jax.core import Tracer  # singledispatch needs the concrete type; jax.Array isn't a base of Tracer
+from jax.core import Tracer
 from jax.numpy import ndarray
 
 from funsor.tensor import tensor_to_funsor

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -8,7 +8,7 @@ import jax.numpy as np
 import jax.random
 import numpy as onp
 from jax import lax
-from jax.core import Tracer
+from jax.core import Tracer  # multipledispatch needs the concrete type; jax.Array isn't a base of Tracer
 from jax.scipy.linalg import cho_solve, solve_triangular
 from jax.scipy.special import expit, gammaln, logsumexp
 
@@ -193,14 +193,14 @@ def _log(x):
 @ops.logaddexp.register(array, array)
 def _safe_logaddexp_tensor_tensor(x, y):
     finfo = np.finfo(np.result_type(x))
-    shift = np.clip(ops.max(ops.detach(x), ops.detach(y)), a_max=None, a_min=finfo.min)
+    shift = np.clip(ops.max(ops.detach(x), ops.detach(y)), finfo.min, None)
     return np.log(np.exp(x - shift) + np.exp(y - shift)) + shift
 
 
 @ops.logaddexp.register(numbers.Number, array)
 def _safe_logaddexp_number_tensor(x, y):
     finfo = np.finfo(np.result_type(y))
-    shift = np.clip(ops.detach(y), a_max=None, a_min=max(x, finfo.min))
+    shift = np.clip(ops.detach(y), max(x, finfo.min), None)
     return np.log(np.exp(x - shift) + np.exp(y - shift)) + shift
 
 
@@ -215,23 +215,23 @@ ops.min.register(array, array)(np.minimum)
 
 @ops.max.register((int, float), array)
 def _max(x, y):
-    return np.clip(y, a_min=x, a_max=None)
+    return np.clip(y, x, None)
 
 
 @ops.max.register(array, (int, float))
 def _max(x, y):
-    return np.clip(x, a_min=y, a_max=None)
+    return np.clip(x, y, None)
 
 
 # TODO: replace (int, float) by numbers.Number
 @ops.min.register((int, float), array)
 def _min(x, y):
-    return np.clip(y, a_min=None, a_max=x)
+    return np.clip(y, None, x)
 
 
 @ops.min.register(array, (int, float))
 def _min(x, y):
-    return np.clip(x, a_min=None, a_max=y)
+    return np.clip(x, None, y)
 
 
 @ops.new_full.register(array)
@@ -267,7 +267,7 @@ def _randn(prototype, shape, rng_key=None):
 
 @ops.reciprocal.register(array)
 def _reciprocal(x):
-    result = np.clip(np.reciprocal(x), a_max=np.finfo(np.result_type(x)).max)
+    result = np.clip(np.reciprocal(x), None, np.finfo(np.result_type(x)).max)
     return result
 
 
@@ -278,7 +278,7 @@ def _safediv(x, y):
         finfo = np.finfo(np.result_type(y))
     except ValueError:
         finfo = np.iinfo(np.result_type(y))
-    return x * np.clip(np.reciprocal(y), a_min=None, a_max=finfo.max)
+    return x * np.clip(np.reciprocal(y), None, finfo.max)
 
 
 @ops.safesub.register(array, array)
@@ -288,7 +288,7 @@ def _safesub(x, y):
         finfo = np.finfo(np.result_type(y))
     except ValueError:
         finfo = np.iinfo(np.result_type(y))
-    return x + np.clip(-y, a_min=None, a_max=finfo.max)
+    return x + np.clip(-y, None, finfo.max)
 
 
 @ops.scatter.register(array, tuple, array)

--- a/funsor/jax/ops.py
+++ b/funsor/jax/ops.py
@@ -8,7 +8,7 @@ import jax.numpy as np
 import jax.random
 import numpy as onp
 from jax import lax
-from jax.core import Tracer  # multipledispatch needs the concrete type; jax.Array isn't a base of Tracer
+from jax.core import Tracer
 from jax.scipy.linalg import cho_solve, solve_triangular
 from jax.scipy.special import expit, gammaln, logsumexp
 

--- a/funsor/minipyro.py
+++ b/funsor/minipyro.py
@@ -14,6 +14,7 @@ module.
 An accompanying example that makes use of this implementation can be
 found at examples/minipyro.py.
 """
+
 import functools
 import warnings
 import weakref

--- a/funsor/ops/array.py
+++ b/funsor/ops/array.py
@@ -296,14 +296,14 @@ for typ in array:
 @logaddexp.register(array, array)
 def _safe_logaddexp_tensor_tensor(x, y):
     finfo = np.finfo(x.dtype)
-    shift = np.clip(max(detach(x), detach(y)), a_max=None, a_min=finfo.min)
+    shift = np.clip(max(detach(x), detach(y)), finfo.min, None)
     return np.log(np.exp(x - shift) + np.exp(y - shift)) + shift
 
 
 @logaddexp.register(numbers.Number, array)
 def _safe_logaddexp_number_tensor(x, y):
     finfo = np.finfo(y.dtype)
-    shift = np.clip(detach(y), a_max=None, a_min=max(x, finfo.min))
+    shift = np.clip(detach(y), max(x, finfo.min), None)
     return np.log(np.exp(x - shift) + np.exp(y - shift)) + shift
 
 
@@ -318,22 +318,22 @@ min.register(array, array)(np.minimum)
 
 @max.register((int, float), array)
 def _max(x, y):
-    return np.clip(y, a_min=x, a_max=None)
+    return np.clip(y, x, None)
 
 
 @max.register(array, (int, float))
 def _max(x, y):
-    return np.clip(x, a_min=y, a_max=None)
+    return np.clip(x, y, None)
 
 
 @min.register((int, float), array)
 def _min(x, y):
-    return np.clip(y, a_min=None, a_max=x)
+    return np.clip(y, None, x)
 
 
 @min.register(array, (int, float))
 def _min(x, y):
-    return np.clip(x, a_min=None, a_max=y)
+    return np.clip(x, None, y)
 
 
 @UnaryOp.make
@@ -379,7 +379,7 @@ def permute(x, dims):
 
 @reciprocal.register(array)
 def _reciprocal(x):
-    result = np.clip(np.reciprocal(x), a_max=np.finfo(x.dtype).max)
+    result = np.clip(np.reciprocal(x), None, np.finfo(x.dtype).max)
     return result
 
 
@@ -390,7 +390,7 @@ def _safediv(x, y):
         finfo = np.finfo(y.dtype)
     except ValueError:
         finfo = np.iinfo(y.dtype)
-    return x * np.clip(np.reciprocal(y), a_min=None, a_max=finfo.max)
+    return x * np.clip(np.reciprocal(y), None, finfo.max)
 
 
 @safesub.register(array, array)
@@ -400,7 +400,7 @@ def _safesub(x, y):
         finfo = np.finfo(y.dtype)
     except ValueError:
         finfo = np.iinfo(y.dtype)
-    return x + np.clip(-y, a_min=None, a_max=finfo.max)
+    return x + np.clip(-y, None, finfo.max)
 
 
 @TernaryOp.make

--- a/funsor/ops/op.py
+++ b/funsor/ops/op.py
@@ -158,7 +158,7 @@ class Op(metaclass=OpMeta):
         return self.__name__
 
     def __call__(self, *args, **kwargs):
-        global _TRACE, _TRACE_FILTER_ARGS
+        global _TRACE
         raw_args = args
 
         # Normalize args, kwargs.

--- a/funsor/pyro/hmm.py
+++ b/funsor/pyro/hmm.py
@@ -219,6 +219,7 @@ class GaussianHMM(FunsorDistribution):
     :type observation_dist: ~torch.distributions.MultivariateNormal or
         ~torch.distributions.Independent of ~torch.distributions.Normal
     """
+
     has_rsample = True
     arg_constraints = {}
 
@@ -323,6 +324,7 @@ class GaussianMRF(FunsorDistribution):
         have batch_shape broadcastable to ``self.batch_shape + (num_steps,)``.
         This should have event_shape ``(hidden_dim + obs_dim,)``.
     """
+
     has_rsample = True
 
     def __init__(
@@ -432,6 +434,7 @@ class SwitchingLinearHMM(FunsorDistribution):
         approximation and use parallel scan algorithm to reduce parallel
         complexity to logarithmic in ``num_steps``. Defaults to False.
     """
+
     has_rsample = True
     arg_constraints = {}
 

--- a/funsor/util.py
+++ b/funsor/util.py
@@ -285,10 +285,10 @@ def get_default_dtype():
         return str(torch.get_default_dtype()).split(".")[1]
     elif backend == "numpy":
         np = sys.modules.get("numpy")
-        return np.dtype(np.float_).name
+        return np.dtype(np.float64).name
     elif backend == "jax":
         np = sys.modules.get("jax.numpy")
-        return np.dtype(np.float_).name
+        return np.dtype(np.float64).name
 
 
 def get_tracing_state():

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ setup(
             "scipy",
         ],
         "dev": [
-            "black<24",
-            "flake8<7",
+            "black",
+            "flake8",
             "isort>=5.0",
             "nbsphinx",
             "pandas",

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,8 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",  # for jax but not torch
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",  # for jax but not torch
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup(
             "jaxlib>=0.1.71",
         ],
         "test": [
-            "black<24",
-            "flake8<7",
+            "black",
+            "flake8",
             "isort>=5.0",
             "pandas",
             "pyro-api>=0.1.2",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="https://github.com/pyro-ppl/funsor",
     project_urls={"Documentation": "https://funsor.pyro.ai"},
     author="Uber AI Labs",
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=[
         "makefun",
         "multipledispatch",
@@ -38,30 +38,35 @@ setup(
         "typing_extensions",
     ],
     extras_require={
-        "torch": ["pyro-ppl>=1.8.0", "torch>=1.11.0"],
-        "jax": ["numpyro>=0.7.0", "jax>=0.2.21", "jaxlib>=0.1.71"],
-        "test": [
-            "black",
-            "flake8",
-            "isort>=5.0",
-            "pandas",
-            "pillow==8.2.0",  # https://github.com/pytorch/pytorch/issues/61125
-            "pyro-api>=0.1.2",
-            "pytest==4.3.1",
-            "pytest-xdist==1.27.0",
-            "requests",
-            "scipy",
+        "torch": [
+            "pyro-ppl>=1.8.0",
+            "torch>=1.11.0",
             "torchvision>=0.12.0",
         ],
+        "jax": [
+            "numpyro>=0.7.0",
+            "jax>=0.2.21",
+            "jaxlib>=0.1.71",
+        ],
+        "test": [
+            "black<24",
+            "flake8<7",
+            "isort>=5.0",
+            "pandas",
+            "pyro-api>=0.1.2",
+            "pytest>=7",
+            "pytest-xdist>=3",
+            "requests",
+            "scipy",
+        ],
         "dev": [
-            "black",
-            "flake8",
+            "black<24",
+            "flake8<7",
             "isort>=5.0",
             "nbsphinx",
             "pandas",
-            "pillow==8.2.0",  # https://github.com/pytorch/pytorch/issues/61125
-            "pytest==4.3.1",
-            "pytest-xdist==1.27.0",
+            "pytest>=7",
+            "pytest-xdist>=3",
             "scipy",
             "sphinx>=2.0",
             "sphinx-gallery",
@@ -79,8 +84,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",  # for jax but not torch
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,8 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,7 @@ def pytest_runtest_setup(item):
         pyro.set_rng_seed(0)
         pyro.enable_validation(True)
     elif _BACKEND == "jax":
-        from jax.config import config
+        from jax import config
 
         config.update("jax_platform_name", "cpu")
         config.update("jax_enable_x64", True)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1137,7 +1137,7 @@ def test_torch_save():
     f = io.BytesIO()
     torch.save(x, f)
     f.seek(0)
-    y = torch.load(f)
+    y = torch.load(f, weights_only=False)
     assert_close(x, y)
 
 


### PR DESCRIPTION
JAX 0.10 removed the deprecated `a`, `a_min`, `a_max` kwargs from `jnp.clip` (NumPy 2.x alignment). Switch every `np.clip` / `jnp.clip` call to positional arguments so the code is robust to any future signature change as well.

Also fix `from jax.config import config` in the test conftest, which no longer exists in JAX 0.10.

See https://github.com/pyro-ppl/numpyro/pull/2173 and https://github.com/jax-ml/jax/releases/tag/jax-v0.10.0

@fehiepsi could yo please take a look 🙏  ?