### PR TITLE
Move test/docs/dev deps to groups and simplify CI installs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
       run: |
         sudo apt install -y pandoc
         python -m pip install --upgrade pip
-        # Keep track of pyro-api master branch
-        pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install .[test]
+        pip install . --group test
         pip freeze
     - name: Run test
       run: make test
@@ -51,12 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # Keep track of pyro-api master branch
-        pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cpu
-        # Keep track of Pyro master branch
-        pip install https://github.com/pyro-ppl/pyro/archive/master.zip
-        pip install .[test,torch]
+        pip install .[torch] --group test
         pip freeze
     - name: Run test
       run: make test
@@ -80,12 +73,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # Keep track of pyro-api master branch
-        pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-        pip install "jax<0.10"
-        # Keep track of NumPyro master branch
-        pip install https://github.com/pyro-ppl/numpyro/archive/master.zip
-        pip install .[test]
+        pip install .[jax] --group test
         pip freeze
     - name: Run test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[torch] --group test
+        # TODO: remove once pyro-ppl releases the Uniform arg_constraints fix
+        # (https://github.com/pyro-ppl/pyro/pull/3453).
+        pip install .[torch] --group test "torch<=2.6"
         pip freeze
     - name: Run test
       run: make test
@@ -73,7 +75,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[jax] --group test
+        # TODO: remove once a NumPyro release fully supports jax>=0.10
+        # (temporary pin from https://github.com/pyro-ppl/funsor/pull/611).
+        pip install .[jax] --group test "jax<0.10"
         pip freeze
     - name: Run test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: docs test
 
 install:
-	pip install -e .[dev]
+	pip install -e . --group dev
 
 docs: FORCE
 	mkdir -p docs/source/_static

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
 [project.optional-dependencies]
 torch = [
     "pyro-ppl>=1.8.0",
-    "torch>=1.11.0",
+    # Cap until pyro-ppl releases the Uniform arg_constraints fix
+    # (https://github.com/pyro-ppl/pyro/pull/3453).
+    "torch>=2.0,<=2.6",
     "torchvision>=0.12.0",
 ]
 jax = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,8 @@ dependencies = [
 [project.optional-dependencies]
 torch = [
     "pyro-ppl>=1.8.0",
-    # Cap until pyro-ppl releases the Uniform arg_constraints fix
-    # (https://github.com/pyro-ppl/pyro/pull/3453).
-    "torch>=2.0,<=2.6",
-    "torchvision>=0.12.0",
+    "torch>=2.0",
+    "torchvision>=0.15.0",
 ]
 jax = [
     "numpyro>=0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ jax = [
     "jax>=0.2.21",
     "jaxlib>=0.1.71",
 ]
+
+[dependency-groups]
 test = [
     "pandas",
     "pyro-api>=0.1.2",
@@ -54,17 +56,16 @@ test = [
     "ruff>=0.16.1",
     "scipy",
 ]
-dev = [
-    "nbsphinx",
-    "pandas",
-    "pytest>=7",
-    "pytest-xdist>=3",
-    "ruff>=0.16.1",
-    "scipy",
+docs = [
+    "ipython<=8.6.0",
+    "nbsphinx==0.8.9",
     "sphinx>=2.0",
     "sphinx-gallery",
     "sphinx_rtd_theme",
-    "torchvision>=0.12.0",
+]
+dev = [
+    { include-group = "test" },
+    { include-group = "docs" },
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Move `test`, `docs`, and `dev` from package extras into PEP 735 `[dependency-groups]`, keeping only `torch`/`jax` as optional extras.
- Point local `make install` and GitHub Actions at `pip install ... --group ...` (requires pip ≥ 25.1).
- Drop CI installs from pyro/numpyro/pyro-api master and special torch/jax pins; resolve backends from the declared extras instead.

## Test plan
- [ ] Default CI job passes with `pip install . --group test`
- [ ] Torch CI job passes with `pip install .[torch] --group test`
- [ ] Jax CI job passes with `pip install .[jax] --group test`
- [ ] Locally: `pip install -e . --group dev` still installs docs + test tooling
- [ ] Confirm ReadTheDocs is unchanged (`docs/requirements.txt` still used)