### PR TITLE
Fix Uniform distribution parameter registration

### DIFF
--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -16,7 +16,7 @@ import funsor.delta
 import funsor.ops as ops
 from funsor.affine import is_affine
 from funsor.cnf import Contraction, GaussianMixture
-from funsor.domains import Array, Real, Reals
+from funsor.domains import Array, Bint, Real, Reals
 from funsor.gaussian import Gaussian
 from funsor.interpreter import gensym
 from funsor.tensor import (
@@ -495,7 +495,8 @@ def indepdist_to_funsor(backend_dist, output=None, dim_to_name=None):
     else:
         # this handles the output of eager rewrites, e.g. Normal->Gaussian or Beta->Dirichlet
         for dim, name in reversed(event_dim_to_name.items()):
-            result = funsor.terms.Independent(result, "value", name, "value")
+            if name in result.inputs:
+                result = funsor.terms.Independent(result, "value", name, "value")
     return result
 
 
@@ -505,6 +506,23 @@ def expandeddist_to_funsor(backend_dist, output=None, dim_to_name=None):
     )
     if not dim_to_name:
         assert not backend_dist.batch_shape
+        return funsor_base_dist
+
+    if not isinstance(funsor_base_dist, Distribution):
+        # This handles the output of eager rewrites, e.g. Normal -> Gaussian.
+        min_dim = -len(backend_dist.batch_shape)
+        for dim, name in reversed(dim_to_name.items()):
+            if dim < min_dim or dim >= 0:
+                continue
+            size = backend_dist.batch_shape[dim]
+            zero = Tensor(
+                ops.expand(numeric_array(0.0), (size,)),
+                OrderedDict([(name, Bint[size])]),
+            )
+            funsor_base_dist += zero
+            funsor_base_dist = funsor.terms.Independent(
+                funsor_base_dist, "value", name, "value"
+            )
         return funsor_base_dist
 
     name_to_dim = {name: dim for dim, name in dim_to_name.items()}

--- a/funsor/distribution.py
+++ b/funsor/distribution.py
@@ -440,7 +440,7 @@ FUNSOR_DIST_NAMES = [
     ("Pareto", ()),
     ("Poisson", ()),
     ("StudentT", ()),
-    ("Uniform", ()),
+    ("Uniform", ("low", "high")),
     ("VonMises", ()),
 ]
 

--- a/funsor/jax/distributions.py
+++ b/funsor/jax/distributions.py
@@ -4,6 +4,7 @@
 import functools
 from typing import Tuple, Union
 
+import jax.numpy as jnp
 import numpyro.distributions as dist
 
 import funsor.ops as ops
@@ -57,7 +58,9 @@ class _NumPyroWrapper_Binomial(dist.BinomialProbs):
 
 
 class _NumPyroWrapper_Categorical(dist.CategoricalProbs):
-    pass
+    def __init__(self, probs, validate_args=None):
+        probs = probs / jnp.sum(probs, axis=-1, keepdims=True)
+        super().__init__(probs, validate_args=validate_args)
 
 
 class _NumPyroWrapper_Geometric(dist.GeometricProbs):
@@ -65,7 +68,16 @@ class _NumPyroWrapper_Geometric(dist.GeometricProbs):
 
 
 class _NumPyroWrapper_Multinomial(dist.MultinomialProbs):
-    pass
+    def __init__(
+        self, probs, total_count=1, *, total_count_max=None, validate_args=None
+    ):
+        probs = probs / jnp.sum(probs, axis=-1, keepdims=True)
+        super().__init__(
+            probs,
+            total_count,
+            total_count_max=total_count_max,
+            validate_args=validate_args,
+        )
 
 
 class _NumPyroWrapper_NonreparameterizedBeta(dist.Beta):

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -349,9 +349,11 @@ for batch_shape in [(), (5,), (2, 3)]:
             ("probs", f"rand({batch_shape})"),
         ),
         funsor.Real,
-        xfail_reason="NumPyro converts NegativeBinomial through GammaPoisson"
-        if get_backend() == "jax"
-        else "",
+        xfail_reason=(
+            "NumPyro converts NegativeBinomial through GammaPoisson"
+            if get_backend() == "jax"
+            else ""
+        ),
     )
 
     # Normal

--- a/test/test_distribution_generic.py
+++ b/test/test_distribution_generic.py
@@ -91,6 +91,10 @@ def eager_no_dists(cls, *args):
 TEST_CASES = []
 
 
+def simplex(probs):
+    return probs / probs.sum(-1, keepdims=True)
+
+
 class DistTestCase:
     def __init__(self, raw_dist, raw_params, expected_value_domain, xfail_reason=""):
         assert isinstance(raw_dist, str)
@@ -173,7 +177,7 @@ for batch_shape in [(), (5,), (2, 3)]:
     for size in [2, 4]:
         DistTestCase(
             "dist.Categorical(probs=case.probs)",
-            (("probs", f"rand({batch_shape + (size,)})"),),
+            (("probs", f"simplex(rand({batch_shape + (size,)}))"),),
             funsor.Bint[size],
         )
 
@@ -321,7 +325,7 @@ for batch_shape in [(), (5,), (2, 3)]:
             "dist.Multinomial(case.total_count, probs=case.probs)",
             (
                 ("total_count", "randint(5, 7, ())" if get_backend() == "jax" else "5"),
-                ("probs", f"rand({batch_shape + event_shape})"),
+                ("probs", f"simplex(rand({batch_shape + event_shape}))"),
             ),
             funsor.Reals[event_shape],
         )
@@ -345,6 +349,9 @@ for batch_shape in [(), (5,), (2, 3)]:
             ("probs", f"rand({batch_shape})"),
         ),
         funsor.Real,
+        xfail_reason="NumPyro converts NegativeBinomial through GammaPoisson"
+        if get_backend() == "jax"
+        else "",
     )
 
     # Normal
@@ -364,7 +371,7 @@ for batch_shape in [(), (5,), (2, 3)]:
     for size in [2, 4]:
         DistTestCase(
             "dist.OneHotCategorical(probs=case.probs)",
-            (("probs", f"rand({batch_shape + (size,)})"),),
+            (("probs", f"simplex(rand({batch_shape + (size,)}))"),),
             funsor.Reals[size],  # funsor.Bint[size],
         )
 


### PR DESCRIPTION
PyTorch changed Uniform.arg_constraints to a property, so register Uniform's low/high parameters explicitly.