### PR TITLE
Update seal data download URL to GitHub raw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,8 @@ ifeq (${FUNSOR_BACKEND}, torch)
 	python examples/talbot.py -n 2
 	python examples/vae.py --smoke-test
 	python examples/eeg_slds.py --num-steps 2 --fon --test
-	# TODO: re-enable once the seal dataset is mirrored at a reachable URL.
-	# The upstream CSV at d2hg8soec8ck9v.cloudfront.net now returns 403 AccessDenied.
-	# python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
-	# python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
+	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
+	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
 	python examples/sensor.py --seed=0 --num-frames=2 -n 1
 	python examples/adam.py --num-steps=21
 	@echo PASS

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -12,7 +12,7 @@ MISSING = 1e-6
 
 def download_seal_data(filename):
     """download the preprocessed seal data and save it to filename"""
-    url = "https://d2hg8soec8ck9v.cloudfront.net/datasets/prep_seal_data.csv"
+    url = "https://raw.githubusercontent.com/pyro-ppl/datasets/refs/heads/master/prep_seal_data.csv?raw=true"
     with open(filename, "wb") as f:
         f.write(urlopen(url).read())
 


### PR DESCRIPTION
The CloudFront URL for the preprocessed seal dataset was broken (please see [this](https://github.com/pyro-ppl/funsor/pull/611#issuecomment-4352109555) comment). This replaces it with the canonical raw GitHub URL from the pyro-ppl/datasets repository.