### PR TITLE
Convert Makefile and CI to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,10 @@ jobs:
       CI: 1
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         sudo apt install -y pandoc
@@ -43,12 +41,10 @@ jobs:
       FUNSOR_BACKEND: torch
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         uv sync --group test --extra torch --no-default-groups
@@ -68,12 +64,10 @@ jobs:
       FUNSOR_BACKEND: jax
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         uv sync --group test --extra jax --no-default-groups

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,8 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt install -y pandoc
-        uv sync --group test --no-default-groups
-        uv pip freeze
+    - name: Install pandoc
+      run: sudo apt install -y pandoc
     - name: Run test
       run: make test
 
@@ -45,10 +42,6 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        uv sync --group test --extra torch --no-default-groups
-        uv pip freeze
     - name: Run test
       run: make test
 
@@ -68,9 +61,5 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        uv sync --group test --extra jax --no-default-groups
-        uv pip freeze
     - name: Run test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install pandoc
       run: sudo apt install -y pandoc
+    - name: Install
+      run: make install
     - name: Run test
       run: make test
 
@@ -42,6 +44,8 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: make install
     - name: Run test
       run: make test
 
@@ -61,5 +65,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: make install
     - name: Run test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
     - name: Install dependencies
       run: |
         sudo apt install -y pandoc
-        python -m pip install --upgrade pip
-        pip install . --group test
-        pip freeze
+        uv sync --group test --no-default-groups
+        uv pip freeze
     - name: Run test
       run: make test
 
@@ -46,13 +47,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        # TODO: remove once pyro-ppl releases the Uniform arg_constraints fix
-        # (https://github.com/pyro-ppl/pyro/pull/3453).
-        pip install .[torch] --group test "torch<=2.6"
-        pip freeze
+        uv sync --group test --extra torch --no-default-groups
+        uv pip freeze
     - name: Run test
       run: make test
 
@@ -72,12 +72,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        # TODO: remove once a NumPyro release fully supports jax>=0.10
-        # (temporary pin from https://github.com/pyro-ppl/funsor/pull/611).
-        pip install .[jax] --group test "jax<0.10"
-        pip freeze
+        uv sync --group test --extra jax --no-default-groups
+        uv pip freeze
     - name: Run test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       CI: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -42,7 +42,7 @@ jobs:
       CI: 1
       FUNSOR_BACKEND: torch
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       CI: 1
       FUNSOR_BACKEND: jax
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# uv lockfile is intentionally untracked for this library
+uv.lock
+
 # IDE settings
 .spyderproject
 .idea

--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,14 @@ docs: FORCE
 	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
 
 lint: FORCE
-	uv sync --inexact
 	$(UV_RUN) ruff check --fix .
 	$(UV_RUN) python scripts/update_headers.py --check
 	$(UV_RUN) python test/test_import.py
 
 license: FORCE
-	uv sync --inexact
 	$(UV_RUN) python scripts/update_headers.py
 
 format: license FORCE
-	uv sync --inexact
 	$(UV_RUN) ruff format .
 
 test: lint FORCE
@@ -66,7 +63,7 @@ else ifeq (${FUNSOR_BACKEND}, jax)
 	$(UV_RUN) pytest -v -n auto test/test_distribution_generic.py
 	@echo PASS
 else
-	# default backend; lint already synced the default (dev) group
+	# default backend; requires prior `make install` (or equivalent uv sync)
 	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
 		--ignore=test/pyroapi --ignore=test/torch
 	@echo PASS

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ UV_RUN = uv run --no-sync
 all: docs test
 
 install:
-	uv sync --no-default-groups
+	uv sync --group test --no-default-groups
 
 docs: FORCE
 	uv sync --group docs --no-default-groups --inexact

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ UV_RUN = uv run --no-sync
 all: docs test
 
 install:
-	uv sync --group dev --no-default-groups --inexact
+	uv sync --no-default-groups
 
 docs: FORCE
 	uv sync --group docs --no-default-groups --inexact

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all install docs lint format test clean FORCE
 
-# After each target's explicit `uv sync --inexact`, avoid `uv run` pulling default groups.
+# After each target's explicit `uv sync --inexact`, avoid `uv run` pulling extra packages.
 UV_RUN = uv run --no-sync
 
 all: docs test
 
 install:
-	uv sync --group test --no-default-groups
+	uv sync
 
 docs: FORCE
 	uv sync --group docs --no-default-groups --inexact
@@ -14,22 +14,22 @@ docs: FORCE
 	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
 
 lint: FORCE
-	uv sync --group test --no-default-groups --inexact
+	uv sync --inexact
 	$(UV_RUN) ruff check --fix .
 	$(UV_RUN) python scripts/update_headers.py --check
 	$(UV_RUN) python test/test_import.py
 
 license: FORCE
-	uv sync --group test --no-default-groups --inexact
+	uv sync --inexact
 	$(UV_RUN) python scripts/update_headers.py
 
 format: license FORCE
-	uv sync --group test --no-default-groups --inexact
+	uv sync --inexact
 	$(UV_RUN) ruff format .
 
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
-	uv sync --group test --extra torch --no-default-groups --inexact
+	uv sync --extra torch --inexact
 	$(UV_RUN) pytest -v -n auto test/
 	FUNSOR_DEBUG=1 $(UV_RUN) pytest -v test/test_gaussian.py
 	FUNSOR_PROFILE=99 $(UV_RUN) pytest -v test/test_einsum.py
@@ -58,7 +58,7 @@ ifeq (${FUNSOR_BACKEND}, torch)
 	$(UV_RUN) python examples/adam.py --num-steps=21
 	@echo PASS
 else ifeq (${FUNSOR_BACKEND}, jax)
-	uv sync --group test --extra jax --no-default-groups --inexact
+	uv sync --extra jax --inexact
 	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
 		--ignore=test/test_distribution.py --ignore=test/test_distribution_generic.py \
 		--ignore=test/torch
@@ -66,7 +66,7 @@ else ifeq (${FUNSOR_BACKEND}, jax)
 	$(UV_RUN) pytest -v -n auto test/test_distribution_generic.py
 	@echo PASS
 else
-	# default backend; lint already synced the test group
+	# default backend; lint already synced the default (dev) group
 	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
 		--ignore=test/pyroapi --ignore=test/torch
 	@echo PASS

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ license: FORCE
 format: license FORCE
 	uv run ruff format .
 
-test: format lint FORCE
+test: FORCE
+	uv run ruff check .
+	uv run ruff format --check .
+	uv run python scripts/update_headers.py --check
+	uv run python test/test_import.py
 ifeq (${FUNSOR_BACKEND}, torch)
 	uv sync --extra torch --inexact
 	uv run pytest -v -n auto test/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ license: FORCE
 format: license FORCE
 	uv run ruff format .
 
-test: lint FORCE
+test: format lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
 	uv sync --extra torch --inexact
 	uv run pytest -v -n auto test/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: all install docs lint format test clean FORCE
 
-# After each target's explicit `uv sync --inexact`, avoid `uv run` pulling extra packages.
-UV_RUN = uv run --no-sync
-
 all: docs test
 
 install:
@@ -11,7 +8,7 @@ install:
 docs: FORCE
 	uv sync --group docs --no-default-groups --inexact
 	mkdir -p docs/source/_static
-	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
+	$(MAKE) -C docs html SPHINXBUILD="uv run --no-sync sphinx-build"
 
 lint: FORCE
 	uv run ruff check --fix .
@@ -27,44 +24,44 @@ format: license FORCE
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
 	uv sync --extra torch --inexact
-	$(UV_RUN) pytest -v -n auto test/
-	FUNSOR_DEBUG=1 $(UV_RUN) pytest -v test/test_gaussian.py
-	FUNSOR_PROFILE=99 $(UV_RUN) pytest -v test/test_einsum.py
-	FUNSOR_USE_TCO=1 $(UV_RUN) pytest -v test/test_terms.py
-	FUNSOR_USE_TCO=1 $(UV_RUN) pytest -v test/test_einsum.py
-	$(UV_RUN) python examples/adam.py -n 2
-	$(UV_RUN) python examples/discrete_hmm.py -n 2
-	$(UV_RUN) python examples/discrete_hmm.py -n 2 -t 50 --lazy
-	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/discrete_hmm.py -n 1 -t 50 --lazy
-	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/discrete_hmm.py -n 1 -t 500 --lazy
-	$(UV_RUN) python examples/forward_backward.py -t 3
-	$(UV_RUN) python examples/kalman_filter.py -n 2
-	$(UV_RUN) python examples/kalman_filter.py -n 2 -t 50 --lazy
-	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/kalman_filter.py -n 1 -t 50 --lazy
-	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/kalman_filter.py -n 1 -t 500 --lazy
-	$(UV_RUN) python examples/minipyro.py
-	$(UV_RUN) python examples/minipyro.py --jit
-	$(UV_RUN) python examples/slds.py -n 2 -t 50
-	$(UV_RUN) python examples/pcfg.py --size 3
-	$(UV_RUN) python examples/talbot.py -n 2
-	$(UV_RUN) python examples/vae.py --smoke-test
-	$(UV_RUN) python examples/eeg_slds.py --num-steps 2 --fon --test
-	$(UV_RUN) python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
-	$(UV_RUN) python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
-	$(UV_RUN) python examples/sensor.py --seed=0 --num-frames=2 -n 1
-	$(UV_RUN) python examples/adam.py --num-steps=21
+	uv run pytest -v -n auto test/
+	FUNSOR_DEBUG=1 uv run pytest -v test/test_gaussian.py
+	FUNSOR_PROFILE=99 uv run pytest -v test/test_einsum.py
+	FUNSOR_USE_TCO=1 uv run pytest -v test/test_terms.py
+	FUNSOR_USE_TCO=1 uv run pytest -v test/test_einsum.py
+	uv run python examples/adam.py -n 2
+	uv run python examples/discrete_hmm.py -n 2
+	uv run python examples/discrete_hmm.py -n 2 -t 50 --lazy
+	FUNSOR_USE_TCO=1 uv run python examples/discrete_hmm.py -n 1 -t 50 --lazy
+	FUNSOR_USE_TCO=1 uv run python examples/discrete_hmm.py -n 1 -t 500 --lazy
+	uv run python examples/forward_backward.py -t 3
+	uv run python examples/kalman_filter.py -n 2
+	uv run python examples/kalman_filter.py -n 2 -t 50 --lazy
+	FUNSOR_USE_TCO=1 uv run python examples/kalman_filter.py -n 1 -t 50 --lazy
+	FUNSOR_USE_TCO=1 uv run python examples/kalman_filter.py -n 1 -t 500 --lazy
+	uv run python examples/minipyro.py
+	uv run python examples/minipyro.py --jit
+	uv run python examples/slds.py -n 2 -t 50
+	uv run python examples/pcfg.py --size 3
+	uv run python examples/talbot.py -n 2
+	uv run python examples/vae.py --smoke-test
+	uv run python examples/eeg_slds.py --num-steps 2 --fon --test
+	uv run python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
+	uv run python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
+	uv run python examples/sensor.py --seed=0 --num-frames=2 -n 1
+	uv run python examples/adam.py --num-steps=21
 	@echo PASS
 else ifeq (${FUNSOR_BACKEND}, jax)
 	uv sync --extra jax --inexact
-	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
+	uv run pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
 		--ignore=test/test_distribution.py --ignore=test/test_distribution_generic.py \
 		--ignore=test/torch
-	$(UV_RUN) pytest -v -n auto test/test_distribution.py
-	$(UV_RUN) pytest -v -n auto test/test_distribution_generic.py
+	uv run pytest -v -n auto test/test_distribution.py
+	uv run pytest -v -n auto test/test_distribution_generic.py
 	@echo PASS
 else
 	# default backend; requires prior `make install` (or equivalent uv sync)
-	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
+	uv run pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
 		--ignore=test/pyroapi --ignore=test/torch
 	@echo PASS
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,67 @@
 .PHONY: all install docs lint format test clean FORCE
 
+# After an explicit `uv sync`, avoid `uv run` resyncing away CI-selected extras/groups.
+UV_RUN = uv run --no-sync
+
 all: docs test
 
 install:
-	pip install -e . --group dev
+	uv sync --group dev --no-default-groups
 
 docs: FORCE
 	mkdir -p docs/source/_static
-	$(MAKE) -C docs html
+	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
 
 lint: FORCE
-	ruff check --fix .
-	python scripts/update_headers.py --check
-	python test/test_import.py
+	$(UV_RUN) ruff check --fix .
+	$(UV_RUN) python scripts/update_headers.py --check
+	$(UV_RUN) python test/test_import.py
 
 license: FORCE
-	python scripts/update_headers.py
+	$(UV_RUN) python scripts/update_headers.py
 
 format: license FORCE
-	ruff format .
+	$(UV_RUN) ruff format .
 
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
-	pytest -v -n auto test/
-	FUNSOR_DEBUG=1 pytest -v test/test_gaussian.py
-	FUNSOR_PROFILE=99 pytest -v test/test_einsum.py
-	FUNSOR_USE_TCO=1 pytest -v test/test_terms.py
-	FUNSOR_USE_TCO=1 pytest -v test/test_einsum.py
-	python examples/adam.py -n 2
-	python examples/discrete_hmm.py -n 2
-	python examples/discrete_hmm.py -n 2 -t 50 --lazy
-	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 50 --lazy
-	FUNSOR_USE_TCO=1 python examples/discrete_hmm.py -n 1 -t 500 --lazy
-	python examples/forward_backward.py -t 3
-	python examples/kalman_filter.py -n 2
-	python examples/kalman_filter.py -n 2 -t 50 --lazy
-	FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 50 --lazy
-	FUNSOR_USE_TCO=1 python examples/kalman_filter.py -n 1 -t 500 --lazy
-	python examples/minipyro.py
-	python examples/minipyro.py --jit
-	python examples/slds.py -n 2 -t 50
-	python examples/pcfg.py --size 3
-	python examples/talbot.py -n 2
-	python examples/vae.py --smoke-test
-	python examples/eeg_slds.py --num-steps 2 --fon --test
-	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
-	python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
-	python examples/sensor.py --seed=0 --num-frames=2 -n 1
-	python examples/adam.py --num-steps=21
+	$(UV_RUN) pytest -v -n auto test/
+	FUNSOR_DEBUG=1 $(UV_RUN) pytest -v test/test_gaussian.py
+	FUNSOR_PROFILE=99 $(UV_RUN) pytest -v test/test_einsum.py
+	FUNSOR_USE_TCO=1 $(UV_RUN) pytest -v test/test_terms.py
+	FUNSOR_USE_TCO=1 $(UV_RUN) pytest -v test/test_einsum.py
+	$(UV_RUN) python examples/adam.py -n 2
+	$(UV_RUN) python examples/discrete_hmm.py -n 2
+	$(UV_RUN) python examples/discrete_hmm.py -n 2 -t 50 --lazy
+	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/discrete_hmm.py -n 1 -t 50 --lazy
+	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/discrete_hmm.py -n 1 -t 500 --lazy
+	$(UV_RUN) python examples/forward_backward.py -t 3
+	$(UV_RUN) python examples/kalman_filter.py -n 2
+	$(UV_RUN) python examples/kalman_filter.py -n 2 -t 50 --lazy
+	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/kalman_filter.py -n 1 -t 50 --lazy
+	FUNSOR_USE_TCO=1 $(UV_RUN) python examples/kalman_filter.py -n 1 -t 500 --lazy
+	$(UV_RUN) python examples/minipyro.py
+	$(UV_RUN) python examples/minipyro.py --jit
+	$(UV_RUN) python examples/slds.py -n 2 -t 50
+	$(UV_RUN) python examples/pcfg.py --size 3
+	$(UV_RUN) python examples/talbot.py -n 2
+	$(UV_RUN) python examples/vae.py --smoke-test
+	$(UV_RUN) python examples/eeg_slds.py --num-steps 2 --fon --test
+	$(UV_RUN) python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --smoke
+	$(UV_RUN) python examples/mixed_hmm/experiment.py -d seal -i discrete -g discrete -zi --parallel --smoke
+	$(UV_RUN) python examples/sensor.py --seed=0 --num-frames=2 -n 1
+	$(UV_RUN) python examples/adam.py --num-steps=21
 	@echo PASS
 else ifeq (${FUNSOR_BACKEND}, jax)
-	pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
+	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
 		--ignore=test/test_distribution.py --ignore=test/test_distribution_generic.py \
 		--ignore=test/torch
-	pytest -v -n auto test/test_distribution.py
-	pytest -v -n auto test/test_distribution_generic.py
+	$(UV_RUN) pytest -v -n auto test/test_distribution.py
+	$(UV_RUN) pytest -v -n auto test/test_distribution_generic.py
 	@echo PASS
 else
 	# default backend
-	pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
+	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
 		--ignore=test/pyroapi --ignore=test/torch
 	@echo PASS
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,35 @@
 .PHONY: all install docs lint format test clean FORCE
 
-# After an explicit `uv sync`, avoid `uv run` resyncing away CI-selected extras/groups.
+# After each target's explicit `uv sync --inexact`, avoid `uv run` pulling default groups.
 UV_RUN = uv run --no-sync
 
 all: docs test
 
 install:
-	uv sync --group dev --no-default-groups
+	uv sync --group dev --no-default-groups --inexact
 
 docs: FORCE
+	uv sync --group docs --no-default-groups --inexact
 	mkdir -p docs/source/_static
 	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
 
 lint: FORCE
+	uv sync --group test --no-default-groups --inexact
 	$(UV_RUN) ruff check --fix .
 	$(UV_RUN) python scripts/update_headers.py --check
 	$(UV_RUN) python test/test_import.py
 
 license: FORCE
+	uv sync --group test --no-default-groups --inexact
 	$(UV_RUN) python scripts/update_headers.py
 
 format: license FORCE
+	uv sync --group test --no-default-groups --inexact
 	$(UV_RUN) ruff format .
 
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)
+	uv sync --group test --extra torch --no-default-groups --inexact
 	$(UV_RUN) pytest -v -n auto test/
 	FUNSOR_DEBUG=1 $(UV_RUN) pytest -v test/test_gaussian.py
 	FUNSOR_PROFILE=99 $(UV_RUN) pytest -v test/test_einsum.py
@@ -53,6 +58,7 @@ ifeq (${FUNSOR_BACKEND}, torch)
 	$(UV_RUN) python examples/adam.py --num-steps=21
 	@echo PASS
 else ifeq (${FUNSOR_BACKEND}, jax)
+	uv sync --group test --extra jax --no-default-groups --inexact
 	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro --ignore=test/pyroapi \
 		--ignore=test/test_distribution.py --ignore=test/test_distribution_generic.py \
 		--ignore=test/torch
@@ -60,7 +66,7 @@ else ifeq (${FUNSOR_BACKEND}, jax)
 	$(UV_RUN) pytest -v -n auto test/test_distribution_generic.py
 	@echo PASS
 else
-	# default backend
+	# default backend; lint already synced the test group
 	$(UV_RUN) pytest -v -n auto --ignore=test/examples --ignore=test/pyro \
 		--ignore=test/pyroapi --ignore=test/torch
 	@echo PASS

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,15 @@ docs: FORCE
 	$(MAKE) -C docs html SPHINXBUILD="$(UV_RUN) sphinx-build"
 
 lint: FORCE
-	$(UV_RUN) ruff check --fix .
-	$(UV_RUN) python scripts/update_headers.py --check
-	$(UV_RUN) python test/test_import.py
+	uv run ruff check --fix .
+	uv run python scripts/update_headers.py --check
+	uv run python test/test_import.py
 
 license: FORCE
-	$(UV_RUN) python scripts/update_headers.py
+	uv run python scripts/update_headers.py
 
 format: license FORCE
-	$(UV_RUN) ruff format .
+	uv run ruff format .
 
 test: lint FORCE
 ifeq (${FUNSOR_BACKEND}, torch)

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ docs: FORCE
 
 lint: FORCE
 	uv run ruff check --fix .
-	uv run python scripts/update_headers.py --check
-	uv run python test/test_import.py
 
 license: FORCE
 	uv run python scripts/update_headers.py

--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ git checkout master
 pip install .
 ```
 
+**Install using uv:**
+
+From PyPI:
+
+```sh
+uv add funsor
+```
+
+From source (installs the project and the default `dev` dependency group):
+
+```sh
+git clone git@github.com:pyro-ppl/funsor.git
+cd funsor
+git checkout master
+make install   # or: uv sync
+```
+
+Optional backends:
+
+```sh
+uv sync --extra torch --inexact
+uv sync --extra jax --inexact
+```
+
 ## Using funsor
 
 Funsor can be used through a number of interfaces:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,26 @@ known-first-party = ["funsor", "test"]
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
 
+[tool.uv]
+# Temporary CI/local sync constraints (not published package metadata).
+constraint-dependencies = [
+    # TODO: remove once pyro-ppl releases the Uniform arg_constraints fix
+    # (https://github.com/pyro-ppl/pyro/pull/3453).
+    "torch<=2.6",
+    # TODO: remove once a NumPyro release fully supports jax>=0.10
+    # (temporary pin from https://github.com/pyro-ppl/funsor/pull/611).
+    "jax<0.10",
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cpu" }
+torchvision = { index = "pytorch-cpu" }
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,15 +117,6 @@ constraint-dependencies = [
     "jax<0.10",
 ]
 
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-
-[tool.uv.sources]
-torch = { index = "pytorch-cpu" }
-torchvision = { index = "pytorch-cpu" }
-
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ jax = [
 ]
 
 [dependency-groups]
-test = [
+dev = [
     "pandas",
     "pyro-api>=0.1.2",
     "pytest>=7",
@@ -62,10 +62,6 @@ docs = [
     "sphinx>=2.0",
     "sphinx-gallery",
     "sphinx_rtd_theme",
-]
-dev = [
-    { include-group = "test" },
-    { include-group = "docs" },
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Switch Makefile and GitHub Actions from pip to `uv sync` / `uv run`, without tracking a `uv.lock`.
- Rename the former `test` dependency group to `dev` (uv's default); keep `docs` separate.
- CI uses `astral-sh/setup-uv` (with matrix Python) and `make install`, then `make test`; torch/jax extras are added inexactly from the Makefile.
- Carry temporary `torch<=2.6` / `jax<0.10` constraints under `[tool.uv]`, bump `actions/checkout` to v7, and run `format` as part of `make test`.

## Test plan
- [ ] Default CI: `make install` then `make test`
- [ ] Torch CI: `FUNSOR_BACKEND=torch make test` after `make install`
- [ ] Jax CI: `FUNSOR_BACKEND=jax make test` after `make install`
- [ ] Local: `make install`, `make lint`, `make format`
- [ ] Optional: `make docs` (docs-only sync + `uv run --no-sync`)